### PR TITLE
Update: navigation links from 寄附 to 貸借対照表

### DIFF
--- a/webapp/src/client/components/layout/Footer.tsx
+++ b/webapp/src/client/components/layout/Footer.tsx
@@ -32,10 +32,10 @@ export default function Footer() {
               1年の推移
             </Link>
             <Link
-              href="/#donation-summary"
+              href="/#balance-sheet"
               className="text-gray-800 text-sm font-bold leading-[1.36em] hover:opacity-80 transition-opacity"
             >
-              寄附金額
+              貸借対照表
             </Link>
           </div>
           {/* Mobile: Second row with 2 links */}

--- a/webapp/src/client/components/layout/header/HeaderClient.tsx
+++ b/webapp/src/client/components/layout/header/HeaderClient.tsx
@@ -21,9 +21,9 @@ const navigationItems = [
     desktopLabel: "1年間の推移",
   },
   {
-    href: "/#donation-summary",
-    label: "これまでの寄附金額",
-    desktopLabel: "寄附金額",
+    href: "/#balance-sheet",
+    label: "貸借対照表",
+    desktopLabel: "貸借対照表",
   },
   {
     href: "/#transactions",


### PR DESCRIPTION
## Summary
- Changed navigation labels and links in header and footer from donation-related terms to balance sheet
- Updated links to point to `/#balance-sheet` instead of `/#donation-summary`
- Both desktop and mobile navigation now properly display "貸借対照表"

## Test plan
- [ ] Verify header navigation shows "貸借対照表" instead of "寄附金額"
- [ ] Verify footer navigation shows "貸借対照表" instead of "寄附金額"
- [ ] Test that clicking the links properly navigates to the balance sheet section
- [ ] Check both desktop and mobile layouts

🤖 Generated with [Claude Code](https://claude.ai/code)