### PR TITLE
Fix: Remove server action redirects to prevent Next Redirect errors

### DIFF
--- a/admin/src/app/(auth)/political-organizations/[orgId]/page.tsx
+++ b/admin/src/app/(auth)/political-organizations/[orgId]/page.tsx
@@ -31,7 +31,7 @@ export default async function EditPoliticalOrganizationPage({
 
   const handleSubmit = async (formData: UpdatePoliticalOrganizationData) => {
     "use server";
-    await updatePoliticalOrganization(orgId, formData);
+    return await updatePoliticalOrganization(orgId, formData);
   };
 
   return (

--- a/admin/src/app/(auth)/political-organizations/new/page.tsx
+++ b/admin/src/app/(auth)/political-organizations/new/page.tsx
@@ -7,7 +7,7 @@ import type { CreatePoliticalOrganizationData } from "@/server/actions/create-po
 export default function NewPoliticalOrganizationPage() {
   const handleSubmit = async (formData: CreatePoliticalOrganizationData) => {
     "use server";
-    await createPoliticalOrganization(formData);
+    return await createPoliticalOrganization(formData);
   };
 
   return (

--- a/admin/src/client/components/political-organizations/PoliticalOrganizationForm.tsx
+++ b/admin/src/client/components/political-organizations/PoliticalOrganizationForm.tsx
@@ -2,6 +2,7 @@
 import "client-only";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 interface PoliticalOrganizationFormData {
@@ -12,7 +13,9 @@ interface PoliticalOrganizationFormData {
 
 interface PoliticalOrganizationFormProps {
   initialData?: Partial<PoliticalOrganizationFormData>;
-  onSubmit: (data: PoliticalOrganizationFormData) => Promise<void>;
+  onSubmit: (
+    data: PoliticalOrganizationFormData,
+  ) => Promise<{ success: boolean }>;
   submitButtonText: string;
   title: string;
 }
@@ -23,6 +26,7 @@ export function PoliticalOrganizationForm({
   submitButtonText,
   title,
 }: PoliticalOrganizationFormProps) {
+  const router = useRouter();
   const [formData, setFormData] = useState<PoliticalOrganizationFormData>({
     name: initialData.name || "",
     slug: initialData.slug || "",
@@ -38,7 +42,10 @@ export function PoliticalOrganizationForm({
     try {
       setIsLoading(true);
       setError(null);
-      await onSubmit(formData);
+      const result = await onSubmit(formData);
+      if (result.success) {
+        router.push("/political-organizations");
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : "更新に失敗しました");
     } finally {

--- a/admin/src/server/actions/create-political-organization.ts
+++ b/admin/src/server/actions/create-political-organization.ts
@@ -2,7 +2,6 @@
 
 import { PrismaClient } from "@prisma/client";
 import { revalidatePath } from "next/cache";
-import { redirect } from "next/navigation";
 
 const prisma = new PrismaClient();
 
@@ -33,6 +32,9 @@ export async function createPoliticalOrganization(
         description: description?.trim() || null,
       },
     });
+
+    revalidatePath("/political-organizations");
+    return { success: true };
   } catch (error) {
     console.error("Error creating political organization:", error);
 
@@ -44,7 +46,4 @@ export async function createPoliticalOrganization(
       error instanceof Error ? error.message : "政治団体の作成に失敗しました",
     );
   }
-
-  revalidatePath("/political-organizations");
-  redirect("/political-organizations");
 }

--- a/admin/src/server/actions/update-political-organization.ts
+++ b/admin/src/server/actions/update-political-organization.ts
@@ -2,7 +2,6 @@
 
 import { PrismaClient } from "@prisma/client";
 import { revalidatePath } from "next/cache";
-import { redirect } from "next/navigation";
 
 const prisma = new PrismaClient();
 
@@ -41,6 +40,9 @@ export async function updatePoliticalOrganization(
         description: description?.trim() || null,
       },
     });
+
+    revalidatePath("/political-organizations");
+    return { success: true };
   } catch (error) {
     console.error("Error updating political organization:", error);
 
@@ -59,7 +61,4 @@ export async function updatePoliticalOrganization(
       error instanceof Error ? error.message : "政治団体の更新に失敗しました",
     );
   }
-
-  revalidatePath("/political-organizations");
-  redirect("/political-organizations");
 }


### PR DESCRIPTION
## Summary
- Replaced redirect() calls in server actions with return { success: true }
- Moved redirect logic to client-side using useRouter in form component
- Updated form component type to expect success response from server actions

## Problem
When creating or updating political organizations, users experienced a brief "Next Redirect" error message. This occurred because redirect() calls within server actions throw internal redirect exceptions that can briefly surface to the user interface.

## Solution
- Server actions now return success/failure status instead of handling redirects
- Client-side form component handles navigation using Next.js useRouter
- This provides cleaner separation of concerns and eliminates the error message

## Test plan
- [x] Test creating new political organizations
- [x] Test updating existing political organizations
- [x] Verify no "Next Redirect" error messages appear
- [x] Confirm proper navigation after successful operations

🤖 Generated with [Claude Code](https://claude.ai/code)