### PR TITLE
カテゴリーフィルターUIを横並びレイアウトに改善

### DIFF
--- a/webapp/src/client/components/top-page/features/transactions-table/CategoryFilter.tsx
+++ b/webapp/src/client/components/top-page/features/transactions-table/CategoryFilter.tsx
@@ -105,61 +105,27 @@ export default function CategoryFilter({
   };
 
   return (
-    <div className="absolute top-full left-0 mt-1 bg-white rounded z-[9999] w-[236px] shadow-lg p-4">
-      <div>
-        <div className="flex flex-col items-center gap-6">
+    <div className="absolute top-full left-0 mt-1 bg-white rounded shadow-[2px_4px_8px_0px_rgba(0,0,0,0.1)] z-[9999] p-4">
+      <div className="flex flex-col gap-4">
+        {/* カテゴリーセクション */}
+        <div className="flex gap-6">
           {/* 収入カテゴリー */}
-          <div className="flex flex-col w-full">
-            <div className="flex items-center gap-2 pt-2 pb-0">
-              <span className="text-gray-600 text-xs font-medium leading-[1.67]">
-                収入カテゴリー
-              </span>
-            </div>
-            <div
-              className="max-h-[172px] overflow-y-auto"
-              style={{
-                scrollbarWidth: "thin",
-                scrollbarColor: "#9ca3af transparent",
-              }}
-            >
-              {/* すべて選択オプション */}
-              <button
-                type="button"
-                onClick={handleIncomeSelectAll}
-                className="flex items-center gap-2 py-[6px] pl-2 pr-1 w-full h-auto hover:bg-[#F1F5F9] transition-colors cursor-pointer"
-              >
-                <div className="w-[18px] h-[18px] flex items-center justify-center">
-                  {incomeCategories.every((cat) => cat.checked) && (
-                    <div className="w-[18px] h-[18px] relative">
-                      <Image
-                        src="/icons/icon-checkmark.svg"
-                        alt="Checkmark"
-                        width={13}
-                        height={11}
-                        className="absolute top-[4px] left-[2.5px]"
-                      />
-                    </div>
-                  )}
-                </div>
-                <span
-                  className={`text-[13px] leading-[1.54] text-left flex-1 ${
-                    incomeCategories.every((cat) => cat.checked)
-                      ? "font-bold"
-                      : "font-medium"
-                  } text-[#47474C]`}
-                >
-                  （すべて選択）
+          <div className="flex flex-col gap-6">
+            <div className="flex flex-col">
+              <div className="flex items-center gap-2 mb-1">
+                <span className="text-gray-600 text-sm font-medium leading-[1.67]">
+                  収入カテゴリー
                 </span>
-              </button>
-              {incomeCategories.map((category) => (
+              </div>
+              <div className="flex flex-col">
+                {/* すべて選択オプション */}
                 <button
-                  key={category.id}
                   type="button"
-                  onClick={() => handleIncomeToggle(category.id)}
-                  className="flex items-center gap-2 py-[6px] pl-2 pr-1 w-full h-auto hover:bg-[#F1F5F9] transition-colors cursor-pointer"
+                  onClick={handleIncomeSelectAll}
+                  className="flex items-center gap-2 py-[6px] px-1 w-[236px] h-auto hover:bg-[#F1F5F9] rounded-md transition-colors cursor-pointer"
                 >
                   <div className="w-[18px] h-[18px] flex items-center justify-center">
-                    {category.checked && (
+                    {incomeCategories.every((cat) => cat.checked) && (
                       <div className="w-[18px] h-[18px] relative">
                         <Image
                           src="/icons/icon-checkmark.svg"
@@ -172,75 +138,68 @@ export default function CategoryFilter({
                     )}
                   </div>
                   <span
-                    className={`text-[13px] leading-[1.54] text-left flex-1 ${
-                      category.checked ? "font-bold" : "font-medium"
+                    className={`text-[13px] leading-[1.31] text-left flex-1 ${
+                      incomeCategories.every((cat) => cat.checked)
+                        ? "font-semibold"
+                        : "font-medium"
                     } text-[#47474C]`}
                   >
-                    {category.label}
+                    （すべて選択）
                   </span>
                 </button>
-              ))}
+                <div className="pl-4">
+                  {incomeCategories.map((category) => (
+                    <button
+                      key={category.id}
+                      type="button"
+                      onClick={() => handleIncomeToggle(category.id)}
+                      className="flex items-center gap-2 py-[6px] px-1 w-[200px] h-auto hover:bg-[#F1F5F9] rounded-md transition-colors cursor-pointer"
+                    >
+                      <div className="w-[18px] h-[18px] flex items-center justify-center">
+                        {category.checked && (
+                          <div className="w-[18px] h-[18px] relative">
+                            <Image
+                              src="/icons/icon-checkmark.svg"
+                              alt="Checkmark"
+                              width={13}
+                              height={11}
+                              className="absolute top-[4px] left-[2.5px]"
+                            />
+                          </div>
+                        )}
+                      </div>
+                      <span
+                        className={`text-[13px] leading-[1.54] text-left flex-1 ${
+                          category.checked ? "font-semibold" : "font-medium"
+                        } text-[#47474C]`}
+                      >
+                        {category.label}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              </div>
             </div>
           </div>
 
           {/* 支出カテゴリー */}
-          <div className="flex flex-col w-full">
-            {/* 区切り線 */}
-            <div className="flex flex-col justify-center gap-2 h-6">
-              <div className="w-full h-0 border-t border-[#E5E7EB]"></div>
-            </div>
-
-            <div className="flex justify-stretch items-stretch">
-              <span className="text-gray-600 text-xs font-medium leading-[1.67] tracking-[0.071em] flex-1">
-                支出カテゴリー
-              </span>
-            </div>
-
-            <div
-              className="max-h-[172px] overflow-y-auto"
-              style={{
-                scrollbarWidth: "thin",
-                scrollbarColor: "#9ca3af transparent",
-              }}
-            >
-              {/* すべて選択オプション */}
-              <button
-                type="button"
-                onClick={handleExpenseSelectAll}
-                className="flex items-center gap-2 py-[6px] pl-2 pr-1 w-full h-auto hover:bg-[#F1F5F9] transition-colors cursor-pointer"
-              >
-                <div className="w-[18px] h-[18px] flex items-center justify-center">
-                  {expenseCategories.every((cat) => cat.checked) && (
-                    <div className="w-[18px] h-[18px] relative">
-                      <Image
-                        src="/icons/icon-checkmark.svg"
-                        alt="Checkmark"
-                        width={13}
-                        height={11}
-                        className="absolute top-[4px] left-[2.5px]"
-                      />
-                    </div>
-                  )}
-                </div>
-                <span
-                  className={`text-[13px] leading-[1.54] text-left flex-1 ${
-                    expenseCategories.every((cat) => cat.checked)
-                      ? "font-bold"
-                      : "font-medium"
-                  } text-[#47474C]`}
-                >
-                  （すべて選択）
+          <div className="flex flex-col gap-6">
+            <div className="flex flex-col gap-1">
+              <div className="flex items-center">
+                <span className="text-gray-600 text-sm font-medium leading-[1.67] w-[212px]">
+                  支出カテゴリー
                 </span>
-              </button>
-              {expenseCategories.map((category) => (
+              </div>
+
+              <div className="flex flex-col">
+                {/* すべて選択オプション */}
                 <button
-                  key={category.id}
                   type="button"
-                  onClick={() => handleExpenseToggle(category.id)}
-                  className="flex items-center gap-2 py-[6px] pl-2 pr-1 w-full h-auto hover:bg-[#F1F5F9] transition-colors cursor-pointer"
+                  onClick={handleExpenseSelectAll}
+                  className="flex items-center gap-2 py-[6px] px-1 w-[236px] h-auto hover:bg-[#F1F5F9] rounded-md transition-colors cursor-pointer"
                 >
                   <div className="w-[18px] h-[18px] flex items-center justify-center">
-                    {category.checked && (
+                    {expenseCategories.every((cat) => cat.checked) && (
                       <div className="w-[18px] h-[18px] relative">
                         <Image
                           src="/icons/icon-checkmark.svg"
@@ -253,38 +212,71 @@ export default function CategoryFilter({
                     )}
                   </div>
                   <span
-                    className={`text-[13px] leading-[1.54] text-left flex-1 ${
-                      category.checked ? "font-bold" : "font-medium"
+                    className={`text-[13px] leading-[1.31] text-left flex-1 ${
+                      expenseCategories.every((cat) => cat.checked)
+                        ? "font-semibold"
+                        : "font-medium"
                     } text-[#47474C]`}
                   >
-                    {category.label}
+                    （すべて選択）
                   </span>
                 </button>
-              ))}
+                <div className="pl-4">
+                  {expenseCategories.map((category) => (
+                    <button
+                      key={category.id}
+                      type="button"
+                      onClick={() => handleExpenseToggle(category.id)}
+                      className="flex items-center gap-2 py-[6px] px-1 w-[200px] h-auto hover:bg-[#F1F5F9] rounded-md transition-colors cursor-pointer"
+                    >
+                      <div className="w-[18px] h-[18px] flex items-center justify-center">
+                        {category.checked && (
+                          <div className="w-[18px] h-[18px] relative">
+                            <Image
+                              src="/icons/icon-checkmark.svg"
+                              alt="Checkmark"
+                              width={13}
+                              height={11}
+                              className="absolute top-[4px] left-[2.5px]"
+                            />
+                          </div>
+                        )}
+                      </div>
+                      <span
+                        className={`text-[13px] leading-[1.54] text-left flex-1 ${
+                          category.checked ? "font-semibold" : "font-medium"
+                        } text-[#47474C]`}
+                      >
+                        {category.label}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              </div>
             </div>
           </div>
+        </div>
 
-          {/* ボタン */}
-          <div className="flex gap-4">
-            <button
-              type="button"
-              onClick={handleCancel}
-              className="flex justify-center items-center gap-[10px] py-2 w-[88px] bg-[#F1F5F9] border-[0.5px] border-[#D1D5DB] rounded-[6px] hover:opacity-70 transition-opacity cursor-pointer"
-            >
-              <span className="text-[#238778] text-sm font-medium leading-[1.29]">
-                キャンセル
-              </span>
-            </button>
-            <button
-              type="button"
-              onClick={handleOk}
-              className="flex justify-center items-center gap-[10px] py-2 w-[88px] bg-[#238778] rounded-[6px] hover:opacity-90 transition-opacity cursor-pointer"
-            >
-              <span className="text-white text-sm font-medium leading-[1.29]">
-                OK
-              </span>
-            </button>
-          </div>
+        {/* ボタン */}
+        <div className="flex justify-center items-center gap-4 w-full">
+          <button
+            type="button"
+            onClick={handleCancel}
+            className="flex justify-center items-center gap-[10px] py-2 px-4 w-[120px] bg-[#F1F5F9] border-[0.5px] border-[#D1D5DB] rounded-[6px] hover:opacity-70 transition-opacity cursor-pointer"
+          >
+            <span className="text-[#238778] text-sm font-medium leading-[1.29]">
+              キャンセル
+            </span>
+          </button>
+          <button
+            type="button"
+            onClick={handleOk}
+            className="flex justify-center items-center gap-[10px] py-2 px-4 w-[120px] bg-[#238778] rounded-[6px] hover:opacity-90 transition-opacity cursor-pointer"
+          >
+            <span className="text-white text-sm font-medium leading-[1.29]">
+              OK
+            </span>
+          </button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- カテゴリーフィルターのUIを縦並びから横並びレイアウトに変更し、Figmaデザインに準拠
- 収入カテゴリーと支出カテゴリーを左右に並べて表示
- 視認性とユーザビリティを向上

## Changes
- 収入・支出カテゴリーを横並び（flex-row）に配置
- カテゴリーラベルのフォントサイズを拡大（text-xs → text-sm）
- チェック済みアイテムをfont-semiboldで表示
- 個別選択肢を左にインデント（pl-4）して階層構造を明確化
- ボタン幅を120pxに統一

## Test plan
- [ ] カテゴリーフィルターを開いて、収入・支出が横並びに表示されることを確認
- [ ] カテゴリーの選択/解除が正常に動作することを確認
- [ ] 「すべて選択」ボタンが正常に動作することを確認
- [ ] OKボタンでフィルターが適用されることを確認
- [ ] キャンセルボタンで変更が破棄されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)