### PR TITLE
Update Sankey chart styling and labels

### DIFF
--- a/webapp/src/client/components/top-page/CashFlowSection.tsx
+++ b/webapp/src/client/components/top-page/CashFlowSection.tsx
@@ -56,7 +56,7 @@ export default function CashFlowSection({
               : "border-transparent text-[#9CA3AF] hover:text-gray-600"
           }`}
         >
-          チームみらいの区分
+          詳細の区分
         </button>
         <button
           type="button"

--- a/webapp/src/client/components/top-page/features/charts/SankeyChart.tsx
+++ b/webapp/src/client/components/top-page/features/charts/SankeyChart.tsx
@@ -352,8 +352,8 @@ const renderPercentageLabel = (
     return null;
   }
 
-  // 処理中ノードの場合は特別な色を使用
-  const textColor = node.label === "処理中" ? "#CA8A04" : boxColor;
+  // (仕訳中)ノードの場合は特別な色を使用
+  const textColor = node.label === "(仕訳中)" ? "#DC2626" : boxColor;
 
   return (
     <text

--- a/webapp/src/client/components/top-page/features/charts/useSankeyHelpers.ts
+++ b/webapp/src/client/components/top-page/features/charts/useSankeyHelpers.ts
@@ -48,8 +48,8 @@ export function useNodeColors() {
         return variant === "light" ? "#D2D4D8" : "#6B7280";
       }
 
-      if (nodeLabel === "処理中") {
-        return variant === "light" ? "#FFF2F2" : "#FCA5A5";
+      if (nodeLabel === "(仕訳中)") {
+        return variant === "light" ? "#FFF2F2" : "#F87171";
       }
 
       // 通常のノードタイプ判定
@@ -144,16 +144,16 @@ export function useSankeySorting(data: SankeyData) {
           if (a.nodeType === "expense") {
             const aIsCarryover = a.label === "繰越し";
             const bIsCarryover = b.label === "繰越し";
-            const aIsProcessing = a.label === "処理中";
-            const bIsProcessing = b.label === "処理中";
+            const aIsProcessing = a.label === "(仕訳中)";
+            const bIsProcessing = b.label === "(仕訳中)";
 
             // 繰越し vs その他
             if (aIsCarryover && !bIsCarryover) return 1; // 繰越しを最後に
             if (bIsCarryover && !aIsCarryover) return -1; // 繰越しを最後に
 
-            // 処理中 vs その他（繰越し以外）
-            if (aIsProcessing && !bIsProcessing && !bIsCarryover) return 1; // 処理中を後に
-            if (bIsProcessing && !aIsProcessing && !aIsCarryover) return -1; // 処理中を後に
+            // (仕訳中) vs その他（繰越し以外）
+            if (aIsProcessing && !bIsProcessing && !bIsCarryover) return 1; // (仕訳中)を後に
+            if (bIsProcessing && !aIsProcessing && !aIsCarryover) return -1; // (仕訳中)を後に
           }
 
           return bValue - aValue; // 大きい順

--- a/webapp/src/server/utils/sankey-category-converter.ts
+++ b/webapp/src/server/utils/sankey-category-converter.ts
@@ -232,14 +232,14 @@ export function convertCategoryAggregationToSankeyData(
     0,
   );
 
-  // 収入 > 支出の場合、「処理中」を追加
+  // 収入 > 支出の場合、「(仕訳中)」を追加
   if (totalIncome > totalExpense) {
     const currentBalance = totalIncome - totalExpense;
-    expenseByCategory.set("処理中", currentBalance);
+    expenseByCategory.set("(仕訳中)", currentBalance);
 
-    // 支出データに「処理中」レコードを追加（UI用）
+    // 支出データに「(仕訳中)」レコードを追加（UI用）
     processedAggregation.expense.push({
-      category: "処理中",
+      category: "(仕訳中)",
       totalAmount: currentBalance,
     });
   }

--- a/webapp/tests/server/utils/sankey-category-converter.test.ts
+++ b/webapp/tests/server/utils/sankey-category-converter.test.ts
@@ -262,15 +262,15 @@ describe("convertCategoryAggregationToSankeyData", () => {
 
     const result = convertCategoryAggregationToSankeyData(aggregation);
 
-    // 「処理中」ノードが追加されることを確認
-    const processingNode = result.nodes.find(node => node.label === "処理中");
+    // 「(仕訳中)」ノードが追加されることを確認
+    const processingNode = result.nodes.find(node => node.label === "(仕訳中)");
     expect(processingNode).toBeDefined();
-    expect(processingNode?.label).toBe("処理中");
+    expect(processingNode?.label).toBe("(仕訳中)");
 
-    // 「処理中」へのリンクが追加されることを確認
+    // 「(仕訳中)」へのリンクが追加されることを確認
     const getNodeIdByLabel = (label: string) => result.nodes.find(n => n.label === label)?.id;
     const totalId = getNodeIdByLabel("合計");
-    const processingId = getNodeIdByLabel("処理中");
+    const processingId = getNodeIdByLabel("(仕訳中)");
     
     const linkToProcessing = result.links.find(
       link => link.source === totalId && link.target === processingId
@@ -297,12 +297,12 @@ describe("convertCategoryAggregationToSankeyData", () => {
 
     const result = convertCategoryAggregationToSankeyData(aggregation);
 
-    // 「処理中」ノードが追加されないことを確認
-    const processingNode = result.nodes.find(node => node.label === "処理中");
+    // 「(仕訳中)」ノードが追加されないことを確認
+    const processingNode = result.nodes.find(node => node.label === "(仕訳中)");
     expect(processingNode).toBeUndefined();
 
-    // 「処理中」へのリンクが追加されないことを確認
-    const processingId = result.nodes.find(n => n.label === "処理中")?.id;
+    // 「(仕訳中)」へのリンクが追加されないことを確認
+    const processingId = result.nodes.find(n => n.label === "(仕訳中)")?.id;
     const linkToProcessing = result.links.find(
       link => link.target === processingId
     );
@@ -329,14 +329,14 @@ describe("convertCategoryAggregationToSankeyData", () => {
 
     const result = convertCategoryAggregationToSankeyData(aggregation);
 
-    // 「処理中」ノードが追加されることを確認
-    const processingNode = result.nodes.find(node => node.label === "処理中");
+    // 「(仕訳中)」ノードが追加されることを確認
+    const processingNode = result.nodes.find(node => node.label === "(仕訳中)");
     expect(processingNode).toBeDefined();
 
-    // 「処理中」のリンクが正しく追加されることを確認
+    // 「(仕訳中)」のリンクが正しく追加されることを確認
     const getNodeIdByLabel = (label: string) => result.nodes.find(n => n.label === label)?.id;
     const totalId = getNodeIdByLabel("合計");
-    const processingId = getNodeIdByLabel("処理中");
+    const processingId = getNodeIdByLabel("(仕訳中)");
     const donationId = getNodeIdByLabel("寄附");
     const politicalActivityId = getNodeIdByLabel("政治活動費");
     const individualDonationId = getNodeIdByLabel("個人からの寄附");


### PR DESCRIPTION
## Summary
- 「処理中」ノードの色を #F87171 に、パーセンテージ文字色を #DC2626 に変更
- 「処理中」を「(仕訳中)」に変更（文字列比較処理も含めて全箇所）
- タブラベルを「チームみらいの区分」から「詳細の区分」に変更

## Test plan
- [ ] Sankeyチャートで「(仕訳中)」ノードが新しい色で表示されることを確認
- [ ] パーセンテージ文字が正しい色（#DC2626）で表示されることを確認
- [ ] タブラベルが「詳細の区分」と表示されることを確認
- [ ] テストが全て通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)