### PR TITLE
Fix: CardHeaderコンポーネントのPC版レスポンシブ表示改善

### DIFF
--- a/webapp/src/app/o/[slug]/transactions/page.tsx
+++ b/webapp/src/app/o/[slug]/transactions/page.tsx
@@ -135,7 +135,8 @@ export default async function TransactionsPage({
                 height={30}
               />
             }
-            title={`${organization?.displayName || "未登録の政治団体"}｜すべての出入金`}
+            organizationName={organization?.displayName || "未登録の政治団体"}
+            title="すべての出入金"
             updatedAt={updatedAt}
             subtitle="これまでにデータ連携された出入金の明細"
           />

--- a/webapp/src/client/components/layout/CardHeader.tsx
+++ b/webapp/src/client/components/layout/CardHeader.tsx
@@ -25,18 +25,16 @@ export default function CardHeader({
           <div className="w-[30px] h-[30px] flex items-center justify-center flex-shrink-0">
             {icon}
           </div>
-          <div className="flex flex-col md:flex-row md:items-center">
-            {organizationName && (
-              <>
-                <Title className="text-[--color-text-primary]">
-                  {organizationName}
-                </Title>
-                <Title className="hidden md:inline text-[--color-text-primary] mx-1">
-                  ｜
-                </Title>
-              </>
+          <div className="flex flex-col md:block">
+            {organizationName ? (
+              <Title className="text-[--color-text-primary]">
+                <span className="md:inline block">{organizationName}</span>
+                <span className="hidden md:inline mx-1">｜</span>
+                <span className="md:inline block">{title}</span>
+              </Title>
+            ) : (
+              <Title className="text-[--color-text-primary]">{title}</Title>
             )}
-            <Title className="text-[--color-text-primary]">{title}</Title>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- CardHeaderコンポーネントにおいて、PC版で組織名とタイトルが適切に一行表示されるよう修正
- props構造を変更し、organizationNameとtitleを別々に受け取るよう改善
- モバイル版では従来通り別行表示を維持

## Test plan
- PC版での組織名とタイトルの一行表示確認
- モバイル版での別行表示確認
- transactions pageでの表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)