### PR TITLE
Add political organization deletion functionality

### DIFF
--- a/admin/src/app/(auth)/political-organizations/page.tsx
+++ b/admin/src/app/(auth)/political-organizations/page.tsx
@@ -2,6 +2,7 @@ import "server-only";
 
 import Link from "next/link";
 import { loadPoliticalOrganizationsData } from "@/server/loaders/load-political-organizations-data";
+import { DeletePoliticalOrganizationButton } from "@/client/components/political-organizations/DeletePoliticalOrganizationButton";
 
 export default async function PoliticalOrganizationsPage() {
   const organizations = await loadPoliticalOrganizationsData();
@@ -50,12 +51,18 @@ export default async function PoliticalOrganizationsPage() {
                       {new Date(org.createdAt).toLocaleDateString("ja-JP")}
                     </div>
                   </div>
-                  <Link
-                    href={`/political-organizations/${org.id}`}
-                    className="bg-primary-hover text-white no-underline text-sm px-4 py-2 rounded-lg hover:bg-primary-border transition-colors duration-200"
-                  >
-                    編集
-                  </Link>
+                  <div className="flex gap-2">
+                    <Link
+                      href={`/political-organizations/${org.id}`}
+                      className="bg-primary-hover text-white no-underline text-sm px-4 py-2 rounded-lg hover:bg-primary-border transition-colors duration-200"
+                    >
+                      編集
+                    </Link>
+                    <DeletePoliticalOrganizationButton
+                      orgId={BigInt(org.id)}
+                      orgName={org.name}
+                    />
+                  </div>
                 </div>
               </div>
             ))}

--- a/admin/src/client/components/political-organizations/DeletePoliticalOrganizationButton.tsx
+++ b/admin/src/client/components/political-organizations/DeletePoliticalOrganizationButton.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState } from "react";
+import { deletePoliticalOrganization } from "@/server/actions/delete-political-organization";
+
+interface DeletePoliticalOrganizationButtonProps {
+  orgId: bigint;
+  orgName: string;
+}
+
+export function DeletePoliticalOrganizationButton({
+  orgId,
+  orgName,
+}: DeletePoliticalOrganizationButtonProps) {
+  const [deleting, setDeleting] = useState(false);
+
+  const handleDelete = async () => {
+    if (
+      !window.confirm(
+        `政治団体「${orgName}」を削除してもよろしいですか？この操作は取り消せません。`,
+      )
+    ) {
+      return;
+    }
+
+    try {
+      setDeleting(true);
+      const result = await deletePoliticalOrganization(orgId);
+
+      if (result.success) {
+        alert(result.message);
+      } else {
+        alert(result.message);
+      }
+    } catch (err) {
+      alert(`エラー: ${err instanceof Error ? err.message : "Unknown error"}`);
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleDelete}
+      disabled={deleting}
+      className={`bg-red-600 text-white border-0 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-red-400 ${
+        deleting
+          ? "opacity-50 cursor-not-allowed"
+          : "hover:bg-red-700 cursor-pointer"
+      }`}
+    >
+      {deleting ? "削除中..." : "削除"}
+    </button>
+  );
+}

--- a/admin/src/server/actions/delete-political-organization.ts
+++ b/admin/src/server/actions/delete-political-organization.ts
@@ -1,0 +1,28 @@
+"use server";
+
+import "server-only";
+import { revalidatePath } from "next/cache";
+import { PrismaClient } from "@prisma/client";
+import { DeletePoliticalOrganizationUsecase } from "@/server/usecases/delete-political-organization-usecase";
+import { PrismaPoliticalOrganizationRepository } from "@/server/repositories/prisma-political-organization.repository";
+
+interface DeletePoliticalOrganizationResult {
+  success: boolean;
+  message: string;
+}
+
+export async function deletePoliticalOrganization(
+  orgId: bigint,
+): Promise<DeletePoliticalOrganizationResult> {
+  const prisma = new PrismaClient();
+  const repository = new PrismaPoliticalOrganizationRepository(prisma);
+  const usecase = new DeletePoliticalOrganizationUsecase(repository);
+
+  const result = await usecase.execute(orgId);
+
+  if (result.success) {
+    revalidatePath("/political-organizations");
+  }
+
+  return result;
+}

