### PR TITLE
feat: Speed Insightsのサンプリングレートを10%に削減

### DIFF
--- a/webapp/src/app/layout.tsx
+++ b/webapp/src/app/layout.tsx
@@ -89,7 +89,7 @@ export default function RootLayout({
         <div className="mt-0 sm:mt-16">
           <Footer />
         </div>
-        <SpeedInsights />
+        <SpeedInsights sampleRate={0.1} />
         <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_TRACKING_ID || ""} />
       </body>
     </html>


### PR DESCRIPTION
## Summary
- Vercel Speed Insightsの`sampleRate`を0.1（10%）に設定し、イベント送信量を削減

## Changes
- `webapp/src/app/layout.tsx`の`SpeedInsights`コンポーネントに`sampleRate={0.1}`を追加

## Background
Speed Insightsのイベント送信量を削減するため、サンプリングレートを従来の1/10（100%→10%）に変更しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)