### PR TITLE
寄附推移グラフを直近90日表示に変更

### DIFF
--- a/webapp/src/client/components/top-page/DonationSummarySection.tsx
+++ b/webapp/src/client/components/top-page/DonationSummarySection.tsx
@@ -52,7 +52,7 @@ export default function DonationSummarySection({
         }
         title="これまでの累計寄付金額"
         updatedAt={updatedAt}
-        subtitle="いただいた寄付総額と直近1ヶ月の推移"
+        subtitle="いただいた寄付総額と直近3ヶ月の推移"
       />
 
       {/* 寄付統計サマリー */}

--- a/webapp/src/client/components/top-page/features/charts/DonationChart.tsx
+++ b/webapp/src/client/components/top-page/features/charts/DonationChart.tsx
@@ -27,11 +27,8 @@ export default function DonationChart({
   data,
   height = 287,
 }: DonationChartProps) {
-  // 直近30日のデータを抽出
-  const recentData = data.slice(-30);
-
-  // チャート用にデータを変換
-  const chartData: ChartDataPoint[] = recentData.map((item) => ({
+  // BFF側で既に90日分に絞られているので、全データを使用
+  const chartData: ChartDataPoint[] = data.map((item) => ({
     date: item.date,
     displayDate: formatXAxisLabel(item.date),
     cumulativeAmount: item.cumulativeAmount,
@@ -66,7 +63,7 @@ export default function DonationChart({
       >
         <div className="text-center text-gray-500">
           <div className="text-lg font-medium mb-2">
-            直近1ヶ月の寄付金額の推移
+            直近3ヶ月の寄付金額の推移
           </div>
           <div className="text-sm">データがありません</div>
         </div>
@@ -79,16 +76,16 @@ export default function DonationChart({
       className="bg-white rounded-lg "
       style={{ height }}
       role="img"
-      aria-label="直近1ヶ月の寄付金額の推移グラフ"
+      aria-label="直近3ヶ月の寄付金額の推移グラフ"
       aria-describedby="donation-chart-description"
     >
       <div className="text-center">
         <h4 className="text-[13px] font-bold leading-[1.31] text-gray-600">
-          直近1ヶ月の寄付金額の推移
+          直近3ヶ月の寄付金額の推移
         </h4>
       </div>
       <div id="donation-chart-description" className="sr-only">
-        直近30日間の累計寄付金額の推移を示す折れ線グラフです。
+        直近90日間の累計寄付金額の推移を示す折れ線グラフです。
       </div>
       <div
         style={{ height: height }}

--- a/webapp/src/server/loaders/load-top-page-data.ts
+++ b/webapp/src/server/loaders/load-top-page-data.ts
@@ -80,6 +80,7 @@ export const loadTopPageData = unstable_cache(
         slugs: params.slugs,
         financialYear: params.financialYear,
         today: new Date(),
+        days: 90,
       }),
     ]);
 

--- a/webapp/tests/server/usecases/get-daily-donation-usecase.test.ts
+++ b/webapp/tests/server/usecases/get-daily-donation-usecase.test.ts
@@ -1,0 +1,126 @@
+import { GetDailyDonationUsecase } from "@/server/usecases/get-daily-donation-usecase";
+import type { ITransactionRepository } from "@/server/repositories/interfaces/transaction-repository.interface";
+import type { IPoliticalOrganizationRepository } from "@/server/repositories/interfaces/political-organization-repository.interface";
+import type { DailyDonationData } from "@/server/repositories/interfaces/transaction-repository.interface";
+
+// モックリポジトリの作成
+const mockTransactionRepository = {
+  getDailyDonationData: jest.fn(),
+} as unknown as ITransactionRepository;
+
+const mockPoliticalOrganizationRepository = {
+  findBySlugs: jest.fn(),
+} as unknown as IPoliticalOrganizationRepository;
+
+describe("GetDailyDonationUsecase", () => {
+  let usecase: GetDailyDonationUsecase;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    usecase = new GetDailyDonationUsecase(
+      mockTransactionRepository,
+      mockPoliticalOrganizationRepository,
+    );
+  });
+
+  it("should return recent N days of data with cumulative sum", async () => {
+    // モックデータの準備
+    const mockOrganizations = [{ id: "1", slug: "test-org" }];
+    const mockRawData: DailyDonationData[] = [
+      { date: "2025-01-01", dailyAmount: 1000, cumulativeAmount: 1000 },
+      { date: "2025-01-03", dailyAmount: 2000, cumulativeAmount: 3000 }, // 1/2は歯抜け
+      { date: "2025-01-05", dailyAmount: 1500, cumulativeAmount: 4500 }, // 1/4は歯抜け
+    ];
+
+    // モックの設定
+    (mockPoliticalOrganizationRepository.findBySlugs as jest.Mock).mockResolvedValue(
+      mockOrganizations,
+    );
+    (mockTransactionRepository.getDailyDonationData as jest.Mock).mockResolvedValue(
+      mockRawData,
+    );
+
+    // テスト実行（N=3で直近3日分を取得）
+    const result = await usecase.execute({
+      slugs: ["test-org"],
+      financialYear: 2025,
+      today: new Date("2025-01-05"),
+      days: 3,
+    });
+
+    // 検証
+    expect(result.donationSummary.dailyDonationData).toHaveLength(3);
+    
+    // 日付が連続していることを確認（歯抜けが埋められている）
+    const data = result.donationSummary.dailyDonationData;
+    expect(data[0].date).toBe("2025-01-03");
+    expect(data[1].date).toBe("2025-01-04");
+    expect(data[2].date).toBe("2025-01-05");
+
+    // 金額が正しく設定されていることを確認
+    expect(data[0].dailyAmount).toBe(2000);
+    expect(data[1].dailyAmount).toBe(0); // 歯抜け日は0
+    expect(data[2].dailyAmount).toBe(1500);
+
+    // 累積和が正しく計算されていることを確認
+    expect(data[0].cumulativeAmount).toBe(3000); // 1000 + 2000
+    expect(data[1].cumulativeAmount).toBe(3000); // 前日と同じ（当日寄附なし）
+    expect(data[2].cumulativeAmount).toBe(4500); // 3000 + 1500
+
+    // その他のサマリー情報も確認
+    expect(result.donationSummary.totalAmount).toBe(4500);
+    expect(result.donationSummary.totalDays).toBe(2); // 寄附があった日数
+  });
+
+  it("should handle case when today is not found in data", async () => {
+    // モックデータの準備
+    const mockOrganizations = [{ id: "1", slug: "test-org" }];
+    const mockRawData: DailyDonationData[] = [
+      { date: "2025-01-01", dailyAmount: 1000, cumulativeAmount: 1000 },
+      { date: "2025-01-02", dailyAmount: 2000, cumulativeAmount: 3000 },
+      { date: "2025-01-03", dailyAmount: 1500, cumulativeAmount: 4500 },
+    ];
+
+    // モックの設定
+    (mockPoliticalOrganizationRepository.findBySlugs as jest.Mock).mockResolvedValue(
+      mockOrganizations,
+    );
+    (mockTransactionRepository.getDailyDonationData as jest.Mock).mockResolvedValue(
+      mockRawData,
+    );
+
+    // 今日がデータに存在しない場合をテスト（財政年度内だが、データがない日）
+    const result = await usecase.execute({
+      slugs: ["test-org"],
+      financialYear: 2025,
+      today: new Date("2025-01-10"), // データ範囲外だが財政年度内
+      days: 3,
+    });
+
+    // 今日を含む3日分が返されることを確認
+    expect(result.donationSummary.dailyDonationData).toHaveLength(3);
+    
+    const data = result.donationSummary.dailyDonationData;
+    expect(data[0].date).toBe("2025-01-08");
+    expect(data[1].date).toBe("2025-01-09");
+    expect(data[2].date).toBe("2025-01-10");
+    
+    // 今日のデータは0であることを確認
+    expect(data[2].dailyAmount).toBe(0);
+  });
+
+  it("should throw error when organization not found", async () => {
+    // モックの設定：組織が見つからない場合
+    (mockPoliticalOrganizationRepository.findBySlugs as jest.Mock).mockResolvedValue([]);
+
+    // エラーが投げられることを確認
+    await expect(
+      usecase.execute({
+        slugs: ["non-existent-org"],
+        financialYear: 2025,
+        today: new Date("2025-04-05"),
+        days: 3,
+      }),
+    ).rejects.toThrow('Political organizations with slugs "non-existent-org" not found');
+  });
+});


### PR DESCRIPTION
## Summary
- 寄附推移グラフの表示期間を直近30日から90日（3ヶ月）に変更
- 政治団体の財政年度（1月1日〜12月31日）に対応
- 日付の歯抜けを補完し累積和を正確に計算するロジックを実装

## 主な変更内容
- `GetDailyDonationUsecase`に`days`パラメータを追加し、動的に表示日数を指定可能に
- 財政年度全体のデータに対して日付の歯抜けをゼロ埋めする機能を追加
- 今日を基準とした直近N日分のデータを抽出する機能を実装
- フロントエンドで不要になった`slice(-30)`を削除し、BFFからの全データを使用
- 表示タイトルを「直近1ヶ月」から「直近3ヶ月」に更新

## Test plan
- [x] N=3のケースでユニットテストを作成し、動作を検証
- [x] 日付の歯抜け補完と累積和計算が正しく動作することを確認
- [x] 今日が見つからない場合のフォールバック処理をテスト
- [x] 組織が見つからない場合のエラーハンドリングをテスト

🤖 Generated with [Claude Code](https://claude.ai/code)