### PR TITLE
Update: SP表示での日付表示位置を修正

### DIFF
--- a/webapp/src/client/components/layout/CardHeader.tsx
+++ b/webapp/src/client/components/layout/CardHeader.tsx
@@ -46,9 +46,9 @@ export default function CardHeader({
         </Subtitle>
       </div>
 
-      {/* 右側：更新時刻 */}
+      {/* 右側：更新時刻（SPでは非表示） */}
       {updatedAt && (
-        <div className="flex flex-shrink-0 self-end md:self-start">
+        <div className="hidden md:flex flex-shrink-0 self-end md:self-start">
           <span className="text-[11px] md:text-[13px] font-bold text-[#9CA3AF] leading-[1.31]">
             {updatedAt}
           </span>

--- a/webapp/src/client/components/top-page/BalanceSheetSection.tsx
+++ b/webapp/src/client/components/top-page/BalanceSheetSection.tsx
@@ -40,6 +40,13 @@ export default function BalanceSheetSection({
           データを読み込み中...
         </div>
       )}
+
+      {/* 更新日時 */}
+      <div className="mt-4 text-right">
+        <span className="text-xs font-normal text-[#9CA3AF] leading-[1.33]">
+          {updatedAt}
+        </span>
+      </div>
     </MainColumnCard>
   );
 }

--- a/webapp/src/client/components/top-page/CashFlowSection.tsx
+++ b/webapp/src/client/components/top-page/CashFlowSection.tsx
@@ -104,6 +104,13 @@ export default function CashFlowSection({
           <span className="text-[10px]">{getDisclaimerText()}</span>
         </div>
       )}
+
+      {/* 更新日時 */}
+      <div className="mt-4 text-right">
+        <span className="text-xs font-normal text-[#9CA3AF] leading-[1.33]">
+          {updatedAt}
+        </span>
+      </div>
     </MainColumnCard>
   );
 }

--- a/webapp/src/client/components/top-page/MonthlyTrendsSection.tsx
+++ b/webapp/src/client/components/top-page/MonthlyTrendsSection.tsx
@@ -42,6 +42,13 @@ export default function MonthlyTrendsSection({
       <div className="-mr-[18px] sm:mr-0">
         <MonthlyChart data={monthlyData || []} />
       </div>
+
+      {/* 更新日時 */}
+      <div className="mt-4 text-right">
+        <span className="text-xs font-normal text-[#9CA3AF] leading-[1.33]">
+          {updatedAt}
+        </span>
+      </div>
     </MainColumnCard>
   );
 }


### PR DESCRIPTION
## Summary
- CardHeaderでSP表示時に日付を非表示に変更
- 各セクション(サンキー図、月ごとの収支、貸借対照表)の右下に統一された形式で更新日時を表示
- Figmaデザインに合わせてモバイル向けのUX改善

## Test plan
- [ ] SP表示でHeaderの日付が非表示になることを確認
- [ ] 各セクションの右下に同じ形式で日付が表示されることを確認
- [ ] PC表示では従来通りHeaderに日付が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)