### PR TITLE
add details for Upsider/amex

### DIFF
--- a/admin/src/server/lib/mf-record-converter.ts
+++ b/admin/src/server/lib/mf-record-converter.ts
@@ -111,13 +111,22 @@ export class MfRecordConverter {
   }
 
   private shouldDisplayDescription(record: MfCsvRecord): boolean {
-    const descriptionStartsWithDebit =
-      record.description?.startsWith("デビット");
-    const memoIncludesUpsider = record.memo
-      ? record.memo.toLowerCase().includes("upsider")
-      : false;
+    const description = record.description ?? "";
+    const memo = record.memo ?? "";
 
-    return Boolean(descriptionStartsWithDebit || memoIncludesUpsider);
+    const normalizedDescription = description.toLowerCase();
+    const normalizedMemo = memo.toLowerCase();
+
+    const descriptionStartsWithDebit = description.startsWith("デビット");
+    const containsUpsider =
+      normalizedDescription.includes("upsider") ||
+      normalizedMemo.includes("upsider");
+    const containsAmex =
+      normalizedDescription.includes("amex") || normalizedMemo.includes("amex");
+
+    return Boolean(
+      descriptionStartsWithDebit || containsUpsider || containsAmex,
+    );
   }
 
   private parseAmount(amountStr: string): number {

--- a/admin/tests/server/lib/mf-record-converter.test.ts
+++ b/admin/tests/server/lib/mf-record-converter.test.ts
@@ -129,12 +129,22 @@ describe("MfRecordConverter", () => {
     it("should set label when memo contains upsider (case-insensitive)", () => {
       const record = createMockRecord({
         description: "通常の明細",
-        memo: "利用先: UPSIDER株式会社",
+        memo: "Upsider",
       });
 
       const result = converter.convertRow(record, "test-org-id");
 
       expect(result.label).toBe("通常の明細");
+    });
+
+    it("should set label when description contains amex (case-insensitive)", () => {
+      const record = createMockRecord({
+        description: "AMEX 123456 TEST",
+      });
+
+      const result = converter.convertRow(record, "test-org-id");
+
+      expect(result.label).toBe("AMEX 123456 TEST");
     });
 
     it("should not set label when conditions are not met", () => {


### PR DESCRIPTION
- [x] デビットの場合同様、memo欄に Upsider/amexがある場合は摘要を表示する

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction record labeling with refined logic for determining when descriptions should be displayed as labels, ensuring consistent behavior across different transaction types and formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->