### PR TITLE
Fix: Add cache revalidation for transaction data updates

### DIFF
--- a/admin/src/server/actions/delete-all-transactions.ts
+++ b/admin/src/server/actions/delete-all-transactions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
 import { PrismaClient } from "@prisma/client";
 import { PrismaTransactionRepository } from "../repositories/prisma-transaction.repository";
 import { DeleteAllTransactionsUsecase } from "../usecases/delete-all-transactions-usecase";
@@ -18,6 +18,8 @@ export async function deleteAllTransactionsAction(): Promise<{
 
     const result = await usecase.execute();
 
+    // キャッシュを無効化してトランザクション一覧を更新
+    revalidateTag("transactions-data");
     revalidatePath("/transactions");
 
     return {

--- a/admin/src/server/actions/upload-csv.ts
+++ b/admin/src/server/actions/upload-csv.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { PrismaClient } from "@prisma/client";
+import { revalidateTag } from "next/cache";
 import { PrismaTransactionRepository } from "@/server/repositories/prisma-transaction.repository";
 import { SavePreviewTransactionsUsecase } from "@/server/usecases/save-preview-transactions-usecase";
 import type { PreviewTransaction } from "@/server/lib/mf-record-converter";
@@ -58,6 +59,9 @@ export async function uploadCsv(
       result.skippedCount > 0
         ? `${result.processedCount}件を処理し、${result.savedCount}件を新規保存、${result.skippedCount}件を重複のためスキップしました`
         : `${result.processedCount}件を処理し、${result.savedCount}件を保存しました`;
+
+    // キャッシュを無効化してトランザクション一覧を更新
+    revalidateTag("transactions-data");
 
     return {
       ok: true,


### PR DESCRIPTION
## Summary
- Fix cache invalidation issue where transaction list wasn't updating after CSV upload or data deletion
- Add proper revalidation to ensure users see fresh data immediately

## Changes Made
- **CSV Upload**: Add `revalidateTag("transactions-data")` to invalidate cache after successful upload
- **Delete All**: Add `revalidateTag("transactions-data")` in addition to existing `revalidatePath()` for comprehensive cache invalidation

## Problem Solved
Before this fix, users had to wait up to 60 seconds (cache expiry) to see updated transaction data after:
- Uploading CSV files
- Deleting all transactions

Now data updates are reflected immediately.

## Technical Details
- Uses Next.js `revalidateTag()` to invalidate the `unstable_cache` in `loadTransactionsData`
- Maintains existing `revalidatePath()` for additional cache layer invalidation
- Consistent cache invalidation strategy across all data mutation operations

## Test Plan
- [ ] Upload CSV and verify transaction list updates immediately
- [ ] Delete all transactions and verify list updates immediately
- [ ] Confirm no performance impact on cache invalidation

🤖 Generated with [Claude Code](https://claude.ai/code)