### PR TITLE
perf: implement PrismaClient singleton to reduce database connection overhead

### DIFF
--- a/admin/src/app/(public)/auth/callback/route.ts
+++ b/admin/src/app/(public)/auth/callback/route.ts
@@ -1,10 +1,9 @@
 import "server-only";
 import { NextResponse } from "next/server";
 import { createClient } from "@/server/auth/client";
-import { PrismaClient } from "@prisma/client";
+import { prisma } from "@/server/lib/prisma";
 import { PrismaUserRepository } from "@/server/repositories/prisma-user.repository";
 
-const prisma = new PrismaClient();
 const userRepository = new PrismaUserRepository(prisma);
 
 export async function GET(request: Request) {

--- a/admin/src/app/api/users/create-from-invite/route.ts
+++ b/admin/src/app/api/users/create-from-invite/route.ts
@@ -1,9 +1,8 @@
 import "server-only";
 import { NextResponse } from "next/server";
-import { PrismaClient } from "@prisma/client";
+import { prisma } from "@/server/lib/prisma";
 import { PrismaUserRepository } from "@/server/repositories/prisma-user.repository";
 
-const prisma = new PrismaClient();
 const userRepository = new PrismaUserRepository(prisma);
 
 export async function POST(request: Request) {

--- a/admin/src/app/api/users/role/route.ts
+++ b/admin/src/app/api/users/role/route.ts
@@ -1,10 +1,10 @@
 import "server-only";
 import { NextRequest, NextResponse } from "next/server";
 import { requireRole } from "@/server/auth/roles";
-import { PrismaClient, UserRole } from "@prisma/client";
+import { UserRole } from "@prisma/client";
+import { prisma } from "@/server/lib/prisma";
 import { PrismaUserRepository } from "@/server/repositories/prisma-user.repository";
 
-const prisma = new PrismaClient();
 const userRepository = new PrismaUserRepository(prisma);
 
 export async function PATCH(request: NextRequest) {

--- a/admin/src/app/api/users/route.ts
+++ b/admin/src/app/api/users/route.ts
@@ -1,10 +1,9 @@
 import "server-only";
 import { NextResponse } from "next/server";
 import { requireRole } from "@/server/auth/roles";
-import { PrismaClient } from "@prisma/client";
+import { prisma } from "@/server/lib/prisma";
 import { PrismaUserRepository } from "@/server/repositories/prisma-user.repository";
 
-const prisma = new PrismaClient();
 const userRepository = new PrismaUserRepository(prisma);
 
 export async function GET() {

--- a/admin/src/server/actions/create-balance-snapshot.ts
+++ b/admin/src/server/actions/create-balance-snapshot.ts
@@ -1,10 +1,8 @@
 "use server";
 
-import { PrismaClient } from "@prisma/client";
+import { prisma } from "../lib/prisma";
 import { PrismaBalanceSnapshotRepository } from "../repositories/prisma-balance-snapshot.repository";
 import { CreateBalanceSnapshotUsecase } from "../usecases/create-balance-snapshot-usecase";
-
-const prisma = new PrismaClient();
 
 export interface CreateBalanceSnapshotData {
   politicalOrganizationId: string;

--- a/admin/src/server/actions/create-political-organization.ts
+++ b/admin/src/server/actions/create-political-organization.ts
@@ -1,9 +1,7 @@
 "use server";
 
-import { PrismaClient } from "@prisma/client";
 import { revalidatePath } from "next/cache";
-
-const prisma = new PrismaClient();
+import { prisma } from "../lib/prisma";
 
 export interface CreatePoliticalOrganizationData {
   name: string;

--- a/admin/src/server/actions/delete-all-transactions.ts
+++ b/admin/src/server/actions/delete-all-transactions.ts
@@ -1,11 +1,9 @@
 "use server";
 
 import { revalidateTag } from "next/cache";
-import { PrismaClient } from "@prisma/client";
+import { prisma } from "../lib/prisma";
 import { PrismaTransactionRepository } from "../repositories/prisma-transaction.repository";
 import { DeleteAllTransactionsUsecase } from "../usecases/delete-all-transactions-usecase";
-
-const prisma = new PrismaClient();
 
 export async function deleteAllTransactionsAction(): Promise<{
   success: boolean;

--- a/admin/src/server/actions/delete-balance-snapshot.ts
+++ b/admin/src/server/actions/delete-balance-snapshot.ts
@@ -1,11 +1,9 @@
 "use server";
 
-import { PrismaClient } from "@prisma/client";
 import { revalidatePath } from "next/cache";
+import { prisma } from "../lib/prisma";
 import { PrismaBalanceSnapshotRepository } from "../repositories/prisma-balance-snapshot.repository";
 import { DeleteBalanceSnapshotUsecase } from "../usecases/delete-balance-snapshot-usecase";
-
-const prisma = new PrismaClient();
 
 export async function deleteBalanceSnapshot(id: string) {
   try {

--- a/admin/src/server/actions/delete-political-organization.ts
+++ b/admin/src/server/actions/delete-political-organization.ts
@@ -2,7 +2,7 @@
 
 import "server-only";
 import { revalidatePath } from "next/cache";
-import { PrismaClient } from "@prisma/client";
+import { prisma } from "@/server/lib/prisma";
 import { DeletePoliticalOrganizationUsecase } from "@/server/usecases/delete-political-organization-usecase";
 import { PrismaPoliticalOrganizationRepository } from "@/server/repositories/prisma-political-organization.repository";
 
@@ -14,7 +14,6 @@ interface DeletePoliticalOrganizationResult {
 export async function deletePoliticalOrganization(
   orgId: bigint,
 ): Promise<DeletePoliticalOrganizationResult> {
-  const prisma = new PrismaClient();
   const repository = new PrismaPoliticalOrganizationRepository(prisma);
   const usecase = new DeletePoliticalOrganizationUsecase(repository);
 

--- a/admin/src/server/actions/preview-csv.ts
+++ b/admin/src/server/actions/preview-csv.ts
@@ -1,12 +1,11 @@
 "use server";
 
-import { PrismaClient } from "@prisma/client";
+import { prisma } from "@/server/lib/prisma";
 import { EncodingConverter } from "@/server/lib/encoding-converter";
 import { PrismaTransactionRepository } from "@/server/repositories/prisma-transaction.repository";
 import { PreviewMfCsvUsecase } from "@/server/usecases/preview-mf-csv-usecase";
 import type { PreviewMfCsvResult } from "@/server/usecases/preview-mf-csv-usecase";
 
-const prisma = new PrismaClient();
 const transactionRepository = new PrismaTransactionRepository(prisma);
 const previewUsecase = new PreviewMfCsvUsecase(transactionRepository);
 
@@ -45,7 +44,5 @@ export async function previewCsv(
     throw error instanceof Error
       ? error
       : new Error("サーバー内部エラーが発生しました");
-  } finally {
-    await prisma.$disconnect();
   }
 }

--- a/admin/src/server/actions/update-political-organization.ts
+++ b/admin/src/server/actions/update-political-organization.ts
@@ -1,9 +1,7 @@
 "use server";
 
-import { PrismaClient } from "@prisma/client";
 import { revalidatePath } from "next/cache";
-
-const prisma = new PrismaClient();
+import { prisma } from "../lib/prisma";
 
 export interface UpdatePoliticalOrganizationData {
   name: string;

--- a/admin/src/server/actions/upload-csv.ts
+++ b/admin/src/server/actions/upload-csv.ts
@@ -1,12 +1,11 @@
 import "server-only";
 
-import { PrismaClient } from "@prisma/client";
 import { revalidateTag } from "next/cache";
+import { prisma } from "@/server/lib/prisma";
 import { PrismaTransactionRepository } from "@/server/repositories/prisma-transaction.repository";
 import { SavePreviewTransactionsUsecase } from "@/server/usecases/save-preview-transactions-usecase";
 import type { PreviewTransaction } from "@/server/lib/mf-record-converter";
 
-const prisma = new PrismaClient();
 const transactionRepository = new PrismaTransactionRepository(prisma);
 const uploadUsecase = new SavePreviewTransactionsUsecase(transactionRepository);
 
@@ -75,7 +74,5 @@ export async function uploadCsv(
     throw error instanceof Error
       ? error
       : new Error("サーバー内部エラーが発生しました");
-  } finally {
-    await prisma.$disconnect();
   }
 }

--- a/admin/src/server/auth/login.ts
+++ b/admin/src/server/auth/login.ts
@@ -2,10 +2,9 @@
 
 import { redirect } from "next/navigation";
 import { createClient } from "@/server/auth/client";
-import { PrismaClient } from "@prisma/client";
+import { prisma } from "@/server/lib/prisma";
 import { PrismaUserRepository } from "@/server/repositories/prisma-user.repository";
 
-const prisma = new PrismaClient();
 const userRepository = new PrismaUserRepository(prisma);
 
 export async function loginWithPassword(formData: FormData) {

--- a/admin/src/server/auth/roles.ts
+++ b/admin/src/server/auth/roles.ts
@@ -1,8 +1,8 @@
 import { createClient } from "@/server/auth/client";
-import { PrismaClient, type UserRole } from "@prisma/client";
+import { type UserRole } from "@prisma/client";
+import { prisma } from "@/server/lib/prisma";
 import { PrismaUserRepository } from "@/server/repositories/prisma-user.repository";
 
-const prisma = new PrismaClient();
 const userRepository = new PrismaUserRepository(prisma);
 
 export type { UserRole } from "@prisma/client";

--- a/admin/src/server/lib/prisma.ts
+++ b/admin/src/server/lib/prisma.ts
@@ -1,0 +1,16 @@
+import "server-only";
+
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = globalThis as unknown as { prisma: PrismaClient };
+
+export const prisma =
+  globalForPrisma.prisma ||
+  new PrismaClient({
+    log:
+      process.env.NODE_ENV === "development" ? ["query", "error"] : ["error"],
+  });
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma;
+}

--- a/admin/src/server/loaders/load-balance-snapshots-data.ts
+++ b/admin/src/server/loaders/load-balance-snapshots-data.ts
@@ -1,10 +1,8 @@
 import "server-only";
 
-import { PrismaClient } from "@prisma/client";
+import { prisma } from "../lib/prisma";
 import type { BalanceSnapshot } from "@/shared/models/balance-snapshot";
 import { PrismaBalanceSnapshotRepository } from "../repositories/prisma-balance-snapshot.repository";
-
-const prisma = new PrismaClient();
 
 export async function loadBalanceSnapshotsData(
   politicalOrganizationId: string,

--- a/admin/src/server/loaders/load-political-organization-data.ts
+++ b/admin/src/server/loaders/load-political-organization-data.ts
@@ -1,10 +1,8 @@
 import "server-only";
 
-import { PrismaClient } from "@prisma/client";
 import { unstable_cache } from "next/cache";
+import { prisma } from "../lib/prisma";
 import type { PoliticalOrganization } from "@/shared/models/political-organization";
-
-const prisma = new PrismaClient();
 const CACHE_REVALIDATE_SECONDS = 60;
 
 export const loadPoliticalOrganizationData = unstable_cache(

--- a/admin/src/server/loaders/load-political-organizations-data.ts
+++ b/admin/src/server/loaders/load-political-organizations-data.ts
@@ -1,10 +1,8 @@
 import "server-only";
 
-import { PrismaClient } from "@prisma/client";
 import { unstable_cache } from "next/cache";
+import { prisma } from "../lib/prisma";
 import type { PoliticalOrganization } from "@/shared/models/political-organization";
-
-const prisma = new PrismaClient();
 const CACHE_REVALIDATE_SECONDS = 60;
 
 export const loadPoliticalOrganizationsData = unstable_cache(

--- a/admin/src/server/loaders/load-transactions-data.ts
+++ b/admin/src/server/loaders/load-transactions-data.ts
@@ -1,15 +1,13 @@
 import "server-only";
 
-import { PrismaClient } from "@prisma/client";
 import { unstable_cache } from "next/cache";
+import { prisma } from "../lib/prisma";
 import { PrismaTransactionRepository } from "../repositories/prisma-transaction.repository";
 import {
   GetTransactionsUsecase,
   type GetTransactionsParams,
   type GetTransactionsResult,
 } from "../usecases/get-transactions-usecase";
-
-const prisma = new PrismaClient();
 const CACHE_REVALIDATE_SECONDS = 5;
 
 export const loadTransactionsData = unstable_cache(


### PR DESCRIPTION
## Summary
- Implement PrismaClient singleton pattern to eliminate repeated database connection overhead
- Replace 18 instances of `new PrismaClient()` across all server-side modules
- Remove unnecessary `$disconnect()` calls from server actions

## Background
The admin panel was experiencing 4-5 second response times, with investigation showing:
- 1.8+ second database connection handshake delays on each request
- Multiple PrismaClient instances being created per request
- No connection reuse between serverless function invocations

## Changes
- **Created**: `admin/src/server/lib/prisma.ts` - singleton PrismaClient manager
- **Updated**: 4 loaders, 8 actions, 4 API routes, 2 auth handlers
- **Optimized**: Development logging configuration
- **Removed**: Manual `$disconnect()` calls (handled by singleton)

## Performance Impact
- **Before**: 4-5 second response times due to connection overhead
- **Expected**: 2-3 second response times with connection reuse
- **Benefit**: ~1.8 second reduction in database handshake time per request

## Test plan
- [x] TypeScript compilation passes
- [x] ESLint checks pass
- [ ] Test admin panel performance in staging environment
- [ ] Verify no regression in functionality

🤖 Generated with [Claude Code](https://claude.ai/code)