### PR TITLE
Update: CardHeader組織名とタイトル分離、動的リンク設定

### DIFF
--- a/webapp/src/app/o/[slug]/page.tsx
+++ b/webapp/src/app/o/[slug]/page.tsx
@@ -78,7 +78,7 @@ export default async function OrgPage({ params }: OrgPageProps) {
         slug={slug}
         organizationName={currentOrganization?.displayName}
       />
-      <AnotherPageLinkSection />
+      <AnotherPageLinkSection currentSlug={slug} />
       <ProgressSection />
       <ExplanationSection />
       <AboutSection />

--- a/webapp/src/client/components/common/AnotherPageLinkSection.tsx
+++ b/webapp/src/client/components/common/AnotherPageLinkSection.tsx
@@ -2,15 +2,30 @@ import "server-only";
 import Image from "next/image";
 import Link from "next/link";
 
-export default function AnotherPageLinkSection() {
+interface AnotherPageLinkSectionProps {
+  currentSlug: string;
+}
+
+export default function AnotherPageLinkSection({
+  currentSlug,
+}: AnotherPageLinkSectionProps) {
+  const getTargetSlug = () => {
+    return currentSlug === "digimin" ? "team-mirai" : "digimin";
+  };
+
+  const getTargetOrgName = () => {
+    return currentSlug === "digimin"
+      ? "政党・チームみらい"
+      : "党首・安野貴博の政治団体";
+  };
   return (
     <div className="w-full md:flex md:justify-end">
       <Link
-        href="/o/digimin"
-        className="bg-white border border-black rounded-2xl md:rounded-3xl px-6 py-6 md:px-12 md:py-9 flex items-center gap-6 md:gap-24 hover:bg-gray-50 transition-colors w-full md:inline-flex"
+        href={`/o/${getTargetSlug()}`}
+        className="bg-white border border-black rounded-2xl md:rounded-3xl px-6 py-6 md:px-12 md:py-9 flex items-center gap-6 md:gap-40 hover:bg-gray-50 transition-colors w-full md:w-auto"
       >
         <div className="text-[17px] md:text-[27px] font-bold text-gray-800 leading-[1.56] tracking-[0.01em] flex-1 md:flex-none">
-          党首・安野貴博の政治団体の
+          {getTargetOrgName()}の
           <br />
           「まる見え政治資金」も公開中
         </div>


### PR DESCRIPTION
## Summary
- CardHeaderでPC版は横並び「組織名｜タイトル」、SP版は縦並び表示に対応
- 全セクション（CashFlow, MonthlyTrends, BalanceSheet, Transactions）でorganizationNameとtitleを分離
- AnotherPageLinkSectionを現在のslugに応じて動的にリンク先と組織名を切り替え
- デバッグログ削除（getLiabilityBalance）
- PC版マージン調整

## Test plan
- [ ] PC版でCardHeaderが「組織名｜タイトル」で横並び表示されることを確認
- [ ] SP版でCardHeaderが組織名とタイトルが縦並び表示されることを確認
- [ ] digiminページでAnotherPageLinkSectionがteam-miraiにリンクすることを確認
- [ ] team-miraiページでAnotherPageLinkSectionがdigiminにリンクすることを確認
- [ ] コンソールにgetLiabilityBalanceのログが出力されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)