### PR TITLE
Update: 「その他」から始まるSankeyラベルの改行ルール対応

### DIFF
--- a/webapp/src/client/components/top-page/features/charts/SankeyChart.tsx
+++ b/webapp/src/client/components/top-page/features/charts/SankeyChart.tsx
@@ -322,6 +322,11 @@ const splitLabel = (label: string, maxCharsPerLine: number): string[] => {
     return [label];
   }
 
+  // 「その他」から始まるケースの特別対応：「その他」が1行目、それ以降が2行目
+  if (label.startsWith("その他")) {
+    return ["その他", label.substring(3)];
+  }
+
   // 特殊ケース：N+1文字（7文字）の場合は N-2, 3 に分割
   if (label.length === N + 1) {
     return [label.substring(0, N - 2), label.substring(N - 2)];


### PR DESCRIPTION
## Summary
- 「その他」から始まるSankeyラベルについて、特別な改行ルールを実装
- 「その他」を1行目、それ以降の文字列を2行目に表示するよう対応

## Test plan
- [ ] 「その他」から始まるラベルが正しく2行で表示されることを確認
- [ ] 既存のラベル表示に影響がないことを確認
- [ ] モバイル・デスクトップ両方での表示確認

🤖 Generated with [Claude Code](https://claude.ai/code)