### PR TITLE
Fix: Adjust main content and footer spacing according to Figma design

### DIFF
--- a/webapp/src/app/layout.tsx
+++ b/webapp/src/app/layout.tsx
@@ -64,11 +64,13 @@ export default function RootLayout({
     <html lang="ja">
       <head />
       <body
-        className={`${geistSans.variable} ${geistMono.variable} ${notoSans.variable} ${notoSansJP.variable} ${inter.variable} antialiased pt-24`}
+        className={`${geistSans.variable} ${geistMono.variable} ${notoSans.variable} ${notoSansJP.variable} ${inter.variable} antialiased pt-24 flex flex-col min-h-screen`}
       >
         <Header />
-        {children}
-        <Footer />
+        <div className="flex-grow">{children}</div>
+        <div className="mt-[120px]">
+          <Footer />
+        </div>
         <SpeedInsights />
         <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_TRACKING_ID || ""} />
       </body>

--- a/webapp/src/client/components/layout/MainColumn.tsx
+++ b/webapp/src/client/components/layout/MainColumn.tsx
@@ -9,7 +9,7 @@ export default function MainColumn({
 }: MainColumnProps) {
   return (
     <main
-      className={`mx-auto max-w-[1032px] px-5 sm:px-6 py-6 space-y-6 ${className}`}
+      className={`mx-auto max-w-[1032px] px-5 sm:px-6 py-6 space-y-12 ${className}`}
     >
       {children}
     </main>


### PR DESCRIPTION
- Add 120px spacing between main content and footer in layout.tsx
- Adjust main column spacing from 24px to 48px in MainColumn.tsx
- Implement flex layout to properly control spacing structure

🤖 Generated with [Claude Code](https://claude.ai/code)