### PR TITLE
Refactor: Rename server actions to loaders for better semantic clarity

### DIFF
--- a/webapp/src/app/api/refresh/route.ts
+++ b/webapp/src/app/api/refresh/route.ts
@@ -22,8 +22,8 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    revalidateTag("transactions-by-slug");
-    revalidateTag("transaction-page-data");
+    revalidateTag("transactions-page-data");
+    revalidateTag("top-page-data");
 
     revalidatePath("/transactions");
     revalidatePath("/");

--- a/webapp/src/app/page.tsx
+++ b/webapp/src/app/page.tsx
@@ -6,7 +6,7 @@ import CashFlowSection from "@/client/components/top-page/CashFlowSection";
 import DonationSummarySection from "@/client/components/top-page/DonationSummarySection";
 import MonthlyTrendsSection from "@/client/components/top-page/MonthlyTrendsSection";
 import TransactionsSection from "@/client/components/top-page/TransactionsSection";
-import { getTransactionPageDataAction } from "@/server/actions/get-transaction-page-data";
+import { loadTopPageData } from "@/server/loaders/load-top-page-data";
 import { formatUpdatedAt } from "@/server/utils/format-date";
 
 export const revalidate = 300; // 5 minutes
@@ -15,7 +15,7 @@ export default async function Home() {
   const slug = "team-mirai";
 
   // 統合アクションで全データを取得
-  const data = await getTransactionPageDataAction({
+  const data = await loadTopPageData({
     slug,
     page: 1,
     perPage: 6, // 表示用に7件のみ取得

--- a/webapp/src/app/transactions/page.tsx
+++ b/webapp/src/app/transactions/page.tsx
@@ -8,7 +8,7 @@ import CardHeader from "@/client/components/layout/CardHeader";
 import MainColumn from "@/client/components/layout/MainColumn";
 import MainColumnCard from "@/client/components/layout/MainColumnCard";
 import InteractiveTransactionTable from "@/client/components/top-page/features/transactions-table/InteractiveTransactionTable";
-import { getTransactionsBySlugAction } from "@/server/actions/get-transactions-by-slug";
+import { loadTransactionsPageData } from "@/server/loaders/load-transactions-page-data";
 import { formatUpdatedAt } from "@/server/utils/format-date";
 
 interface TransactionsPageProps {
@@ -22,7 +22,7 @@ export async function generateMetadata(): Promise<Metadata> {
   const currentFinancialYear = 2025;
 
   try {
-    const result = await getTransactionsBySlugAction({
+    const result = await loadTransactionsPageData({
       slug,
       page: 1,
       perPage: 1,
@@ -81,7 +81,7 @@ export default async function TransactionsPage({
   const financialYear = 2025; // 固定値
 
   try {
-    const data = await getTransactionsBySlugAction({
+    const data = await loadTransactionsPageData({
       slug,
       page,
       perPage,

--- a/webapp/src/server/loaders/load-top-page-data.ts
+++ b/webapp/src/server/loaders/load-top-page-data.ts
@@ -14,13 +14,13 @@ import {
 const prisma = new PrismaClient();
 const CACHE_REVALIDATE_SECONDS = 60;
 
-export interface GetTransactionPageDataParams
+export interface TopPageDataParams
   extends Omit<GetTransactionsBySlugParams, "financialYear"> {
   financialYear: number; // 必須項目として設定
 }
 
-export const getTransactionPageDataAction = unstable_cache(
-  async (params: GetTransactionPageDataParams) => {
+export const loadTopPageData = unstable_cache(
+  async (params: TopPageDataParams) => {
     // モックデータを使用する場合
     if (process.env.USE_MOCK_DATA === "true") {
       const mockUsecase = new GetMockTransactionPageDataUsecase();
@@ -91,6 +91,6 @@ export const getTransactionPageDataAction = unstable_cache(
       donationSummary: donationData.donationSummary,
     };
   },
-  ["transaction-page-data"],
+  ["top-page-data"],
   { revalidate: CACHE_REVALIDATE_SECONDS },
 );

--- a/webapp/src/server/loaders/load-transactions-page-data.ts
+++ b/webapp/src/server/loaders/load-transactions-page-data.ts
@@ -10,7 +10,7 @@ import {
 const prisma = new PrismaClient();
 const CACHE_REVALIDATE_SECONDS = 60;
 
-export const getTransactionsBySlugAction = unstable_cache(
+export const loadTransactionsPageData = unstable_cache(
   async (params: GetTransactionsBySlugParams) => {
     const transactionRepository = new PrismaTransactionRepository(prisma);
     const politicalOrganizationRepository =
@@ -22,6 +22,6 @@ export const getTransactionsBySlugAction = unstable_cache(
 
     return await usecase.execute(params);
   },
-  ["transactions-by-slug"],
+  ["transactions-page-data"],
   { revalidate: CACHE_REVALIDATE_SECONDS },
 );

--- a/webapp/src/server/usecases/get-mock-transaction-page-data-usecase.ts
+++ b/webapp/src/server/usecases/get-mock-transaction-page-data-usecase.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import type { GetTransactionPageDataParams } from "@/server/actions/get-transaction-page-data";
+import type { TopPageDataParams } from "@/server/loaders/load-top-page-data";
 import type { MonthlyAggregation } from "@/server/repositories/interfaces/transaction-repository.interface";
 import type { DonationSummaryData } from "@/server/usecases/get-daily-donation-usecase";
 import type { SankeyData } from "@/types/sankey";
@@ -81,7 +81,7 @@ const MOCK_TRANSACTION_DATA = {
 };
 
 export class GetMockTransactionPageDataUsecase {
-  async execute(params: GetTransactionPageDataParams) {
+  async execute(params: TopPageDataParams) {
     console.log("🔧 Using mock data for development");
 
     return {


### PR DESCRIPTION
## Summary
- Rename `/server/actions` directory to `/server/loaders` to better reflect their purpose as data loading functions
- Update file names and function names to use `load` prefix instead of `get`/`Action` suffix
- Update all import references and cache keys throughout the codebase

## Changes Made
### Directory Structure
- `webapp/src/server/actions/` → `webapp/src/server/loaders/`

### File Renames
- `get-transactions-by-slug.ts` → `load-transactions-page-data.ts`
- `get-transaction-page-data.ts` → `load-top-page-data.ts`

### Function Renames
- `getTransactionsBySlugAction` → `loadTransactionsPageData`
- `getTransactionPageDataAction` → `loadTopPageData`

### Interface Updates
- `TransactionPageDataParams` → `TopPageDataParams`

### Cache Key Updates
- Updated cache refresh API to use new cache tags
- Updated cache keys to match new naming convention

## Rationale
This change improves code clarity by distinguishing between:
- **Server Actions**: Functions with `"use server"` for mutations and form handling
- **Data Loaders**: Server-side data fetching functions for SSR components

The new naming convention makes the codebase more maintainable and follows Next.js best practices.

## Test Plan
- [x] All TypeScript checks pass
- [x] All lint checks pass
- [x] All existing functionality preserved
- [x] Cache refresh API updated accordingly

🤖 Generated with [Claude Code](https://claude.ai/code)