### PR TITLE
improve: 取引一覧のローディング表示を改善

### DIFF
--- a/admin/src/client/components/transactions/TransactionsClient.tsx
+++ b/admin/src/client/components/transactions/TransactionsClient.tsx
@@ -81,30 +81,6 @@ export function TransactionsClient({ organizations }: TransactionsClientProps) {
     }
   };
 
-  if (loading) {
-    return (
-      <div className="bg-primary-panel rounded-xl p-4">
-        <div className="flex justify-center items-center py-10">
-          <p className="text-primary-muted">読み込み中...</p>
-        </div>
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="bg-primary-panel rounded-xl p-4">
-        <div className="flex justify-center items-center py-10">
-          <p className="text-red-500">エラー: {error}</p>
-        </div>
-      </div>
-    );
-  }
-
-  if (!data) {
-    return null;
-  }
-
   return (
     <div className="bg-primary-panel rounded-xl p-4">
       <div className="mb-4">
@@ -112,39 +88,57 @@ export function TransactionsClient({ organizations }: TransactionsClientProps) {
 
         {/* Organization Filter */}
         <div className="mb-4">
-          <div className="flex items-center gap-2">
-            <div className="flex-1">
-              <Selector
-                options={organizationOptions}
-                value={selectedOrgId}
-                onChange={handleOrgFilterChange}
-                label="政治団体でフィルタ"
-                placeholder=""
-              />
-            </div>
-            {fetching && (
-              <div className="text-primary-muted text-sm">取得中...</div>
-            )}
+          <div className="flex-1">
+            <Selector
+              options={organizationOptions}
+              value={selectedOrgId}
+              onChange={handleOrgFilterChange}
+              label="政治団体でフィルタ"
+              placeholder=""
+            />
           </div>
         </div>
       </div>
 
-      <div className="flex justify-between items-center mt-5 mb-4">
-        <p className="text-primary-muted">
-          全 {data.total} 件中 {(data.page - 1) * data.perPage + 1} -{" "}
-          {Math.min(data.page * data.perPage, data.total)} 件を表示
-        </p>
-        <DeleteAllButton
-          disabled={data.total === 0}
-          organizationId={selectedOrgId || undefined}
-          onDeleted={() => {
-            // データを再取得
-            window.location.reload();
-          }}
-        />
-      </div>
+      {!loading && data && (
+        <div className="flex justify-between items-center mt-5 mb-4">
+          <p className="text-primary-muted">
+            全 {data.total} 件中 {(data.page - 1) * data.perPage + 1} -{" "}
+            {Math.min(data.page * data.perPage, data.total)} 件を表示
+          </p>
+          <DeleteAllButton
+            disabled={data.total === 0}
+            organizationId={selectedOrgId || undefined}
+            onDeleted={() => {
+              // データを再取得
+              window.location.reload();
+            }}
+          />
+        </div>
+      )}
 
-      {data.transactions.length === 0 ? (
+      {fetching && (
+        <div className="text-center py-2 mb-4">
+          <div className="flex items-center justify-center gap-2">
+            <div className="w-4 h-4 border-2 border-primary-muted border-t-transparent rounded-full animate-spin"></div>
+            <p className="text-primary-muted text-sm">取得中...</p>
+          </div>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="text-center py-10">
+          <p className="text-primary-muted">読み込み中...</p>
+        </div>
+      ) : error ? (
+        <div className="text-center py-10">
+          <p className="text-red-500">エラー: {error}</p>
+        </div>
+      ) : !data ? (
+        <div className="text-center py-10">
+          <p className="text-primary-muted">データがありません</p>
+        </div>
+      ) : data.transactions.length === 0 ? (
         <div className="text-center py-10">
           <p className="text-primary-muted">
             トランザクションが登録されていません


### PR DESCRIPTION
## Summary
- ローダーをページ全体からテーブル部分のみに変更し、ヘッダーとフィルター部分は常に表示されるように改善
- フィルター操作時の「取得中...」表示にスピナーアニメーションを追加してUXを向上

## Test plan
- [ ] 取引一覧ページにアクセスして初回ローディングが正常に動作することを確認
- [ ] 政治団体フィルターを変更した際にスピナーアニメーション付きの「取得中...」が表示されることを確認
- [ ] ページネーション操作時にもローディング表示が適切に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)