### PR TITLE
Update: Figmaデザインに合わせて寄付金額サマリーセクションのレイアウトを2カード構成に変更

### DIFF
--- a/webapp/src/client/components/top-page/DonationSummarySection.tsx
+++ b/webapp/src/client/components/top-page/DonationSummarySection.tsx
@@ -17,9 +17,7 @@ export default function DonationSummarySection({
 }: DonationSummarySectionProps) {
   // サーバーサイドで計算された統計情報を使用
   const totalDonationAmount = donationSummary?.totalAmount || 0;
-  const totalDonationDays = donationSummary?.totalDays || 0;
   const dayOverDayChange = donationSummary?.amountDayOverDay || 0;
-  const donationCountChange = donationSummary?.countDayOverDay || 0;
   const dailyDonationData = donationSummary?.dailyDonationData || [];
 
   // DonationSection専用のupdatedAt表示フォーマット
@@ -74,9 +72,7 @@ export default function DonationSummarySection({
         totalOku={totalOku}
         totalMan={totalMan}
         totalEn={totalEn}
-        totalDonationDays={totalDonationDays}
         dayOverDayChange={dayOverDayChange}
-        donationCountChange={donationCountChange}
       />
 
       {/* 寄附推移グラフ */}

--- a/webapp/src/client/components/top-page/features/donation-summary/DonationSummaryCards.tsx
+++ b/webapp/src/client/components/top-page/features/donation-summary/DonationSummaryCards.tsx
@@ -7,29 +7,27 @@ interface DonationSummaryCardsProps {
   totalOku: number;
   totalMan: number;
   totalEn: number;
-  totalDonationDays: number;
   dayOverDayChange: number;
-  donationCountChange: number;
 }
 
 export default function DonationSummaryCards({
   totalOku,
   totalMan,
   totalEn,
-  totalDonationDays,
   dayOverDayChange,
-  donationCountChange,
 }: DonationSummaryCardsProps) {
   return (
     <>
-      {/* SP レイアウト - 3つのカードが縦に並ぶ */}
+      {/* SP レイアウト - 2つのカードが縦に並ぶ */}
       <div className="flex md:hidden flex-col gap-2">
-        {/* 累計寄附金額カード */}
-        <BaseCard className="!p-3">
-          <div className="flex flex-row justify-between items-center">
-            <div className="text-[#4B5563] font-bold text-sm">累計寄附金額</div>
-            <div className="flex flex-col items-end gap-0">
-              <div className="flex items-baseline gap-[2px] p-2">
+        {/* 寄付金額カード */}
+        <BaseCard className="!p-4">
+          <div className="flex flex-row justify-between items-center gap-3">
+            <div className="flex flex-col justify-center">
+              <div className="text-[#4B5563] font-bold text-sm">寄付金額</div>
+            </div>
+            <div className="flex flex-col items-end gap-2">
+              <div className="flex items-baseline gap-[2px]">
                 {totalOku > 0 && (
                   <>
                     <span className="font-bold text-2xl leading-5 text-gray-800">
@@ -72,71 +70,39 @@ export default function DonationSummaryCards({
           </div>
         </BaseCard>
 
-        {/* 寄附件数と企業団体献金 - 横並び */}
-        <div className="flex gap-2 items-stretch">
-          {/* 寄附件数カード - fill（残りの幅を全て使用） */}
-          <BaseCard className="flex-1 !p-3">
-            <div className="flex flex-row justify-between items-center gap-3">
-              <div className="text-[#4B5563] font-bold text-sm">寄附件数</div>
-              <div className="flex flex-col items-end gap-0">
-                <div className="flex items-baseline gap-[2px] p-2">
-                  <span className="font-bold text-2xl leading-5 text-gray-800">
-                    {totalDonationDays}
-                  </span>
-                  <span className="font-bold text-xs text-[#4B5563]">件</span>
-                </div>
-                <div className="flex items-center gap-[2px] h-4">
-                  <span className="text-[#238778] font-normal text-[11px]">
-                    前日比
-                  </span>
-                  <div className="flex items-center">
-                    <span className="font-bold text-[#238778] text-[13px]">
-                      {donationCountChange}
-                    </span>
-                    <span className="text-[#238778] font-normal text-[11px]">
-                      件
-                    </span>
-                    <Image
-                      src="/icons/icon-arrow-up.svg"
-                      alt="上向き矢印"
-                      width={13}
-                      height={13}
-                      className="flex-shrink-0 ml-[2px]"
-                    />
-                  </div>
-                </div>
+        {/* 企業団体献金カード */}
+        <BaseCard className="!p-4 h-[76px]">
+          <div className="flex flex-row justify-between items-center gap-3 h-full">
+            <div className="flex flex-col justify-center">
+              <div className="text-[#4B5563] font-bold text-sm">
+                うち企業団体献金
               </div>
             </div>
-          </BaseCard>
-
-          {/* 企業団体献金カード - hug（コンテンツサイズに合わせる） */}
-          <BaseCard className="w-fit flex-shrink-0 !p-3 self-stretch">
-            <div className="flex flex-row items-center justify-center gap-[2px] h-full">
-              <div className="text-[#4B5563] font-bold text-[13px] leading-[18px] whitespace-pre-line w-[63px]">
-                {"企業\n団体献金"}
-              </div>
+            <div className="flex items-end">
               <div className="flex items-baseline gap-[2px]">
                 <span className="font-bold text-2xl leading-5 text-gray-800">
                   0
                 </span>
-                <span className="font-bold text-xs text-[#4B5563]">件</span>
+                <span className="font-bold text-xs text-[#6B7280]">円</span>
               </div>
             </div>
-          </BaseCard>
-        </div>
+          </div>
+        </BaseCard>
       </div>
 
-      {/* PC レイアウト - 3つのカードが横に並ぶ */}
+      {/* PC レイアウト - 2つのカードが横に並ぶ */}
       <div className="hidden md:flex gap-6">
-        {/* 累計寄附金額カード */}
+        {/* 寄付金額カード */}
         <BaseCard className="flex-1">
-          <div className="flex flex-col">
-            <div className="flex justify-between items-start mb-4">
-              <div className="text-gray-800 font-bold text-base">
-                累計寄附金額
+          <div className="flex flex-col justify-center gap-4">
+            <div className="flex flex-row justify-between items-start">
+              <div className="flex flex-col justify-center gap-6">
+                <div className="text-gray-800 font-bold text-base">
+                  寄付金額
+                </div>
               </div>
               <div className="flex items-center gap-[2px]">
-                <span className="text-[#238778] font-bold text-[11px] leading-[17px]">
+                <span className="text-[#238778] font-bold text-[13px] leading-[17px]">
                   前日比
                 </span>
                 <Image
@@ -149,7 +115,7 @@ export default function DonationSummaryCards({
                 <span className="font-bold text-[#238778] text-[16px] leading-[16px]">
                   {dayOverDayChange.toLocaleString()}
                 </span>
-                <span className="text-[#238778] font-bold text-[11px] leading-[17px]">
+                <span className="text-[#238778] font-bold text-[13px] leading-[17px]">
                   円
                 </span>
               </div>
@@ -160,7 +126,7 @@ export default function DonationSummaryCards({
                   <span className="font-bold text-[36px] leading-[30px] text-gray-800">
                     {totalOku}
                   </span>
-                  <span className="font-bold text-base leading-[30px] text-gray-800">
+                  <span className="font-bold text-base leading-[16px] text-gray-800">
                     億
                   </span>
                 </>
@@ -170,7 +136,7 @@ export default function DonationSummaryCards({
                   <span className="font-bold text-[36px] leading-[30px] text-gray-800">
                     {totalMan}
                   </span>
-                  <span className="font-bold text-base leading-[30px] text-gray-800">
+                  <span className="font-bold text-base leading-[16px] text-gray-800">
                     万
                   </span>
                 </>
@@ -178,56 +144,26 @@ export default function DonationSummaryCards({
               <span className="font-bold text-[36px] leading-[30px] text-gray-800">
                 {totalEn}
               </span>
-              <span className="font-bold text-base leading-[30px] text-gray-800">
+              <span className="font-bold text-base leading-[16px] text-gray-800">
                 円
               </span>
             </div>
           </div>
         </BaseCard>
 
-        {/* 寄附件数カード */}
-        <BaseCard className="w-60">
-          <div className="flex flex-col gap-4">
-            <div className="flex flex-row items-center gap-6">
-              <div className="text-gray-800 font-bold text-base">寄附件数</div>
-              <div className="flex items-center gap-[2px]">
-                <span className="text-[#238778] font-bold text-[13px]">
-                  前日比
-                </span>
-                <Image
-                  src="/icons/icon-arrow-up.svg"
-                  alt="上向き矢印"
-                  width={24}
-                  height={24}
-                  className="flex-shrink-0"
-                />
-                <span className="font-bold text-[#238778] text-base">
-                  {donationCountChange}
-                </span>
-                <span className="text-[#238778] font-bold text-[13px]">件</span>
-              </div>
-            </div>
-
-            <div className="flex items-baseline gap-1">
-              <span className="font-bold text-[36px] leading-[30px] text-gray-800">
-                {totalDonationDays}
-              </span>
-              <span className="font-bold text-base text-gray-800">件</span>
-            </div>
-          </div>
-        </BaseCard>
-
         {/* 企業団体献金カード */}
-        <BaseCard className="w-60">
-          <div className="flex flex-col gap-4">
+        <BaseCard className="w-full md:w-[364px] h-[115px]">
+          <div className="flex flex-col justify-center gap-4 h-full">
             <div className="text-gray-800 font-bold text-base">
-              企業団体献金
+              うち企業団体献金
             </div>
             <div className="flex items-baseline gap-1">
               <span className="font-bold text-[36px] leading-[30px] text-gray-800">
                 0
               </span>
-              <span className="font-bold text-base text-gray-800">件</span>
+              <span className="font-bold text-base leading-[16px] text-gray-800">
+                円
+              </span>
             </div>
           </div>
         </BaseCard>

--- a/webapp/src/server/usecases/get-daily-donation-usecase.ts
+++ b/webapp/src/server/usecases/get-daily-donation-usecase.ts
@@ -7,9 +7,7 @@ import type {
 export interface DonationSummaryData {
   dailyDonationData: DailyDonationData[];
   totalAmount: number; // 累計寄附金額
-  totalDays: number; // 寄附日数
   amountDayOverDay: number; // 寄附金額の前日比
-  countDayOverDay: number; // 寄附件数の前日比
   lastNonZeroDonationDate: string | null; // 最後に0以外の寄附があった日
 }
 
@@ -162,9 +160,6 @@ export class GetDailyDonationUsecase {
     // 統計情報を計算
     const totalAmount =
       recentDailyData[recentDailyData.length - 1]?.cumulativeAmount || 0;
-    const totalDays = recentDailyData.filter(
-      (item) => item.dailyAmount > 0,
-    ).length;
 
     // 今日と昨日の日付を文字列で準備
     const todayStr = today.toISOString().split("T")[0];
@@ -183,11 +178,6 @@ export class GetDailyDonationUsecase {
     const yesterdayDonation = yesterdayData?.dailyAmount || 0;
     const amountDayOverDay = todayDonation - yesterdayDonation;
 
-    // 寄附件数の前日比（寄附があった日をカウント）
-    const todayHasDonation = todayDonation > 0 ? 1 : 0;
-    const yesterdayHasDonation = yesterdayDonation > 0 ? 1 : 0;
-    const countDayOverDay = todayHasDonation - yesterdayHasDonation;
-
     // 最後に0以外の寄附があった日を検索（逆順で検索）
     const lastNonZeroDonationDate =
       recentDailyData
@@ -198,9 +188,7 @@ export class GetDailyDonationUsecase {
     return {
       dailyDonationData: recentDailyData,
       totalAmount,
-      totalDays,
       amountDayOverDay,
-      countDayOverDay,
       lastNonZeroDonationDate,
     };
   }

--- a/webapp/src/server/usecases/get-mock-transaction-page-data-usecase.ts
+++ b/webapp/src/server/usecases/get-mock-transaction-page-data-usecase.ts
@@ -54,9 +54,7 @@ const MOCK_DONATION_SUMMARY: DonationSummaryData = {
     };
   }),
   totalAmount: 8500000,
-  totalDays: 30,
   amountDayOverDay: 125000,
-  countDayOverDay: 1,
   lastNonZeroDonationDate: new Date().toISOString().split("T")[0], // 今日をモックデータとして設定
 };
 

--- a/webapp/tests/server/usecases/get-daily-donation-usecase.test.ts
+++ b/webapp/tests/server/usecases/get-daily-donation-usecase.test.ts
@@ -69,7 +69,6 @@ describe("GetDailyDonationUsecase", () => {
 
     // その他のサマリー情報も確認
     expect(result.donationSummary.totalAmount).toBe(4500);
-    expect(result.donationSummary.totalDays).toBe(2); // 寄附があった日数
   });
 
   it("should handle case when today is not found in data", async () => {


### PR DESCRIPTION
## Summary
- Figmaデザインに合わせてDonationSummaryCardsコンポーネントを3カードから2カード構成に変更
- 寄付金額カード（前日比付き）と企業団体献金カードの2つに集約
- SPレイアウトではカードを縦配置、PCレイアウトでは横配置に対応
- 不要なpropsとデータ構造を削除してBFFまで遡って最適化

## Test plan
- [ ] SPレイアウトで2つのカードが縦に正しく配置されることを確認
- [ ] PCレイアウトで2つのカードが横に正しく配置されることを確認 
- [ ] 寄付金額カードの前日比表示が正しく動作することを確認
- [ ] 企業団体献金カードの表示が正しいことを確認
- [ ] typecheck と lint が通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)