### PR TITLE
Refactor: Convert political organizations page to server component

### DIFF
--- a/admin/src/app/(auth)/political-organizations/page.tsx
+++ b/admin/src/app/(auth)/political-organizations/page.tsx
@@ -1,33 +1,10 @@
-"use client";
-import "client-only";
+import "server-only";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
-import { apiClient } from "@/client/clients/api-client";
-import type { PoliticalOrganization } from "@/shared/models/political-organization";
+import { getPoliticalOrganizations } from "@/server/actions/get-political-organizations";
 
-export default function PoliticalOrganizationsPage() {
-  const [organizations, setOrganizations] = useState<PoliticalOrganization[]>(
-    [],
-  );
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    const fetchOrganizations = async () => {
-      try {
-        setLoading(true);
-        const data = await apiClient.listPoliticalOrganizations();
-        setOrganizations(data);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Unknown error");
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchOrganizations();
-  }, []);
+export default async function PoliticalOrganizationsPage() {
+  const organizations = await getPoliticalOrganizations();
 
   return (
     <div className="bg-primary-panel rounded-xl p-4">
@@ -41,15 +18,7 @@ export default function PoliticalOrganizationsPage() {
         </Link>
       </div>
 
-      {loading && <p className="text-primary-muted">読み込み中...</p>}
-
-      {error && (
-        <div className="text-red-500 mt-4 p-3 bg-red-900/20 rounded-lg border border-red-900/30">
-          エラー: {error}
-        </div>
-      )}
-
-      {!loading && !error && organizations.length === 0 && (
+      {organizations.length === 0 && (
         <div className="text-center py-10">
           <p className="text-primary-muted">政治団体が登録されていません</p>
           <Link
@@ -61,7 +30,7 @@ export default function PoliticalOrganizationsPage() {
         </div>
       )}
 
-      {!loading && !error && organizations.length > 0 && (
+      {organizations.length > 0 && (
         <div className="mt-5">
           <div className="grid gap-3">
             {organizations.map((org) => (

--- a/admin/src/server/actions/get-political-organizations.ts
+++ b/admin/src/server/actions/get-political-organizations.ts
@@ -1,0 +1,29 @@
+import "server-only";
+
+import { PrismaClient } from "@prisma/client";
+import type { PoliticalOrganization } from "@/shared/models/political-organization";
+
+const prisma = new PrismaClient();
+
+export async function getPoliticalOrganizations(): Promise<
+  PoliticalOrganization[]
+> {
+  try {
+    const organizations = await prisma.politicalOrganization.findMany({
+      orderBy: {
+        createdAt: "desc",
+      },
+    });
+
+    // Convert BigInt to string for JSON serialization
+    const serializedOrganizations = organizations.map((org) => ({
+      ...org,
+      id: org.id.toString(),
+    }));
+
+    return serializedOrganizations;
+  } catch (error) {
+    console.error("Error fetching political organizations:", error);
+    throw new Error("政治団体の取得に失敗しました");
+  }
+}


### PR DESCRIPTION
## Summary
- Convert political organizations list page from client component to server component
- Add server action `getPoliticalOrganizations` for data fetching
- Remove unused API endpoint `GET /api/political-organizations`
- Remove unused `listPoliticalOrganizations` method from API client
- Simplify page logic by removing loading and error states (now handled server-side)

## Test plan
- [ ] Verify political organizations page loads correctly
- [ ] Verify organizations are displayed in correct order (newest first)
- [ ] Verify "新規作成" button works
- [ ] Verify individual organization "編集" links work
- [ ] Verify empty state displays when no organizations exist

🤖 Generated with [Claude Code](https://claude.ai/code)