### PR TITLE
Fix: 「大きい支出順」ソート機能を正しい動作に修正

### DIFF
--- a/webapp/src/client/components/top-page/features/transactions-table/InteractiveTransactionTable.tsx
+++ b/webapp/src/client/components/top-page/features/transactions-table/InteractiveTransactionTable.tsx
@@ -21,7 +21,7 @@ const SORT_CONFIGS: Record<SortOption, SortConfig> = {
   "amount-desc": { sort: "amount", order: "desc" },
   "amount-asc": { sort: "amount", order: "asc" },
   "income-desc": { sort: "amount", order: "desc", filterType: "income" },
-  "expense-asc": { sort: "amount", order: "asc", filterType: "expense" },
+  "expense-desc": { sort: "amount", order: "desc", filterType: "expense" },
 };
 
 interface InteractiveTransactionTableProps {

--- a/webapp/src/client/components/top-page/features/transactions-table/TransactionTableMobileHeader.tsx
+++ b/webapp/src/client/components/top-page/features/transactions-table/TransactionTableMobileHeader.tsx
@@ -7,7 +7,7 @@ export type SortOption =
   | "amount-desc"
   | "amount-asc"
   | "income-desc"
-  | "expense-asc";
+  | "expense-desc";
 
 interface TransactionTableMobileHeaderProps {
   onSortChange: (sortOption: SortOption) => void;
@@ -23,7 +23,7 @@ const TAB_ITEMS: TabItem[] = [
   { id: "date-desc", label: "新しい順" },
   { id: "date-asc", label: "古い順" },
   { id: "income-desc", label: "大きい収入順" },
-  { id: "expense-asc", label: "大きい支出順" },
+  { id: "expense-desc", label: "大きい支出順" },
 ];
 
 export default function TransactionTableMobileHeader({


### PR DESCRIPTION
- TransactionTableMobileHeader: expense-asc → expense-desc に変更
- InteractiveTransactionTable: SORT_CONFIGSでexpense-descをorder:"desc"に修正
- 「大きい支出順」が絶対値の大きいもの順に正しく表示されるよう修正

🤖 Generated with [Claude Code](https://claude.ai/code)