### PR TITLE
Update: セクションタイトルを組織名に応じて動的に変更

### DIFF
--- a/webapp/src/app/o/[slug]/page.tsx
+++ b/webapp/src/app/o/[slug]/page.tsx
@@ -32,6 +32,9 @@ export default async function OrgPage({ params }: OrgPageProps) {
 
   const slugs = [slug];
 
+  // 現在のslugに対応する組織を取得
+  const currentOrganization = organizations.find((org) => org.slug === slug);
+
   // 統合アクションで全データを取得
   const data = await loadTopPageData({
     slugs,
@@ -53,20 +56,24 @@ export default async function OrgPage({ params }: OrgPageProps) {
         political={data?.political ?? null}
         friendly={data?.friendly ?? null}
         updatedAt={updatedAt}
+        organizationName={currentOrganization?.displayName}
       />
       <MonthlyTrendsSection
         monthlyData={data?.monthlyData}
         updatedAt={updatedAt}
+        organizationName={currentOrganization?.displayName}
       />
       <TransparencySection title="党首も毎日これを見て、お金をやりくりしています👀" />
       <BalanceSheetSection
         data={data?.balanceSheetData}
         updatedAt={updatedAt}
+        organizationName={currentOrganization?.displayName}
       />
       <TransactionsSection
         transactionData={data?.transactionData ?? null}
         updatedAt={updatedAt}
         slug={slug}
+        organizationName={currentOrganization?.displayName}
       />
       <ProgressSection />
       <ExplanationSection />

--- a/webapp/src/client/components/top-page/BalanceSheetSection.tsx
+++ b/webapp/src/client/components/top-page/BalanceSheetSection.tsx
@@ -8,11 +8,13 @@ import BalanceSheetChart from "./features/charts/BalanceSheetChart";
 interface BalanceSheetSectionProps {
   data?: BalanceSheetData;
   updatedAt: string;
+  organizationName?: string;
 }
 
 export default function BalanceSheetSection({
   data,
   updatedAt,
+  organizationName,
 }: BalanceSheetSectionProps) {
   return (
     <MainColumnCard id="balance-sheet">
@@ -25,9 +27,9 @@ export default function BalanceSheetSection({
             height={30}
           />
         }
-        title="現時点での貸借対照表"
+        title={`${organizationName || "未登録の政治団体"}｜現時点での貸借対照表`}
         updatedAt={updatedAt}
-        subtitle="現在のチームみらいの財産と負債の状況"
+        subtitle={`現在の${organizationName || "未登録の政治団体"}の財産と負債の状況`}
       />
 
       {data ? (

--- a/webapp/src/client/components/top-page/CashFlowSection.tsx
+++ b/webapp/src/client/components/top-page/CashFlowSection.tsx
@@ -13,12 +13,14 @@ interface CashFlowSectionProps {
   political?: SankeyData | null;
   friendly?: SankeyData | null;
   updatedAt: string;
+  organizationName?: string;
 }
 
 export default function CashFlowSection({
   political,
   friendly,
   updatedAt,
+  organizationName,
 }: CashFlowSectionProps) {
   const [activeTab, setActiveTab] = useState<"political" | "friendly">(
     "friendly",
@@ -37,7 +39,7 @@ export default function CashFlowSection({
             height={31}
           />
         }
-        title="チームみらいの収支の流れ"
+        title={`${organizationName || "未登録の政治団体"}｜収支の流れ`}
         updatedAt={updatedAt}
         subtitle="どこからお金を得て、何に使っているか"
       />

--- a/webapp/src/client/components/top-page/MonthlyTrendsSection.tsx
+++ b/webapp/src/client/components/top-page/MonthlyTrendsSection.tsx
@@ -13,11 +13,13 @@ interface MonthlyData {
 interface MonthlyTrendsSectionProps {
   monthlyData?: MonthlyData[];
   updatedAt: string;
+  organizationName?: string;
 }
 
 export default function MonthlyTrendsSection({
   monthlyData,
   updatedAt,
+  organizationName,
 }: MonthlyTrendsSectionProps) {
   return (
     <MainColumnCard id="monthly-trends">
@@ -30,7 +32,7 @@ export default function MonthlyTrendsSection({
             height={30}
           />
         }
-        title="月ごとの収支の推移"
+        title={`${organizationName || "未登録の政治団体"}｜月ごとの収支の推移`}
         updatedAt={updatedAt}
         subtitle="今年の年始から月ごとの収入と支出"
       />

--- a/webapp/src/client/components/top-page/TransactionsSection.tsx
+++ b/webapp/src/client/components/top-page/TransactionsSection.tsx
@@ -21,12 +21,14 @@ interface TransactionsSectionProps {
   transactionData: TransactionData | null;
   updatedAt: string;
   slug: string;
+  organizationName?: string;
 }
 
 export default function TransactionsSection({
   transactionData,
   updatedAt,
   slug,
+  organizationName,
 }: TransactionsSectionProps) {
   return (
     <MainColumnCard id="transactions">
@@ -39,7 +41,7 @@ export default function TransactionsSection({
             height={30}
           />
         }
-        title="すべての出入金"
+        title={`${organizationName || "未登録の政治団体"}｜すべての出入金`}
         updatedAt={updatedAt}
         subtitle="これまでにデータ連携された出入金の明細"
       />


### PR DESCRIPTION
## Summary
- CashFlowSection, MonthlyTrendsSection, BalanceSheetSection, TransactionsSectionのタイトルを組織名に応じて動的に変更
- 各セクションに`organizationName`プロパティを追加し、URLのslugに対応する組織の`displayName`を表示
- フォールバック値として「未登録の政治団体」を設定

## 変更内容
- `page.tsx`: 現在のslugに対応する組織を取得し、各セクションに組織名を渡すように修正
- `CashFlowSection.tsx`: タイトルを「{組織名}｜収支の流れ」形式に変更
- `MonthlyTrendsSection.tsx`: タイトルを「{組織名}｜月ごとの収支の推移」形式に変更
- `BalanceSheetSection.tsx`: タイトルとサブタイトルに組織名を反映
- `TransactionsSection.tsx`: タイトルを「{組織名}｜すべての出入金」形式に変更

## Test plan
- [ ] 異なるslugでページにアクセスし、セクションタイトルに正しい組織名が表示されることを確認
- [ ] 無効なslugでアクセスした場合のフォールバック表示を確認

🤖 Generated with [Claude Code](https://claude.ai/code)