### PR TITLE
short cache for staging

### DIFF
--- a/webapp/src/server/loaders/constants.ts
+++ b/webapp/src/server/loaders/constants.ts
@@ -1,0 +1,2 @@
+export const CACHE_REVALIDATE_SECONDS =
+  process.env.VERCEL_ENV === "production" ? 3600 : 10;

--- a/webapp/src/server/loaders/load-organizations.ts
+++ b/webapp/src/server/loaders/load-organizations.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { unstable_cache } from "next/cache";
 import { prisma } from "@/server/lib/prisma";
 import type { OrganizationsResponse } from "../../types/organization";
+import { CACHE_REVALIDATE_SECONDS } from "./constants";
 
 export const loadOrganizations = unstable_cache(
   async (): Promise<OrganizationsResponse> => {
@@ -31,6 +32,6 @@ export const loadOrganizations = unstable_cache(
   },
   ["organizations"],
   {
-    revalidate: 3600, // 1時間キャッシュ
+    revalidate: CACHE_REVALIDATE_SECONDS,
   },
 );

--- a/webapp/src/server/loaders/load-top-page-data.ts
+++ b/webapp/src/server/loaders/load-top-page-data.ts
@@ -13,7 +13,7 @@ import {
   type GetTransactionsBySlugParams,
   GetTransactionsBySlugUsecase,
 } from "@/server/usecases/get-transactions-by-slug-usecase";
-const CACHE_REVALIDATE_SECONDS = 3600;
+import { CACHE_REVALIDATE_SECONDS } from "./constants";
 
 export interface TopPageDataParams
   extends Omit<GetTransactionsBySlugParams, "financialYear"> {

--- a/webapp/src/server/loaders/load-transactions-for-csv.ts
+++ b/webapp/src/server/loaders/load-transactions-for-csv.ts
@@ -8,8 +8,7 @@ import {
   type GetTransactionsForCsvParams,
   GetTransactionsForCsvUsecase,
 } from "@/server/usecases/get-transactions-for-csv-usecase";
-
-const CACHE_REVALIDATE_SECONDS = 3600;
+import { CACHE_REVALIDATE_SECONDS } from "./constants";
 
 export const loadTransactionsForCsv = unstable_cache(
   async (params: GetTransactionsForCsvParams) => {

--- a/webapp/src/server/loaders/load-transactions-page-data.ts
+++ b/webapp/src/server/loaders/load-transactions-page-data.ts
@@ -8,7 +8,7 @@ import {
   type GetTransactionsBySlugParams,
   GetTransactionsBySlugUsecase,
 } from "@/server/usecases/get-transactions-by-slug-usecase";
-const CACHE_REVALIDATE_SECONDS = 3600;
+import { CACHE_REVALIDATE_SECONDS } from "./constants";
 
 export const loadTransactionsPageData = (
   params: GetTransactionsBySlugParams,


### PR DESCRIPTION
- 確認時の反映を早めるためstaging環境でのキャッシュを１時間→10秒にした
  - (cache revalidateは vercel authの中にあるので届かない）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Centralized cache revalidation configuration across server data loaders for improved maintainability and consistent caching behavior throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->