### PR TITLE
fix: Restore basic authentication functionality to admin middleware

### DIFF
--- a/admin/src/middleware.ts
+++ b/admin/src/middleware.ts
@@ -1,6 +1,53 @@
 import { createServerClient } from "@supabase/ssr";
 import { type NextRequest, NextResponse } from "next/server";
 
+async function hashCredentials(credentials: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(credentials);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+async function performBasicAuth(
+  request: NextRequest,
+): Promise<NextResponse | null> {
+  const basicAuthSecret = process.env.BASIC_AUTH_SECRET;
+
+  // ベーシック認証の環境変数がない場合は認証をスキップ
+  if (!basicAuthSecret) {
+    return null;
+  }
+
+  const authorizationHeader = request.headers.get("authorization");
+
+  if (!authorizationHeader || !authorizationHeader.startsWith("Basic ")) {
+    return new NextResponse("Authentication required", {
+      status: 401,
+      headers: {
+        "WWW-Authenticate": 'Basic realm="Secure Area"',
+      },
+    });
+  }
+
+  const base64Credentials = authorizationHeader.split(" ")[1];
+  const credentials = atob(base64Credentials);
+
+  // id:passwordの形式でハッシュ化
+  const hashedCredentials = await hashCredentials(credentials);
+
+  if (hashedCredentials !== basicAuthSecret) {
+    return new NextResponse("Invalid credentials", {
+      status: 401,
+      headers: {
+        "WWW-Authenticate": 'Basic realm="Secure Area"',
+      },
+    });
+  }
+
+  return null;
+}
+
 // publicパス以外は全て認証を必須とする（セキュアデフォルト）
 export async function middleware(request: NextRequest): Promise<NextResponse> {
   let response = NextResponse.next({
@@ -43,6 +90,14 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
   const isPublicPath = publicPaths.some((path) =>
     request.nextUrl.pathname.startsWith(path),
   );
+
+  // publicパスの場合はbasic認証を実行
+  if (isPublicPath) {
+    const basicAuthResponse = await performBasicAuth(request);
+    if (basicAuthResponse) {
+      return basicAuthResponse;
+    }
+  }
 
   try {
     const {


### PR DESCRIPTION
## Summary
- Restored basic authentication functionality that was accidentally lost during previous git operations
- Re-added `performBasicAuth` function and `hashCredentials` helper to admin middleware
- Ensures consistent authentication behavior between webapp and admin interfaces

## Changes
- Added basic auth check for public paths (`/login`, `/auth/callback`, `/auth/setup`) in admin middleware
- Uses SHA-256 hashing for credential validation against `BASIC_AUTH_SECRET` environment variable
- Maintains existing Supabase authentication flow while adding basic auth layer for public endpoints

## Test plan
- [x] Verified basic auth functions are restored in admin middleware
- [x] Confirmed authentication logic matches webapp implementation
- [x] Basic auth is properly applied to public paths only
- [x] Environment variable integration works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)