### PR TITLE
Replace legacy "poli-money" references with "open"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "poli-money-alpha",
+  "name": "open",
   "version": "0.1.0",
   "license": "AGPL-3.0",
   "private": true,

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -2,7 +2,7 @@
 # https://supabase.com/docs/guides/local-development/cli/config
 # A string used to distinguish different Supabase projects on the same host. Defaults to the
 # working directory name when running `supabase init`.
-project_id = "poli-money-something"
+project_id = "open"
 
 [api]
 enabled = false
@@ -183,7 +183,7 @@ otp_expiry = 86400
 
 # Uncomment to customize email template
 [auth.email.template.invite]
-subject = "You have been invited to Poli Money Alpha"
+subject = "You have been invited to みらいまる見え政治資金"
 content_path = "./supabase/templates/invite.html"
 
 [auth.sms]


### PR DESCRIPTION
## Summary
- Remove outdated "poli-money" references from project configuration
- Update package.json name field from "poli-money-alpha" to "open" 
- Update supabase project_id from "poli-money-something" to "open"
- Email template subject was updated to proper Japanese project name

## Test plan
- [x] Verify package.json name field is updated correctly
- [x] Verify supabase config project_id is updated correctly
- [ ] Test local development environment still works with new project name

🤖 Generated with [Claude Code](https://claude.ai/code)