### PR TITLE
Update: MainButtonデザインをFigmaに合わせてシンプル化

### DIFF
--- a/webapp/src/client/components/ui/MainButton.tsx
+++ b/webapp/src/client/components/ui/MainButton.tsx
@@ -21,14 +21,15 @@ export default function MainButton({
       type={type}
       disabled={disabled}
       className={`
+        flex
+        items-center
+        justify-center
         gap-[10px]
         w-[270px]
         h-[48px]
         px-6
         py-2
-        bg-gradient-to-l
-        from-[#BCECD3]
-        to-[#64D8C6]
+        bg-white
         border
         border-[#1F2937]
         rounded-[6px]


### PR DESCRIPTION
## Summary
- グラデーション背景を削除して白背景に変更
- flexレイアウトクラスを追加してセンタリングを明確化
- Figmaデザイン (node-id=299-6022) に合わせたシンプルなスタイルに更新

## Test plan
- [ ] MainButtonコンポーネントが白背景で表示されることを確認
- [ ] レイアウトが正しくセンタリングされていることを確認
- [ ] Figmaデザインと一致していることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)