### PR TITLE
refactor: simplify metadata generation in transactions page

### DIFF
--- a/webapp/src/app/o/[slug]/transactions/page.tsx
+++ b/webapp/src/app/o/[slug]/transactions/page.tsx
@@ -34,29 +34,13 @@ export async function generateMetadata({
   const validSlug = organizations.some((org) => org.slug === slug)
     ? slug
     : defaultSlug;
-  const slugs = [validSlug];
 
-  // financialYearのデフォルト値を設定
-  const currentFinancialYear = 2025;
+  const organization = organizations.find((org) => org.slug === validSlug);
 
-  try {
-    const result = await loadTransactionsPageData({
-      slugs,
-      page: 1,
-      perPage: 1,
-      financialYear: currentFinancialYear,
-    });
-
-    return {
-      title: `${result.politicalOrganizations[0]?.displayName || "Unknown"}:全ての出入金 - みらいまる見え政治資金`,
-      description: `${result.politicalOrganizations[0]?.displayName || "Unknown"}の政治資金取引一覧を表示しています。`,
-    };
-  } catch {
-    return {
-      title: "全ての出入金 - みらいまる見え政治資金",
-      description: "政治資金取引一覧を表示しています。",
-    };
-  }
+  return {
+    title: `${organization?.displayName || "Unknown"}:全ての出入金 - みらいまる見え政治資金`,
+    description: `${organization?.displayName || "Unknown"}の政治資金取引一覧を表示しています。`,
+  };
 }
 
 export default async function TransactionsPage({


### PR DESCRIPTION
## Summary
- generateMetadata関数での不要な`loadTransactionsPageData`呼び出しを削除
- 既に取得済みの`organizations`データから`displayName`を取得するようリファクタリング

## Changes
- `loadTransactionsPageData`の重複呼び出しを削減（metadata生成時には不要）
- より軽量な実装に変更

## Notes
- 同時接続数エラーの直接要因ではないが、不要なデータベースアクセスを削減するリファクタリング
- 機能的な変更はなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)