### PR TITLE
取引一覧ページのタイトルに政治団体名を表示

### DIFF
--- a/webapp/src/app/o/[slug]/transactions/page.tsx
+++ b/webapp/src/app/o/[slug]/transactions/page.tsx
@@ -115,6 +115,9 @@ export default async function TransactionsPage({
       categories,
     });
 
+    const organization = data.politicalOrganizations.find(
+      (org) => org.slug === slug,
+    );
     const updatedAt = formatUpdatedAt(data.lastUpdatedAt ?? null);
 
     return (
@@ -129,7 +132,7 @@ export default async function TransactionsPage({
                 height={30}
               />
             }
-            title="すべての出入金"
+            title={`${organization?.displayName || "未登録の政治団体"}｜すべての出入金`}
             updatedAt={updatedAt}
             subtitle="これまでにデータ連携された出入金の明細"
           />


### PR DESCRIPTION
## Summary
- 取引一覧ページのセクションタイトルに政治団体名を表示するよう修正
- TransactionsSectionと同様の形式で「政治団体名｜すべての出入金」として表示
- render内での計算を避けるため、事前に organization 変数として取得

## Test plan
- [ ] 各政治団体の取引一覧ページでタイトルに正しい政治団体名が表示されることを確認
- [ ] 存在しないslugの場合に「未登録の政治団体」と表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)