### PR TITLE
Add noindex meta tags to all pages

### DIFF
--- a/admin/src/app/layout.tsx
+++ b/admin/src/app/layout.tsx
@@ -3,6 +3,10 @@ import "./styles.css";
 
 export const metadata: Metadata = {
   title: "政治資金ダッシュボード管理画面",
+  robots: {
+    index: false,
+    follow: false,
+  },
 };
 
 export default function RootLayout({

--- a/webapp/src/app/layout.tsx
+++ b/webapp/src/app/layout.tsx
@@ -49,6 +49,10 @@ export const metadata: Metadata = {
   title: "みらいオープンデータ - チームみらいの政治資金をオープンに",
   description:
     "チームみらいの政治資金の流れを透明性を持って公開するプラットフォームです。",
+  robots: {
+    index: false,
+    follow: false,
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
- Add noindex meta tags to prevent search engine indexing during pre-launch phase
- Applied to both webapp and admin applications via root layout metadata

## Test plan
- [ ] Verify webapp pages show `<meta name="robots" content="noindex,nofollow">` in HTML head
- [ ] Verify admin pages show `<meta name="robots" content="noindex,nofollow">` in HTML head
- [ ] Test that applications still function normally

🤖 Generated with [Claude Code](https://claude.ai/code)