### PR TITLE
Fix: admin CSV import not preserving tags

### DIFF
--- a/admin/src/server/usecases/preview-mf-csv-usecase.ts
+++ b/admin/src/server/usecases/preview-mf-csv-usecase.ts
@@ -20,6 +20,7 @@ export interface PreviewTransaction {
   credit_sub_account: string | undefined;
   credit_amount: number;
   description: string | undefined;
+  tags: string | undefined;
   status: "valid" | "invalid" | "skip";
   errors: string[];
   skipReason?: string;
@@ -112,6 +113,7 @@ export class PreviewMfCsvUsecase {
             credit_sub_account: transaction.credit_sub_account,
             credit_amount: transaction.credit_amount,
             description: transaction.description,
+            tags: transaction.tags,
             status,
             errors,
             skipReason,

--- a/admin/src/server/usecases/upload-mf-csv-usecase.ts
+++ b/admin/src/server/usecases/upload-mf-csv-usecase.ts
@@ -94,7 +94,7 @@ export class UploadMfCsvUsecase {
       description_3: this.splitDescription(previewTransaction.description || "")
         .description_3,
       description_detail: undefined,
-      tags: "",
+      tags: previewTransaction.tags || "",
       memo: "",
     };
   }


### PR DESCRIPTION
- Add tags field to PreviewTransaction interface
- Fix upload-mf-csv-usecase to use actual tags from CSV instead of empty string
- Ensure CSV tags column ("タグ" or "起訖タグ") is properly imported to database

🤖 Generated with [Claude Code](https://claude.ai/code)