### PR TITLE
Fix: header logo link to always point to default organization

### DIFF
--- a/webapp/src/client/components/layout/header/HeaderClient.tsx
+++ b/webapp/src/client/components/layout/header/HeaderClient.tsx
@@ -49,7 +49,7 @@ export default function HeaderClient({ organizations }: HeaderClientProps) {
   const currentSlug = pathname.startsWith("/o/")
     ? pathname.split("/")[2]
     : organizations.default;
-  const logoHref = `/o/${currentSlug}/`;
+  const logoHref = `/o/${organizations.default}/`;
   const navigationItems = getNavigationItems(currentSlug);
 
   return (


### PR DESCRIPTION
## Summary
- ヘッダーのロゴリンクが現在のスラッグではなく、常にデフォルト組織に遷移するように修正

## Test plan
- [ ] ヘッダーのロゴをクリックして、デフォルト組織のページに遷移することを確認
- [ ] 異なる組織のページでも同様に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)