### PR TITLE
fix: pin Biome version in package.json per official recommendation

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "zod": "^4.0.15"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.2.0",
+    "@biomejs/biome": "2.2.2",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",


### PR DESCRIPTION
package.json で Biome のバージョンが固定されていないため、固定しました
元の指定は `^2.2.0` でしたが biome.json で `2.2.2` が指定されているためそちらに合わせています

後から開発を始めた人が biome.json との整合性が取れなくなったり他のコミッターと異なる整形をしてしまう可能性があるため、Biome 公式でもバージョンの固定が強く推奨されています
https://biomejs.dev/internals/versioning/#:~:text=Fixes%20to%20lint%20rules%2C%20formatting,script%20won't%20fail%20unexpectedly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies for enhanced stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->