### PR TITLE
fix: formatAmount関数でマイナス値をサポート

### DIFF
--- a/webapp/src/server/utils/financial-calculator.ts
+++ b/webapp/src/server/utils/financial-calculator.ts
@@ -7,32 +7,31 @@ export interface FormattedAmount {
 
 // 金額を万円単位でフォーマットする関数
 export function formatAmount(amount: number): FormattedAmount {
-  if (amount < 0) {
-    throw new Error("Negative amounts are not supported");
-  }
-
-  const manAmount = Math.round(amount / 10000); // 万円に変換
+  const isNegative = amount < 0;
+  const absAmount = Math.abs(amount);
+  const manAmount = Math.round(absAmount / 10000); // 万円に変換
+  const sign = isNegative ? "-" : "";
 
   if (manAmount >= 10000) {
     const oku = Math.floor(manAmount / 10000);
     const man = manAmount % 10000;
     if (man === 0) {
       return {
-        main: oku.toString(),
+        main: `${sign}${oku}`,
         secondary: "億",
         tertiary: "",
         unit: "円",
       };
     }
     return {
-      main: oku.toString(),
+      main: `${sign}${oku}`,
       secondary: "億",
       tertiary: man.toString(),
       unit: "万円",
     };
   }
   return {
-    main: manAmount.toString(),
+    main: `${sign}${manAmount}`,
     secondary: "",
     tertiary: "",
     unit: "万円",

--- a/webapp/tests/server/utils/financial-calculator.test.ts
+++ b/webapp/tests/server/utils/financial-calculator.test.ts
@@ -50,21 +50,26 @@ describe("formatAmount", () => {
       input: 99995000,
       expected: { main: "1", secondary: "億", tertiary: "", unit: "円" },
     },
+
+    // マイナス値
+    {
+      description: "-1,000,000円 = -100万円",
+      input: -1000000,
+      expected: { main: "-100", secondary: "", tertiary: "", unit: "万円" },
+    },
+    {
+      description: "-100,000,000円 = -1億円",
+      input: -100000000,
+      expected: { main: "-1", secondary: "億", tertiary: "", unit: "円" },
+    },
+    {
+      description: "-150,000,000円 = -1億5000万円",
+      input: -150000000,
+      expected: { main: "-1", secondary: "億", tertiary: "5000", unit: "万円" },
+    },
   ];
 
   it.each(testCases)("should format $description", ({ input, expected }) => {
     expect(formatAmount(input)).toEqual(expected);
-  });
-
-  const errorTestCases: Array<{
-    description: string;
-    input: number;
-  }> = [
-    { description: "-1", input: -1 },
-    { description: "-100,000,000円", input: -100000000 },
-  ];
-
-  it.each(errorTestCases)("should throw error for negative amount $description", ({ input }) => {
-    expect(() => formatAmount(input)).toThrow("Negative amounts are not supported");
   });
 });


### PR DESCRIPTION
## Summary
- `formatAmount` 関数でマイナス値が入力された場合にエラーをスローする代わりに、適切にマイナス符号を付けた文字列を返すように修正
- テストケースも負の値をサポートするよう更新

## Changes
- `formatAmount` 関数の実装を修正し、負の値を絶対値に変換してフォーマット後、符号を付与する処理に変更
- 負の値に対するエラーテストケースを削除し、代わりに負の値の正常ケースを追加

## Test plan
- [x] 既存のテストケースが全てパス
- [x] 新規追加した負の値のテストケースがパス
- [x] `npm run typecheck` がパス
- [x] `npm run lint` がパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)