### PR TITLE
Fix: transaction table mobile header spacing and labels

### DIFF
--- a/webapp/src/client/components/top-page/features/transactions-table/TransactionTableMobileHeader.tsx
+++ b/webapp/src/client/components/top-page/features/transactions-table/TransactionTableMobileHeader.tsx
@@ -22,8 +22,8 @@ interface TabItem {
 const TAB_ITEMS: TabItem[] = [
   { id: "date-desc", label: "新しい順" },
   { id: "date-asc", label: "古い順" },
-  { id: "income-desc", label: "大きい収入順" },
-  { id: "expense-desc", label: "大きい支出順" },
+  { id: "expense-desc", label: "支出が多い順" },
+  { id: "income-desc", label: "収入が多い順" },
 ];
 
 export default function TransactionTableMobileHeader({
@@ -31,14 +31,13 @@ export default function TransactionTableMobileHeader({
   currentSort,
 }: TransactionTableMobileHeaderProps) {
   const handleClick = (sortOption: SortOption) => {
-    console.log("Tab clicked:", sortOption); // デバッグ用
     onSortChange(sortOption);
   };
 
   return (
     <div className="w-full bg-white relative border-b-0">
       {/* Tab Items */}
-      <div className="flex gap-8 overflow-x-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
+      <div className="flex gap-6 overflow-x-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
         {TAB_ITEMS.map((tab) => {
           const isActive = currentSort === tab.id;
 
@@ -47,7 +46,7 @@ export default function TransactionTableMobileHeader({
               key={tab.id}
               type="button"
               onClick={() => handleClick(tab.id)}
-              className="flex flex-col items-center justify-center relative whitespace-nowrap py-2 px-2 cursor-pointer touch-manipulation"
+              className="flex flex-col items-center justify-center relative whitespace-nowrap py-2 px-0 cursor-pointer touch-manipulation"
             >
               {/* Tab Label */}
               <span


### PR DESCRIPTION
- Change item spacing from 32px (gap-8) to 24px (gap-6)
- Remove horizontal padding from tab items (px-2 to px-0)
- Update tab labels for better clarity
- Remove debug console.log

🤖 Generated with [Claude Code](https://claude.ai/code)