### PR TITLE
Update: フォント太さをレスポンシブ対応（SP: 500, PC: 400）

### DIFF
--- a/webapp/src/client/components/common/AboutSection.tsx
+++ b/webapp/src/client/components/common/AboutSection.tsx
@@ -53,7 +53,7 @@ export default function AboutSection() {
           <h3 className="text-base sm:text-lg font-bold text-gray-800 mb-3">
             チームみらいについて
           </h3>
-          <p className="text-[11px] sm:text-[15px] leading-[1.82] sm:leading-[1.87] tracking-[0.01em] text-gray-500 sm:text-gray-700 font-medium font-japanese">
+          <p className="text-[11px] sm:text-[15px] leading-[1.82] sm:leading-[1.87] tracking-[0.01em] text-gray-500 sm:text-gray-700 font-medium sm:font-normal font-japanese">
             チームみらいは、AIエンジニアの安野たかひろが立ち上げた政党です。2025年参議院選挙にて1議席を獲得して国政政党となりました。テクノロジーで政治の課題を解決することを目指して、既存の枠組みにとらわれることなく活動していきます。
             テクノロジーで政治を変え、国民の皆さまとともに日本の未来をつくることを目指しています。
           </p>

--- a/webapp/src/client/components/common/ExplanationSection.tsx
+++ b/webapp/src/client/components/common/ExplanationSection.tsx
@@ -9,7 +9,7 @@ export default function ExplanationSection() {
           <h3 className="text-base sm:text-lg font-bold text-gray-800 mb-3 font-japanese">
             みらい まる見え政治資金について
           </h3>
-          <p className="text-[11px] sm:text-[15px] leading-[1.82] sm:leading-[1.87] tracking-[0.01em] text-gray-500 sm:text-gray-800 font-medium font-japanese">
+          <p className="text-[11px] sm:text-[15px] leading-[1.82] sm:leading-[1.87] tracking-[0.01em] text-gray-500 sm:text-gray-800 font-medium sm:font-normal font-japanese">
             本プロジェクトは、チームみらいによって政治資金の透明化を目的に開発されたオープンソースソフトウェアです。決済データは、クレジットカード、デビットカード、銀行口座を通じて収集され、現在はおおよそ週次で更新されています。すでにオープンソースで
             <a
               href="https://github.com/team-mirai-volunteer/open"
@@ -36,7 +36,7 @@ export default function ExplanationSection() {
           <h3 className="text-base sm:text-lg font-bold text-gray-800 mb-3 font-japanese">
             データの出典
           </h3>
-          <p className="text-[11px] sm:text-[15px] leading-[1.82] sm:leading-[1.87] tracking-[0.01em] text-gray-500 sm:text-gray-800 font-medium font-japanese">
+          <p className="text-[11px] sm:text-[15px] leading-[1.82] sm:leading-[1.87] tracking-[0.01em] text-gray-500 sm:text-gray-800 font-medium sm:font-normal font-japanese">
             本サイトに含まれる政治資金収支データは、政党「チームみらい」並びに党首・安野貴博の政治団体である「デジタル民主主義を考える会」の収支を合算したもので、結党した2025年5月以降の仕訳けが完了した収支を掲載しています。なお収支データには、政治資金規制法で定義された政治活動に使うお金である「政治資金」と、公職選挙法で定義された選挙運動に使うお金である「選挙資金」の双方が含まれています。
           </p>
         </div>
@@ -45,7 +45,7 @@ export default function ExplanationSection() {
           <h3 className="text-base sm:text-lg font-bold text-gray-800 mb-3 font-japanese">
             免責事項
           </h3>
-          <p className="text-[11px] sm:text-[15px] leading-[1.82] sm:leading-[1.87] tracking-[0.01em] text-gray-500 sm:text-gray-800 font-medium font-japanese">
+          <p className="text-[11px] sm:text-[15px] leading-[1.82] sm:leading-[1.87] tracking-[0.01em] text-gray-500 sm:text-gray-800 font-medium sm:font-normal font-japanese">
             本サイトで公開するデータは、可能な限り正確かつ最新の情報を反映するよう努めていますが、現時点においてはその正確性・完全性・即時性について保証するものではありません。今後は、これらの側面について一層踏み込んだ公開を目指してまいります。現時点での最終的な収支は、別途公開される「政治資金収支報告書」並びに「選挙運動費用収支報告書」をご確認ください。
           </p>
         </div>


### PR DESCRIPTION
## Summary
- ExplanationSectionとAboutSectionの地の文において、フォント太さをレスポンシブ対応
- SP（モバイル）では `font-medium` (500)
- PC（デスクトップ）では `font-normal` (400)

## Test plan
- [ ] SP表示でフォント太さが500になることを確認
- [ ] PC表示でフォント太さが400になることを確認
- [ ] 各コンポーネントの表示に問題がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)