### PR TITLE
Add political organization column to transactions table

### DIFF
--- a/admin/src/client/components/transactions/TransactionRow.tsx
+++ b/admin/src/client/components/transactions/TransactionRow.tsx
@@ -1,7 +1,7 @@
 "use client";
 import "client-only";
 
-import type { TransactionWithOrganization } from "@/shared/models/transaction-with-organization";
+import type { TransactionWithOrganization } from "@/server/usecases/get-transactions-usecase";
 import { ACCOUNT_CATEGORY_MAPPING } from "@/shared/utils/category-mapping";
 
 interface TransactionRowProps {

--- a/admin/src/server/repositories/interfaces/transaction-repository.interface.ts
+++ b/admin/src/server/repositories/interfaces/transaction-repository.interface.ts
@@ -4,7 +4,7 @@ import type {
   TransactionFilters,
   UpdateTransactionInput,
 } from "@/shared/models/transaction";
-import type { TransactionWithOrganization } from "@/shared/models/transaction-with-organization";
+import type { TransactionWithOrganization } from "@/server/usecases/get-transactions-usecase";
 
 export interface PaginatedResult<T> {
   items: T[];

--- a/admin/src/server/repositories/prisma-transaction.repository.ts
+++ b/admin/src/server/repositories/prisma-transaction.repository.ts
@@ -5,7 +5,7 @@ import type {
   TransactionFilters,
   UpdateTransactionInput,
 } from "@/shared/models/transaction";
-import type { TransactionWithOrganization } from "@/shared/models/transaction-with-organization";
+import type { TransactionWithOrganization } from "@/server/usecases/get-transactions-usecase";
 import type {
   ITransactionRepository,
   PaginatedResult,
@@ -65,7 +65,7 @@ export class PrismaTransactionRepository implements ITransactionRepository {
       orderBy: { transactionDate: "desc" },
     });
 
-    return transactions.map(this.mapToTransaction);
+    return transactions.map((t) => this.mapToTransaction(t));
   }
 
   async findWithPagination(
@@ -220,7 +220,7 @@ export class PrismaTransactionRepository implements ITransactionRepository {
       take: inputs.length,
     });
 
-    return createdTransactions.map(this.mapToTransaction);
+    return createdTransactions.map((t) => this.mapToTransaction(t));
   }
 
   async createManySkipDuplicates(inputs: CreateTransactionInput[]): Promise<{
@@ -281,7 +281,7 @@ export class PrismaTransactionRepository implements ITransactionRepository {
       },
     });
 
-    return transactions.map(this.mapToTransaction);
+    return transactions.map((t) => this.mapToTransaction(t));
   }
 
   async checkDuplicateTransactionNos(
@@ -309,8 +309,8 @@ export class PrismaTransactionRepository implements ITransactionRepository {
       .filter((no): no is string => no !== null);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public mapToTransaction(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     prismaTransaction: any,
     includeOrganization = false,
   ): Transaction | TransactionWithOrganization {

--- a/admin/src/server/usecases/get-transactions-usecase.ts
+++ b/admin/src/server/usecases/get-transactions-usecase.ts
@@ -1,9 +1,15 @@
-import type { TransactionFilters } from "@/shared/models/transaction";
-import type { TransactionWithOrganization } from "@/shared/models/transaction-with-organization";
+import type {
+  Transaction,
+  TransactionFilters,
+} from "@/shared/models/transaction";
 import type {
   ITransactionRepository,
   PaginationOptions,
 } from "../repositories/interfaces/transaction-repository.interface";
+
+export interface TransactionWithOrganization extends Transaction {
+  political_organization_name?: string;
+}
 
 export interface GetTransactionsParams {
   page?: number;

--- a/admin/src/shared/models/transaction-with-organization.ts
+++ b/admin/src/shared/models/transaction-with-organization.ts
@@ -1,5 +1,0 @@
-import type { Transaction } from "@/shared/models/transaction";
-
-export interface TransactionWithOrganization extends Transaction {
-  political_organization_name?: string;
-}


### PR DESCRIPTION
## Summary
- Add political organization name column to transactions table in admin interface
- Implement efficient data fetching to avoid N+1 queries
- Create admin-specific interface for extended transaction data

## Changes Made
- **New Interface**: Added `TransactionWithOrganization` in admin-specific models
- **Repository Layer**: Modified `findWithPagination` to include `politicalOrganization` relation
- **UI Updates**: Added "政治団体" column to transactions table header and rows
- **Performance**: Single JOIN query prevents N+1 problem when fetching organization names

## Technical Details
- Uses Prisma's `include` to fetch related organization data in one query
- Conditional mapping method supports both basic and extended transaction objects
- Type-safe implementation with proper interface separation

## Test Plan
- [ ] Verify political organization names display correctly in transactions table
- [ ] Confirm no N+1 queries are generated (check database query logs)
- [ ] Ensure existing functionality remains unchanged
- [ ] Test with various political organizations

🤖 Generated with [Claude Code](https://claude.ai/code)