--- a/admin/src/server/repositories/interfaces/political-organization-repository.interface.ts
+++ b/admin/src/server/repositories/interfaces/political-organization-repository.interface.ts
@@ -6,4 +6,6 @@ export interface IPoliticalOrganizationRepository {
     slug: string,
     description?: string,
   ): Promise<PoliticalOrganization>;
+  delete(id: bigint): Promise<void>;
+  countTransactions(id: bigint): Promise<number>;
 }

--- a/admin/src/server/repositories/prisma-political-organization.repository.ts
+++ b/admin/src/server/repositories/prisma-political-organization.repository.ts
@@ -25,4 +25,16 @@ export class PrismaPoliticalOrganizationRepository
       id: organization.id.toString(),
     };
   }
+
+  async delete(id: bigint): Promise<void> {
+    await this.prisma.politicalOrganization.delete({
+      where: { id },
+    });
+  }
+
+  async countTransactions(id: bigint): Promise<number> {
+    return await this.prisma.transaction.count({
+      where: { politicalOrganizationId: id },
+    });
+  }
 }

--- a/admin/src/server/usecases/delete-political-organization-usecase.ts
+++ b/admin/src/server/usecases/delete-political-organization-usecase.ts
@@ -1,0 +1,41 @@
+import "server-only";
+
+import type { IPoliticalOrganizationRepository } from "@/server/repositories/interfaces/political-organization-repository.interface";
+
+interface DeletePoliticalOrganizationResult {
+  success: boolean;
+  message: string;
+}
+
+export class DeletePoliticalOrganizationUsecase {
+  constructor(
+    private politicalOrganizationRepository: IPoliticalOrganizationRepository,
+  ) {}
+
+  async execute(orgId: bigint): Promise<DeletePoliticalOrganizationResult> {
+    try {
+      const transactionCount =
+        await this.politicalOrganizationRepository.countTransactions(orgId);
+
+      if (transactionCount > 0) {
+        return {
+          success: false,
+          message: `この政治団体には${transactionCount}件の取引が紐づいているため削除できません。`,
+        };
+      }
+
+      await this.politicalOrganizationRepository.delete(orgId);
+
+      return {
+        success: true,
+        message: "政治団体を削除しました。",
+      };
+    } catch (error) {
+      console.error("Error deleting political organization:", error);
+      return {
+        success: false,
+        message: "削除中にエラーが発生しました。",
+      };
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds deletion functionality for political organizations in admin interface
- Implements proper validation to prevent deletion when associated transactions exist  
- Uses clean architecture pattern with Repository and Usecase layers

## Changes Made
- Extended `IPoliticalOrganizationRepository` with `delete()` and `countTransactions()` methods
- Implemented deletion logic in `PrismaPoliticalOrganizationRepository`
- Created `DeletePoliticalOrganizationUsecase` for business logic separation
- Added `deletePoliticalOrganization` server action following clean architecture
- Built `DeletePoliticalOrganizationButton` client component with confirmation dialog
- Integrated deletion button into political organizations list page

## Business Logic
- Prevents deletion when organization has associated transactions
- Shows transaction count in error message for transparency
- Includes confirmation dialog before deletion
- Provides proper success/error feedback to users

## Test Plan
- [ ] Verify deletion button appears on political organizations list page
- [ ] Test deletion of organization without transactions succeeds
- [ ] Test deletion of organization with transactions is blocked with appropriate message
- [ ] Confirm confirmation dialog appears before deletion
- [ ] Verify page updates after successful deletion
- [ ] Test error handling for deletion failures

🤖 Generated with [Claude Code](https://claude.ai/code)