### PR TITLE
Add CSV download functionality for transactions

### DIFF
--- a/webapp/src/app/transactions/page.tsx
+++ b/webapp/src/app/transactions/page.tsx
@@ -9,6 +9,7 @@ import CardHeader from "@/client/components/layout/CardHeader";
 import MainColumn from "@/client/components/layout/MainColumn";
 import MainColumnCard from "@/client/components/layout/MainColumnCard";
 import InteractiveTransactionTable from "@/client/components/top-page/features/transactions-table/InteractiveTransactionTable";
+import CsvDownloadButton from "@/client/components/transactions/CsvDownloadButton";
 import { loadTransactionsPageData } from "@/server/loaders/load-transactions-page-data";
 import { formatUpdatedAt } from "@/server/utils/format-date";
 
@@ -120,6 +121,10 @@ export default async function TransactionsPage({
             totalPages={data.totalPages}
             selectedCategories={categories}
           />
+
+          <div className="mt-6 flex justify-center">
+            <CsvDownloadButton />
+          </div>
         </MainColumnCard>
 
         <TransparencySection title="党内の機密データの流出事故ではありません☺️" />

--- a/webapp/src/client/components/transactions/CsvDownloadButton.tsx
+++ b/webapp/src/client/components/transactions/CsvDownloadButton.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState } from "react";
+import MainButton from "@/client/components/ui/MainButton";
+import { downloadTransactionsCsv } from "@/server/actions/download-transactions-csv";
+
+export default function CsvDownloadButton() {
+  const [isDownloading, setIsDownloading] = useState(false);
+
+  const handleDownload = async () => {
+    if (isDownloading) return;
+
+    setIsDownloading(true);
+    try {
+      const result = await downloadTransactionsCsv();
+
+      if (result.success && result.data) {
+        // BOMを追加してUTF-8で保存
+        const blob = new Blob([`\uFEFF${result.data}`], {
+          type: "text/csv;charset=utf-8;",
+        });
+
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = result.filename || "transactions.csv";
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        window.URL.revokeObjectURL(url);
+      } else {
+        alert(result.error || "ダウンロードに失敗しました");
+      }
+    } catch (error) {
+      console.error("Download failed:", error);
+      alert("ダウンロードに失敗しました");
+    } finally {
+      setIsDownloading(false);
+    }
+  };
+
+  return (
+    <MainButton onClick={handleDownload} disabled={isDownloading}>
+      {isDownloading ? "ダウンロード中..." : "CSVでダウンロード"}
+    </MainButton>
+  );
+}

--- a/webapp/src/server/actions/download-transactions-csv.ts
+++ b/webapp/src/server/actions/download-transactions-csv.ts
@@ -1,0 +1,60 @@
+"use server";
+
+import { loadAllTransactionsData } from "@/server/loaders/load-all-transactions-data";
+
+export async function downloadTransactionsCsv() {
+  try {
+    // すべてのトランザクションを取得
+    const data = await loadAllTransactionsData({
+      slugs: ["team-mirai", "digimin"],
+      financialYear: 2025,
+    });
+
+    // CSVヘッダー
+    const headers = [
+      "日付",
+      "タイプ",
+      "金額",
+      "カテゴリ",
+      "科目",
+      "チームみらい区分",
+      "ラベル",
+    ];
+
+    // CSVデータを作成
+    const csvRows = [
+      headers.join(","),
+      ...data.transactions.map((transaction) => {
+        const row = [
+          new Date(transaction.date).toISOString().split("T")[0],
+          transaction.transactionType === "income" ? "収入" : "支出",
+          transaction.amount.toString(),
+          `"${transaction.category.replace(/"/g, '""')}"`,
+          `"${transaction.account.replace(/"/g, '""')}"`, // CSVエスケープ
+          `"${(transaction.friendly_category || "").replace(/"/g, '""')}"`,
+          `"${transaction.label.replace(/"/g, '""')}"`,
+        ];
+        return row.join(",");
+      }),
+    ];
+
+    const csvContent = csvRows.join("\n");
+
+    // ダウンロード用のレスポンスを返す
+    const now = new Date();
+    const timestamp = now.toISOString().split("T")[0];
+    const filename = `transactions_${timestamp}.csv`;
+
+    return {
+      success: true,
+      data: csvContent,
+      filename,
+    };
+  } catch (error) {
+    console.error("CSV download error:", error);
+    return {
+      success: false,
+      error: "CSVのダウンロードに失敗しました",
+    };
+  }
+}

--- a/webapp/src/server/loaders/load-all-transactions-data.ts
+++ b/webapp/src/server/loaders/load-all-transactions-data.ts
@@ -1,0 +1,27 @@
+import { PrismaClient } from "@prisma/client";
+import { unstable_cache } from "next/cache";
+import { PrismaPoliticalOrganizationRepository } from "@/server/repositories/prisma-political-organization.repository";
+import { PrismaTransactionRepository } from "@/server/repositories/prisma-transaction.repository";
+import {
+  type GetAllTransactionsBySlugParams,
+  GetAllTransactionsBySlugUsecase,
+} from "@/server/usecases/get-all-transactions-by-slug-usecase";
+
+const prisma = new PrismaClient();
+const CACHE_REVALIDATE_SECONDS = 60;
+
+export const loadAllTransactionsData = unstable_cache(
+  async (params: GetAllTransactionsBySlugParams) => {
+    const transactionRepository = new PrismaTransactionRepository(prisma);
+    const politicalOrganizationRepository =
+      new PrismaPoliticalOrganizationRepository(prisma);
+    const usecase = new GetAllTransactionsBySlugUsecase(
+      transactionRepository,
+      politicalOrganizationRepository,
+    );
+
+    return await usecase.execute(params);
+  },
+  ["all-transactions-data"],
+  { revalidate: CACHE_REVALIDATE_SECONDS },
+);

--- a/webapp/src/server/repositories/interfaces/transaction-repository.interface.ts
+++ b/webapp/src/server/repositories/interfaces/transaction-repository.interface.ts
@@ -44,9 +44,17 @@ export interface DailyDonationData {
   cumulativeAmount: number; // 累積寄付額
 }
 
+export interface SortOptions {
+  sortBy?: "date" | "amount";
+  order?: "asc" | "desc";
+}
+
 export interface ITransactionRepository {
   findById(id: string): Promise<Transaction | null>;
-  findAll(filters?: TransactionFilters): Promise<Transaction[]>;
+  findAll(
+    filters?: TransactionFilters,
+    sortOptions?: SortOptions,
+  ): Promise<Transaction[]>;
   findWithPagination(
     filters?: TransactionFilters,
     pagination?: PaginationOptions,

--- a/webapp/src/server/usecases/get-all-transactions-by-slug-usecase.ts
+++ b/webapp/src/server/usecases/get-all-transactions-by-slug-usecase.ts
@@ -1,0 +1,91 @@
+import type { PoliticalOrganization } from "@/shared/models/political-organization";
+import type { TransactionFilters } from "@/shared/models/transaction";
+import type {
+  DisplayTransaction,
+  DisplayTransactionType,
+} from "@/types/display-transaction";
+import type { IPoliticalOrganizationRepository } from "../repositories/interfaces/political-organization-repository.interface";
+import type { ITransactionRepository } from "../repositories/interfaces/transaction-repository.interface";
+import { convertToDisplayTransactions } from "../utils/transaction-converter";
+
+export interface GetAllTransactionsBySlugParams {
+  slugs: string[];
+  transactionType?: DisplayTransactionType;
+  dateFrom?: Date;
+  dateTo?: Date;
+  financialYear: number;
+  sortBy?: "date" | "amount";
+  order?: "asc" | "desc";
+  categories?: string[];
+}
+
+export interface GetAllTransactionsBySlugResult {
+  transactions: DisplayTransaction[];
+  total: number;
+  politicalOrganizations: PoliticalOrganization[];
+  lastUpdatedAt: string | null;
+}
+
+export class GetAllTransactionsBySlugUsecase {
+  constructor(
+    private transactionRepository: ITransactionRepository,
+    private politicalOrganizationRepository: IPoliticalOrganizationRepository,
+  ) {}
+
+  async execute(
+    params: GetAllTransactionsBySlugParams,
+  ): Promise<GetAllTransactionsBySlugResult> {
+    try {
+      const politicalOrganizations =
+        await this.politicalOrganizationRepository.findBySlugs(params.slugs);
+
+      if (politicalOrganizations.length === 0) {
+        throw new Error(
+          `Political organizations with slugs "${params.slugs.join(", ")}" not found`,
+        );
+      }
+
+      const organizationIds = politicalOrganizations.map((org) => org.id);
+      const filters: TransactionFilters = {
+        political_organization_ids: organizationIds,
+      };
+
+      if (params.transactionType) {
+        filters.transaction_type = params.transactionType;
+      }
+      if (params.dateFrom) {
+        filters.date_from = params.dateFrom;
+      }
+      if (params.dateTo) {
+        filters.date_to = params.dateTo;
+      }
+      if (params.categories && params.categories.length > 0) {
+        filters.category_keys = params.categories;
+      }
+      filters.financial_year = params.financialYear;
+
+      // 全件取得（ページネーションなし）
+      const [transactionResult, lastUpdatedAt] = await Promise.all([
+        this.transactionRepository.findAll(filters, {
+          sortBy: params.sortBy,
+          order: params.order,
+        }),
+        this.transactionRepository.getLastUpdatedAt(),
+      ]);
+
+      const transactions = convertToDisplayTransactions(transactionResult);
+      const total = transactions.length;
+
+      return {
+        transactions,
+        total,
+        politicalOrganizations,
+        lastUpdatedAt: lastUpdatedAt?.toISOString() ?? null,
+      };
+    } catch (error) {
+      throw new Error(
+        `Failed to get all transactions by slug: ${error instanceof Error ? error.message : "Unknown error"}`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add CSV download button to transactions page in MainColumnCard
- Create server action for CSV generation with all transaction data  
- Add new usecase for fetching all transactions without pagination limit
- CSV includes: date, type, amount, category, account (科目), team-mirai classification, and label

## Test plan
- [ ] Verify CSV download button appears at bottom of transactions page
- [ ] Test CSV download functionality works correctly
- [ ] Confirm CSV contains all transaction data with proper formatting
- [ ] Check that all transactions are included (not limited to 100 records)

🤖 Generated with [Claude Code](https://claude.ai/code)