### PR TITLE
feat: ベーシック認証機能を追加

### DIFF
--- a/webapp/.env.example
+++ b/webapp/.env.example
@@ -8,3 +8,9 @@ DATA_REFRESH_TOKEN="your-secret-refresh-token"
 
 # Google Analytics
 NEXT_PUBLIC_GA_TRACKING_ID="your-ga-tracking-id"
+
+# ベーシック認証（オプション）
+# 設定すると、webアプリ全体にベーシック認証を適用
+# 値は "id:password" 形式の文字列をSHA256ハッシュ化したもの
+# 例: echo -n "admin:password" | shasum -a 256
+BASIC_AUTH_SECRET="sha256_hash_of_id_password"

--- a/webapp/src/middleware.ts
+++ b/webapp/src/middleware.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+async function hashCredentials(credentials: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(credentials);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+export async function middleware(request: NextRequest) {
+  const basicAuthSecret = process.env.BASIC_AUTH_SECRET;
+
+  // ベーシック認証の環境変数がない場合は認証をスキップ
+  if (!basicAuthSecret) {
+    return NextResponse.next();
+  }
+
+  const authorizationHeader = request.headers.get("authorization");
+
+  if (!authorizationHeader || !authorizationHeader.startsWith("Basic ")) {
+    return new NextResponse("Authentication required", {
+      status: 401,
+      headers: {
+        "WWW-Authenticate": 'Basic realm="Secure Area"',
+      },
+    });
+  }
+
+  const base64Credentials = authorizationHeader.split(" ")[1];
+  const credentials = atob(base64Credentials);
+
+  // id:passwordの形式でハッシュ化
+  const hashedCredentials = await hashCredentials(credentials);
+
+  if (hashedCredentials !== basicAuthSecret) {
+    return new NextResponse("Invalid credentials", {
+      status: 401,
+      headers: {
+        "WWW-Authenticate": 'Basic realm="Secure Area"',
+      },
+    });
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+  ],
+};


### PR DESCRIPTION
## Summary
- BASIC_AUTH_SECRET環境変数による条件付きベーシック認証を実装
- 環境変数未設定時は認証をスキップし、通常アクセスを許可
- SHA256ハッシュを使用した安全なクレデンシャル認証

## 実装詳細
- `src/middleware.ts`でNext.jsミドルウェアを作成
- Edge Runtime対応（Web Crypto API使用）
- `id:password`形式の文字列をSHA256でハッシュ化
- 静的ファイル・画像・Next.js内部ファイルは認証対象外

## 設定方法
```bash
# クレデンシャルのハッシュ値を生成
echo -n "admin:password" | shasum -a 256

# .env.localに設定
BASIC_AUTH_SECRET=生成されたハッシュ値
```

## Test plan
- [x] 環境変数設定時のベーシック認証動作確認
- [x] 正しいクレデンシャルでのアクセス成功確認
- [x] 不正なクレデンシャルでのアクセス拒否確認
- [x] 環境変数未設定時の通常アクセス確認
- [x] TypeScript型チェック・Lint通過確認

🤖 Generated with [Claude Code](https://claude.ai/code)