### PR TITLE
feat: サンキー図の「現残高」を「収支」に変更

### DIFF
--- a/webapp/src/client/components/top-page/features/charts/SankeyChart.tsx
+++ b/webapp/src/client/components/top-page/features/charts/SankeyChart.tsx
@@ -532,11 +532,11 @@ export default function SankeyChart({ data }: SankeyChartProps) {
         return aOrder - bOrder; // タイプ順
       }
 
-      // 「現残高」は末尾に配置
-      if (a.label === "現残高" && b.label !== "現残高") {
+      // 「収支」は末尾に配置
+      if (a.label === "収支" && b.label !== "収支") {
         return 1; // aを後に
       }
-      if (b.label === "現残高" && a.label !== "現残高") {
+      if (b.label === "収支" && a.label !== "収支") {
         return -1; // bを後に
       }
 

--- a/webapp/src/client/components/top-page/features/financial-summary/FinancialSummarySection.tsx
+++ b/webapp/src/client/components/top-page/features/financial-summary/FinancialSummarySection.tsx
@@ -17,17 +17,17 @@ function calculateFinancialData(sankeyData: SankeyData | null) {
     .filter((link: SankeyLink) => link.target === "合計")
     .reduce((sum: number, link: SankeyLink) => sum + link.value, 0);
 
-  // 支出の計算（「合計」ノードからの流出、ただし「expense-現残高」は除く）
+  // 支出の計算（「合計」ノードからの流出、ただし「expense-収支」は除く）
   const expense = sankeyData.links
     .filter(
       (link: SankeyLink) =>
-        link.source === "合計" && link.target !== "expense-現残高",
+        link.source === "合計" && link.target !== "expense-収支",
     )
     .reduce((sum: number, link: SankeyLink) => sum + link.value, 0);
 
-  // 残高の計算（「expense-現残高」への流出があればその値、なければ0）
+  // 残高の計算（「expense-収支」への流出があればその値、なければ0）
   const balanceLink = sankeyData.links.find(
-    (link: SankeyLink) => link.target === "expense-現残高",
+    (link: SankeyLink) => link.target === "expense-収支",
   );
   const balance = balanceLink ? balanceLink.value : 0;
 

--- a/webapp/src/server/utils/sankey-category-converter.ts
+++ b/webapp/src/server/utils/sankey-category-converter.ts
@@ -184,14 +184,14 @@ export function convertCategoryAggregationToSankeyData(
     0,
   );
 
-  // 収入 > 支出の場合、「現残高」を追加
+  // 収入 > 支出の場合、「収支」を追加
   if (totalIncome > totalExpense) {
     const currentBalance = totalIncome - totalExpense;
-    expenseByCategory.set("現残高", currentBalance);
+    expenseByCategory.set("収支", currentBalance);
 
-    // 支出データに「現残高」レコードを追加（UI用）
+    // 支出データに「収支」レコードを追加（UI用）
     processedAggregation.expense.push({
-      category: "現残高",
+      category: "収支",
       totalAmount: currentBalance,
     });
   }

--- a/webapp/tests/server/utils/sankey-category-converter.test.ts
+++ b/webapp/tests/server/utils/sankey-category-converter.test.ts
@@ -220,7 +220,7 @@ describe("convertCategoryAggregationToSankeyData", () => {
     expect(subToCategory?.value).toBe(1000000);
   });
 
-  it("should add '現残高' when income > expense", () => {
+  it("should add '収支' when income > expense", () => {
     const aggregation: SankeyCategoryAggregationResult = {
       income: [
         {
@@ -238,20 +238,20 @@ describe("convertCategoryAggregationToSankeyData", () => {
 
     const result = convertCategoryAggregationToSankeyData(aggregation);
 
-    // 「現残高」ノードが追加されることを確認
-    const currentBalanceNode = result.nodes.find(node => node.id === "expense-現残高");
+    // 「収支」ノードが追加されることを確認
+    const currentBalanceNode = result.nodes.find(node => node.id === "expense-収支");
     expect(currentBalanceNode).toBeDefined();
-    expect(currentBalanceNode?.label).toBe("現残高");
+    expect(currentBalanceNode?.label).toBe("収支");
 
-    // 「現残高」へのリンクが追加されることを確認
+    // 「収支」へのリンクが追加されることを確認
     const linkToCurrentBalance = result.links.find(
-      link => link.source === "合計" && link.target === "expense-現残高"
+      link => link.source === "合計" && link.target === "expense-収支"
     );
     expect(linkToCurrentBalance).toBeDefined();
     expect(linkToCurrentBalance?.value).toBe(800000); // 200万 - 120万 = 80万
   });
 
-  it("should not add '現残高' when income <= expense", () => {
+  it("should not add '収支' when income <= expense", () => {
     const aggregation: SankeyCategoryAggregationResult = {
       income: [
         {
@@ -269,18 +269,18 @@ describe("convertCategoryAggregationToSankeyData", () => {
 
     const result = convertCategoryAggregationToSankeyData(aggregation);
 
-    // 「現残高」ノードが追加されないことを確認
-    const currentBalanceNode = result.nodes.find(node => node.id === "expense-現残高");
+    // 「収支」ノードが追加されないことを確認
+    const currentBalanceNode = result.nodes.find(node => node.id === "expense-収支");
     expect(currentBalanceNode).toBeUndefined();
 
-    // 「現残高」へのリンクが追加されないことを確認
+    // 「収支」へのリンクが追加されないことを確認
     const linkToCurrentBalance = result.links.find(
-      link => link.target === "expense-現残高"
+      link => link.target === "expense-収支"
     );
     expect(linkToCurrentBalance).toBeUndefined();
   });
 
-  it("should handle '現残高' with existing subcategories", () => {
+  it("should handle '収支' with existing subcategories", () => {
     const aggregation: SankeyCategoryAggregationResult = {
       income: [
         {
@@ -300,13 +300,13 @@ describe("convertCategoryAggregationToSankeyData", () => {
 
     const result = convertCategoryAggregationToSankeyData(aggregation);
 
-    // 「現残高」ノードが追加されることを確認
-    const currentBalanceNode = result.nodes.find(node => node.id === "expense-現残高");
+    // 「収支」ノードが追加されることを確認
+    const currentBalanceNode = result.nodes.find(node => node.id === "expense-収支");
     expect(currentBalanceNode).toBeDefined();
 
-    // 「現残高」のリンクが正しく追加されることを確認
+    // 「収支」のリンクが正しく追加されることを確認
     const linkToCurrentBalance = result.links.find(
-      link => link.source === "合計" && link.target === "expense-現残高"
+      link => link.source === "合計" && link.target === "expense-収支"
     );
     expect(linkToCurrentBalance?.value).toBe(1500000); // 300万 - 150万 = 150万
 


### PR DESCRIPTION
## Summary
- サンキー図の残高表示ラベルを「現残高」から「収支」に変更
- 関連するテストファイルも更新し、全てのテストが通ることを確認

## Test plan
- [x] 既存のテストが全て通ることを確認
- [x] サンキー図での表示が「収支」に変更されることを確認
- [x] 財務サマリー機能も適切に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)