### PR TITLE
Add database migration documentation section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,17 @@ pnpm run clean         # 全てのnode_modulesとSupabaseを停止
 pnpm run fresh         # クリーンインストール + セットアップ
 ```
 
+## データベースのマイグレーション
+
+### 本番環境・開発環境
+- Vercelで行われるwebappのbuild過程で自動的にマイグレーションが実行されます
+
+### ローカル開発環境
+- 以下のコマンドでマイグレーションを実行してください：
+```bash
+pnpm run db:migrate
+```
+
 ### ブラウザからの確認方法
 
 - **メインアプリ**: [http://localhost:3000](http://localhost:3000)


### PR DESCRIPTION
## Summary
- Added "データベースのマイグレーション" section to README.md
- Documents automatic migration in production/dev environments via Vercel build process
- Documents local development migration command (`pnpm run db:migrate`)

## Changes
- Added new section after the utility commands section
- Clearly separates production/dev and local development migration approaches

## Test plan
- [x] Verify README renders correctly
- [x] Confirm migration documentation is accurate

🤖 Generated with [Claude Code](https://claude.ai/code)