### PR TITLE
Update: ヘッダーロゴクリック時に現在のslugページに遷移するよう改善

### DIFF
--- a/webapp/src/client/components/layout/header/HeaderClient.tsx
+++ b/webapp/src/client/components/layout/header/HeaderClient.tsx
@@ -3,6 +3,7 @@ import "client-only";
 import Image from "next/image";
 import Link from "next/link";
 import { useState } from "react";
+import { usePathname } from "next/navigation";
 import HamburgerMenuButton from "@/client/components/ui/HamburgerMenuButton";
 import OrganizationSelector from "./OrganizationSelector";
 import type { OrganizationsResponse } from "@/types/organization";
@@ -42,6 +43,13 @@ interface HeaderClientProps {
 
 export default function HeaderClient({ organizations }: HeaderClientProps) {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const pathname = usePathname();
+
+  // 現在のslugを取得（/o/[slug]/... の形式の場合、なければdefaultを使用）
+  const currentSlug = pathname.startsWith("/o/")
+    ? pathname.split("/")[2]
+    : organizations.default;
+  const logoHref = `/o/${currentSlug}/`;
 
   return (
     <header className="fixed top-0 left-0 right-0 z-40 px-2.5 py-3 xl:px-6 xl:py-4">
@@ -50,7 +58,7 @@ export default function HeaderClient({ organizations }: HeaderClientProps) {
         <div className="flex justify-between items-center gap-2 xl:h-16">
           {/* Logo and Title Section */}
           <Link
-            href="/"
+            href={logoHref}
             className="flex items-center gap-2 xl:gap-6 hover:opacity-80 transition-opacity cursor-pointer"
           >
             {/* Logo */}
@@ -101,12 +109,18 @@ export default function HeaderClient({ organizations }: HeaderClientProps) {
                   </Link>
                 ))}
             </nav>
-            <OrganizationSelector organizations={organizations} />
+            <OrganizationSelector
+              organizations={organizations}
+              currentSlug={currentSlug}
+            />
           </div>
 
           {/* Mobile: Organization Selector + Menu */}
           <div className="lg:hidden flex items-center gap-2">
-            <OrganizationSelector organizations={organizations} />
+            <OrganizationSelector
+              organizations={organizations}
+              currentSlug={currentSlug}
+            />
             <HamburgerMenuButton
               isOpen={isMobileMenuOpen}
               onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}

--- a/webapp/src/client/components/layout/header/OrganizationSelector.tsx
+++ b/webapp/src/client/components/layout/header/OrganizationSelector.tsx
@@ -6,10 +6,12 @@ import type { OrganizationsResponse } from "@/types/organization";
 
 interface OrganizationSelectorProps {
   organizations: OrganizationsResponse;
+  currentSlug: string;
 }
 
 export default function OrganizationSelector({
   organizations,
+  currentSlug,
 }: OrganizationSelectorProps) {
   const router = useRouter();
   const pathname = usePathname();
@@ -19,14 +21,6 @@ export default function OrganizationSelector({
     label: org.displayName,
     subtitle: org.orgName || undefined,
   }));
-
-  const getCurrentSlugFromPath = () => {
-    const pathSegments = pathname.split("/");
-    if (pathSegments[1] === "o" && pathSegments[2]) {
-      return pathSegments[2];
-    }
-    return organizations.default;
-  };
 
   const handleSelect = (value: string) => {
     const pathSegments = pathname.split("/");
@@ -41,7 +35,7 @@ export default function OrganizationSelector({
   return (
     <Selector
       options={options}
-      defaultValue={getCurrentSlugFromPath()}
+      defaultValue={currentSlug}
       placeholder="チームみらい計"
       title="政治団体の区別"
       onSelect={handleSelect}


### PR DESCRIPTION
## Summary
- ヘッダーのロゴクリック時に `/o/[現在のslug]/` に遷移するよう改善
- HeaderClientとOrganizationSelectorでslug取得ロジックを統一し、DRY原則に従った実装に変更
- HeaderClientで一元的にdefaultフォールバックを処理

## Changes
- **HeaderClient**: ロゴのhrefを動的に設定、currentSlugをOrganizationSelectorに渡すよう変更
- **OrganizationSelector**: 重複していたslug取得ロジックを削除、propsでcurrentSlugを受け取るよう変更

## Test plan
- [x] `/o/team-mirai/` などの組織ページでロゴクリック時の遷移を確認
- [x] トップページ（`/`）でのロゴクリック動作を確認
- [x] OrganizationSelectorの動作確認
- [x] TypeScript型チェック
- [x] Linting

🤖 Generated with [Claude Code](https://claude.ai/code)