### PR TITLE
Localize admin user info interface to Japanese

### DIFF
--- a/admin/src/app/(auth)/user-info/page.tsx
+++ b/admin/src/app/(auth)/user-info/page.tsx
@@ -16,18 +16,18 @@ export default async function UserInfoPage() {
 
   return (
     <div className="card">
-      <h1>User Info</h1>
+      <h1>ユーザー情報</h1>
       <p>
         <b>ID:</b> {user.id}
       </p>
       <p>
-        <b>Email:</b> {user.email}
+        <b>メールアドレス:</b> {user.email}
       </p>
       <p>
-        <b>Role:</b> {userRole}
+        <b>ロール:</b> {userRole}
       </p>
       <p>
-        <b>Last Sign In:</b>{" "}
+        <b>最終ログイン:</b>{" "}
         {user.last_sign_in_at
           ? new Date(user.last_sign_in_at).toLocaleString("ja-JP")
           : "N/A"}

--- a/admin/src/client/components/layout/Sidebar.tsx
+++ b/admin/src/client/components/layout/Sidebar.tsx
@@ -23,7 +23,7 @@ export default function Sidebar({
   };
 
   const navItems = [
-    { href: "/user-info", label: "User Info" },
+    { href: "/user-info", label: "ユーザー情報" },
     { href: "/political-organizations", label: "政治団体" },
     { href: "/transactions", label: "トランザクション" },
     { href: "/upload-csv", label: "CSVアップロード" },


### PR DESCRIPTION
## Summary
- サイドバーの「User Info」を「ユーザー情報」に変更
- ユーザー情報ページのラベルを日本語化（Email → メールアドレス、Role → ロール、Last Sign In → 最終ログイン）
- ページタイトルを「User Info」から「ユーザー情報」に変更

## Test plan
- [ ] adminアプリケーションにログインして、サイドバーの「ユーザー情報」リンクが日本語で表示されることを確認
- [ ] ユーザー情報ページで、すべてのラベルが日本語で表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)