### PR TITLE
feat: 寄付データ取得の90日範囲対応とリポジトリインターフェース改善

### DIFF
--- a/webapp/src/server/actions/get-transaction-page-data.ts
+++ b/webapp/src/server/actions/get-transaction-page-data.ts
@@ -82,6 +82,7 @@ export const getTransactionPageDataAction = unstable_cache(
         slug: params.slug,
         financialYear: params.financialYear,
         today: new Date(),
+        daysRange: 90,
       }),
     ]);
 

--- a/webapp/src/server/repositories/interfaces/transaction-repository.interface.ts
+++ b/webapp/src/server/repositories/interfaces/transaction-repository.interface.ts
@@ -67,7 +67,16 @@ export interface ITransactionRepository {
   getDailyDonationData(
     politicalOrganizationId: string,
     financialYear: number,
-    fromDate?: Date,
   ): Promise<DailyDonationData[]>;
+  getDailyDonationDataInRange(
+    politicalOrganizationId: string,
+    financialYear: number,
+    fromDate: Date,
+    toDate: Date,
+  ): Promise<DailyDonationData[]>;
+  getTotalDonationAmount(
+    politicalOrganizationId: string,
+    financialYear: number,
+  ): Promise<number>;
   getLastUpdatedAt(): Promise<Date | null>;
 }


### PR DESCRIPTION
## Summary
- 寄付データ取得で直近90日の範囲指定を可能にし、寄付がない日を0で埋める機能を追加
- リポジトリインターフェースを用途別の専用メソッドに分離してクリーンな設計に改善
- 累計寄付金額は年度全体から取得し、グラフ表示範囲とは独立して計算

## 主な変更点
### 機能追加
- **可変日数範囲**: デフォルト90日だが任意の日数を指定可能
- **欠損日補完**: 寄付がない日を0で埋めて必ず指定日数分のレコードを返す
- **累計金額分離**: 年度全体の累計寄付金額を範囲フィルタとは独立して取得

### リポジトリ設計改善
- `getDailyDonationData`: 年度全体のデータ取得（既存機能維持）
- `getDailyDonationDataInRange`: 期間指定でのデータ取得（新規追加）
- `getTotalDonationAmount`: 年度合計寄付金額の直接取得（新規追加）
- オプショナルパラメータを削除し、明確な責務分離を実現

### テスト充実
- 12のテストケースで全機能を網羅
- 日付計算、データ補完、前日比計算、エラーハンドリングを検証
- リポジトリの2回のSQL実行をモックで適切にテスト

## Test plan
- [x] 既存テストが全て通ることを確認
- [x] 新規テストケースが全て通ることを確認  
- [x] TypeScriptの型チェックが通ることを確認
- [x] 90日間のデータ取得とギャップ埋めが正常に動作することを確認
- [x] 累計金額が年度全体から正しく計算されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)