### PR TITLE
deepwikiのバッジ追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 [![TypeScript](https://img.shields.io/badge/TypeScript-007ACC?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![Next.js](https://img.shields.io/badge/Next.js-000000?logo=next.js&logoColor=white)](https://nextjs.org/)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/team-mirai-volunteer/marumie)
 
 > 政治資金の透明性向上を目指すオープンソースダッシュボード
 


### PR DESCRIPTION
READMEにてdeepwikiのバッジを追加しました。

<img width="663" height="123" alt="スクリーンショット 2025-10-04 12 56 04" src="https://github.com/user-attachments/assets/a28c7ae0-d53f-4347-8a09-1b2783cda770" />

marumieのdeepwikiを
https://deepwiki.com/team-mirai-volunteer/marumie



badge-makerを使ってバッジ化し、
https://deepwiki.com/badge-maker

それをreadmeに埋め込みました。