### PR TITLE
Fix TypeScript error in upload-mf-csv-usecase test

### DIFF
--- a/admin/tests/server/usecases/upload-mf-csv-usecase.test.ts
+++ b/admin/tests/server/usecases/upload-mf-csv-usecase.test.ts
@@ -159,6 +159,8 @@ describe("UploadMfCsvUsecase", () => {
           .map(t => ({
             ...t,
             id: 'test-id',
+            financial_year: new Date(t.transaction_date).getFullYear(),
+            transaction_type: 'other' as const,
             created_at: new Date(),
             updated_at: new Date()
           }))


### PR DESCRIPTION
## Summary
- Fix TypeScript compilation error in admin test file
- Add missing `financial_year` and `transaction_type` fields to mock Transaction objects

## Problem
The test was failing with TS2345 error because `PreviewTransaction` objects were being mapped to `Transaction` type but missing required fields:
- `financial_year`: Required by Transaction interface
- `transaction_type`: Required by Transaction interface

## Solution
- Extract `financial_year` from `transaction_date` using `getFullYear()`
- Set `transaction_type` to default value `'other'` for test purposes

## Test plan
- [x] Verify `pnpm typecheck` passes without errors
- [ ] Run admin tests to ensure functionality still works

🤖 Generated with [Claude Code](https://claude.ai/code)