### PR TITLE
Remove: 寄附セクションをトップページから削除

### DIFF
--- a/webapp/src/app/o/[slug]/page.tsx
+++ b/webapp/src/app/o/[slug]/page.tsx
@@ -6,7 +6,6 @@ import TransparencySection from "@/client/components/common/TransparencySection"
 import MainColumn from "@/client/components/layout/MainColumn";
 import BalanceSheetSection from "@/client/components/top-page/BalanceSheetSection";
 import CashFlowSection from "@/client/components/top-page/CashFlowSection";
-import DonationSummarySection from "@/client/components/top-page/DonationSummarySection";
 import MonthlyTrendsSection from "@/client/components/top-page/MonthlyTrendsSection";
 import ProgressSection from "@/client/components/top-page/ProgressSection";
 import TransactionsSection from "@/client/components/top-page/TransactionsSection";
@@ -60,7 +59,6 @@ export default async function OrgPage({ params }: OrgPageProps) {
         updatedAt={updatedAt}
       />
       <TransparencySection title="党首も毎日これを見て、お金をやりくりしています👀" />
-      <DonationSummarySection donationSummary={data?.donationSummary} />
       <BalanceSheetSection
         data={data?.balanceSheetData}
         updatedAt={updatedAt}

--- a/webapp/src/server/loaders/load-top-page-data.ts
+++ b/webapp/src/server/loaders/load-top-page-data.ts
@@ -4,7 +4,6 @@ import { PrismaPoliticalOrganizationRepository } from "@/server/repositories/pri
 import { PrismaTransactionRepository } from "@/server/repositories/prisma-transaction.repository";
 import { PrismaBalanceSnapshotRepository } from "@/server/repositories/prisma-balance-snapshot.repository";
 import { GetBalanceSheetUsecase } from "@/server/usecases/get-balance-sheet-usecase";
-import { GetDailyDonationUsecase } from "@/server/usecases/get-daily-donation-usecase";
 import { GetMockTransactionPageDataUsecase } from "@/server/usecases/get-mock-transaction-page-data-usecase";
 import { GetMonthlyTransactionAggregationUsecase } from "@/server/usecases/get-monthly-transaction-aggregation-usecase";
 import { GetSankeyAggregationUsecase } from "@/server/usecases/get-sankey-aggregation-usecase";
@@ -54,24 +53,18 @@ export const loadTopPageData = unstable_cache(
       balanceSnapshotRepository,
     );
 
-    const donationUsecase = new GetDailyDonationUsecase(
-      transactionRepository,
-      politicalOrganizationRepository,
-    );
-
     const balanceSheetUsecase = new GetBalanceSheetUsecase(
       transactionRepository,
       balanceSnapshotRepository,
       politicalOrganizationRepository,
     );
 
-    // 6つのUsecaseを並列実行（sankeyは2回実行）
+    // 5つのUsecaseを並列実行（sankeyは2回実行）
     const [
       transactionData,
       monthlyData,
       sankeyPoliticalCategoryData,
       sankeyFriendlyCategoryData,
-      donationData,
       balanceSheetData,
     ] = await Promise.all([
       transactionUsecase.execute(params),
@@ -89,12 +82,6 @@ export const loadTopPageData = unstable_cache(
         financialYear: params.financialYear,
         categoryType: "friendly-category",
       }),
-      donationUsecase.execute({
-        slugs: params.slugs,
-        financialYear: params.financialYear,
-        today: new Date(),
-        days: 90,
-      }),
       balanceSheetUsecase.execute({
         slugs: params.slugs,
         financialYear: params.financialYear,
@@ -106,7 +93,6 @@ export const loadTopPageData = unstable_cache(
       monthlyData: monthlyData.monthlyData,
       political: sankeyPoliticalCategoryData.sankeyData,
       friendly: sankeyFriendlyCategoryData.sankeyData,
-      donationSummary: donationData.donationSummary,
       balanceSheetData: balanceSheetData.balanceSheetData,
     };
   },


### PR DESCRIPTION
## Summary
- トップページから寄附セクション（DonationSummarySection）を削除
- load-top-page-data.ts から寄附関連のデータ取得処理を削除
- GetDailyDonationUsecase の呼び出しとレスポンスから donationSummary を削除

## Test plan
- [ ] トップページが正常に表示されること
- [ ] 寄附セクションが表示されないこと
- [ ] 他のセクションに影響がないこと

🤖 Generated with [Claude Code](https://claude.ai/code)