### PR TITLE
WIP: expense data

### DIFF
--- a/admin/src/app/api/xml-export/route.ts
+++ b/admin/src/app/api/xml-export/route.ts
@@ -5,6 +5,7 @@ import { PrismaReportTransactionRepository } from "@/server/repositories/prisma-
 import { XmlExportUsecase } from "@/server/usecases/xml-export-usecase";
 import { DonationAssembler } from "@/server/usecases/assemblers/donation-assembler";
 import { IncomeAssembler } from "@/server/usecases/assemblers/income-assembler";
+import { ExpenseAssembler } from "@/server/usecases/assemblers/expense-assembler";
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
@@ -50,7 +51,12 @@ export async function GET(request: Request) {
     const repository = new PrismaReportTransactionRepository(prisma);
     const donationAssembler = new DonationAssembler(repository);
     const incomeAssembler = new IncomeAssembler(repository);
-    const usecase = new XmlExportUsecase(donationAssembler, incomeAssembler);
+    const expenseAssembler = new ExpenseAssembler(repository);
+    const usecase = new XmlExportUsecase(
+      donationAssembler,
+      incomeAssembler,
+      expenseAssembler,
+    );
 
     const result = await usecase.execute({
       politicalOrganizationId,

--- a/admin/src/server/actions/export-xml.ts
+++ b/admin/src/server/actions/export-xml.ts
@@ -5,6 +5,7 @@ import { PrismaReportTransactionRepository } from "../repositories/prisma-report
 import { XmlExportUsecase } from "../usecases/xml-export-usecase";
 import { DonationAssembler } from "../usecases/assemblers/donation-assembler";
 import { IncomeAssembler } from "../usecases/assemblers/income-assembler";
+import { ExpenseAssembler } from "../usecases/assemblers/expense-assembler";
 import type { ReportData } from "../domain/report-data";
 
 export interface ExportXmlInput {
@@ -32,7 +33,12 @@ export async function exportXml(
   const repository = new PrismaReportTransactionRepository(prisma);
   const donationAssembler = new DonationAssembler(repository);
   const incomeAssembler = new IncomeAssembler(repository);
-  const usecase = new XmlExportUsecase(donationAssembler, incomeAssembler);
+  const expenseAssembler = new ExpenseAssembler(repository);
+  const usecase = new XmlExportUsecase(
+    donationAssembler,
+    incomeAssembler,
+    expenseAssembler,
+  );
 
   const result = await usecase.execute({
     politicalOrganizationId: input.politicalOrganizationId,

--- a/admin/src/server/domain/converters/expense-converter.ts
+++ b/admin/src/server/domain/converters/expense-converter.ts
@@ -1,0 +1,396 @@
+/**
+ * Expense Converter
+ *
+ * Converts raw transaction data from the database into expense-related domain objects.
+ * This is a pure function layer that handles data transformation and business rules.
+ */
+
+import type {
+  UtilityExpenseTransaction,
+  EquipmentSuppliesExpenseTransaction,
+  OfficeExpenseTransaction,
+  OrganizationalExpenseTransaction,
+  ElectionExpenseTransaction,
+  PublicationExpenseTransaction,
+  AdvertisingExpenseTransaction,
+  FundraisingPartyExpenseTransaction,
+  OtherBusinessExpenseTransaction,
+  ResearchExpenseTransaction,
+  DonationsGrantsExpenseTransaction,
+  OtherExpenseTransaction,
+  GrantToHeadquartersTransaction,
+} from "@/server/domain/types/expense-transaction";
+
+// Re-export input types for consumers
+export type {
+  UtilityExpenseTransaction,
+  EquipmentSuppliesExpenseTransaction,
+  OfficeExpenseTransaction,
+  OrganizationalExpenseTransaction,
+  ElectionExpenseTransaction,
+  PublicationExpenseTransaction,
+  AdvertisingExpenseTransaction,
+  FundraisingPartyExpenseTransaction,
+  OtherBusinessExpenseTransaction,
+  ResearchExpenseTransaction,
+  DonationsGrantsExpenseTransaction,
+  OtherExpenseTransaction,
+  GrantToHeadquartersTransaction,
+};
+
+// ============================================================
+// Output Types (Domain Objects)
+// ============================================================
+
+/**
+ * SYUUSHI07_14: 経常経費の支出の明細行
+ */
+export interface RegularExpenseRow {
+  ichirenNo: string; // 一連番号
+  mokuteki: string; // 目的
+  kingaku: number; // 金額
+  dt: Date; // 年月日
+  nm: string; // 氏名
+  adr: string; // 住所
+  bikou?: string; // 備考
+  ryousyu?: number; // 領収書区分
+}
+
+/**
+ * SYUUSHI07_14: 経常経費の支出（KUBUN別）
+ */
+export interface RegularExpenseSection {
+  totalAmount: number; // 合計
+  sonotaGk: number; // その他の支出
+  rows: RegularExpenseRow[];
+}
+
+/**
+ * SYUUSHI07_14: 経常経費の支出
+ */
+export interface RegularExpenseData {
+  utilities: RegularExpenseSection; // KUBUN1: 光熱水費
+  equipmentSupplies: RegularExpenseSection; // KUBUN2: 備品・消耗品費
+  officeExpenses: RegularExpenseSection; // KUBUN3: 事務所費
+}
+
+/**
+ * SYUUSHI07_15: 政治活動費の支出の明細行
+ */
+export interface PoliticalActivityExpenseRow {
+  ichirenNo: string; // 一連番号
+  mokuteki: string; // 目的
+  kingaku: number; // 金額
+  dt: Date; // 年月日
+  nm: string; // 氏名
+  adr: string; // 住所
+  bikou?: string; // 備考
+  ryousyu?: number; // 領収書区分
+}
+
+/**
+ * SYUUSHI07_15: 政治活動費の支出（KUBUN別）
+ */
+export interface PoliticalActivityExpenseSection {
+  himoku: string; // 費目
+  totalAmount: number; // 合計
+  sonotaGk: number; // その他の支出
+  rows: PoliticalActivityExpenseRow[];
+}
+
+/**
+ * SYUUSHI07_15: 政治活動費の支出
+ */
+export interface PoliticalActivityExpenseData {
+  organizationalActivities: PoliticalActivityExpenseSection; // KUBUN1: 組織活動費
+  electionExpenses: PoliticalActivityExpenseSection; // KUBUN2: 選挙関係費
+  publicationExpenses: PoliticalActivityExpenseSection; // KUBUN3: 機関紙誌の発行事業費
+  advertisingExpenses: PoliticalActivityExpenseSection; // KUBUN4: 宣伝事業費
+  fundraisingPartyExpenses: PoliticalActivityExpenseSection; // KUBUN5: 政治資金パーティー開催事業費
+  otherBusinessExpenses: PoliticalActivityExpenseSection; // KUBUN6: その他の事業費
+  researchExpenses: PoliticalActivityExpenseSection; // KUBUN7: 調査研究費
+  donationsGrantsExpenses: PoliticalActivityExpenseSection; // KUBUN8: 寄附・交付金
+  otherExpenses: PoliticalActivityExpenseSection; // KUBUN9: その他の経費
+}
+
+/**
+ * SYUUSHI07_16: 本部又は支部に対する交付金の明細行
+ */
+export interface GrantToHeadquartersRow {
+  ichirenNo: string; // 一連番号
+  shisyutuKmk: string; // 支出項目
+  kingaku: number; // 金額
+  dt: Date; // 年月日
+  honsibuNm: string; // 本支部名称
+  jimuAdr: string; // 主たる事務所の所在地
+  bikou?: string; // 備考
+}
+
+/**
+ * SYUUSHI07_16: 本部又は支部に対する交付金
+ */
+export interface GrantToHeadquartersSection {
+  totalAmount: number;
+  rows: GrantToHeadquartersRow[];
+}
+
+// ============================================================
+// Internal Types
+// ============================================================
+
+interface ExpenseTransaction {
+  transactionNo: string;
+  transactionDate: Date;
+  friendlyCategory: string | null;
+  label: string | null;
+  description: string | null;
+  memo: string | null;
+  amount: number;
+  counterpartName: string;
+  counterpartAddress: string;
+}
+
+// ============================================================
+// Converter Functions
+// ============================================================
+
+/**
+ * SYUUSHI07_14: 経常経費を変換
+ */
+export function convertToRegularExpenseData(
+  utilities: UtilityExpenseTransaction[],
+  equipmentSupplies: EquipmentSuppliesExpenseTransaction[],
+  officeExpenses: OfficeExpenseTransaction[],
+): RegularExpenseData {
+  return {
+    utilities: aggregateRegularExpenseSection(
+      utilities.map(toExpenseTransaction),
+    ),
+    equipmentSupplies: aggregateRegularExpenseSection(
+      equipmentSupplies.map(toExpenseTransaction),
+    ),
+    officeExpenses: aggregateRegularExpenseSection(
+      officeExpenses.map(toExpenseTransaction),
+    ),
+  };
+}
+
+/**
+ * SYUUSHI07_15: 政治活動費を変換
+ */
+export function convertToPoliticalActivityExpenseData(
+  organizationalActivities: OrganizationalExpenseTransaction[],
+  electionExpenses: ElectionExpenseTransaction[],
+  publicationExpenses: PublicationExpenseTransaction[],
+  advertisingExpenses: AdvertisingExpenseTransaction[],
+  fundraisingPartyExpenses: FundraisingPartyExpenseTransaction[],
+  otherBusinessExpenses: OtherBusinessExpenseTransaction[],
+  researchExpenses: ResearchExpenseTransaction[],
+  donationsGrantsExpenses: DonationsGrantsExpenseTransaction[],
+  otherExpenses: OtherExpenseTransaction[],
+): PoliticalActivityExpenseData {
+  return {
+    organizationalActivities: aggregatePoliticalActivityExpenseSection(
+      organizationalActivities.map(toExpenseTransaction),
+      "組織活動費",
+    ),
+    electionExpenses: aggregatePoliticalActivityExpenseSection(
+      electionExpenses.map(toExpenseTransaction),
+      "選挙関係費",
+    ),
+    publicationExpenses: aggregatePoliticalActivityExpenseSection(
+      publicationExpenses.map(toExpenseTransaction),
+      "機関紙誌の発行事業費",
+    ),
+    advertisingExpenses: aggregatePoliticalActivityExpenseSection(
+      advertisingExpenses.map(toExpenseTransaction),
+      "宣伝事業費",
+    ),
+    fundraisingPartyExpenses: aggregatePoliticalActivityExpenseSection(
+      fundraisingPartyExpenses.map(toExpenseTransaction),
+      "政治資金パーティー開催事業費",
+    ),
+    otherBusinessExpenses: aggregatePoliticalActivityExpenseSection(
+      otherBusinessExpenses.map(toExpenseTransaction),
+      "その他の事業費",
+    ),
+    researchExpenses: aggregatePoliticalActivityExpenseSection(
+      researchExpenses.map(toExpenseTransaction),
+      "調査研究費",
+    ),
+    donationsGrantsExpenses: aggregatePoliticalActivityExpenseSection(
+      donationsGrantsExpenses.map(toExpenseTransaction),
+      "寄附・交付金",
+    ),
+    otherExpenses: aggregatePoliticalActivityExpenseSection(
+      otherExpenses.map(toExpenseTransaction),
+      "その他の経費",
+    ),
+  };
+}
+
+/**
+ * SYUUSHI07_16: 本部又は支部に対する交付金を変換
+ */
+export function convertToGrantToHeadquartersSection(
+  transactions: GrantToHeadquartersTransaction[],
+): GrantToHeadquartersSection {
+  const expenseTransactions = transactions.map(toExpenseTransaction);
+  return aggregateGrantToHeadquartersSection(expenseTransactions);
+}
+
+// ============================================================
+// Input Mapping Functions
+// ============================================================
+
+function toExpenseTransaction(
+  t:
+    | UtilityExpenseTransaction
+    | EquipmentSuppliesExpenseTransaction
+    | OfficeExpenseTransaction
+    | OrganizationalExpenseTransaction
+    | ElectionExpenseTransaction
+    | PublicationExpenseTransaction
+    | AdvertisingExpenseTransaction
+    | FundraisingPartyExpenseTransaction
+    | OtherBusinessExpenseTransaction
+    | ResearchExpenseTransaction
+    | DonationsGrantsExpenseTransaction
+    | OtherExpenseTransaction
+    | GrantToHeadquartersTransaction,
+): ExpenseTransaction {
+  return {
+    transactionNo: t.transactionNo,
+    transactionDate: t.transactionDate,
+    friendlyCategory: t.friendlyCategory,
+    label: t.label,
+    description: t.description,
+    memo: t.memo,
+    amount: resolveTransactionAmount(t.debitAmount, t.creditAmount),
+    counterpartName: t.counterpartName,
+    counterpartAddress: t.counterpartAddress,
+  };
+}
+
+// ============================================================
+// Aggregation Functions
+// ============================================================
+
+function aggregateRegularExpenseSection(
+  transactions: ExpenseTransaction[],
+): RegularExpenseSection {
+  const totalAmount = transactions.reduce((sum, t) => sum + t.amount, 0);
+
+  const rows: RegularExpenseRow[] = transactions.map((t, index) => ({
+    ichirenNo: (index + 1).toString(),
+    mokuteki: buildMokuteki(t),
+    kingaku: Math.round(t.amount),
+    dt: t.transactionDate,
+    nm: sanitizeText(t.counterpartName, 120),
+    adr: sanitizeText(t.counterpartAddress, 120),
+    bikou: buildBikou(t),
+  }));
+
+  return {
+    totalAmount,
+    sonotaGk: 0, // その他の支出は現時点では0
+    rows,
+  };
+}
+
+function aggregatePoliticalActivityExpenseSection(
+  transactions: ExpenseTransaction[],
+  himoku: string,
+): PoliticalActivityExpenseSection {
+  const totalAmount = transactions.reduce((sum, t) => sum + t.amount, 0);
+
+  const rows: PoliticalActivityExpenseRow[] = transactions.map((t, index) => ({
+    ichirenNo: (index + 1).toString(),
+    mokuteki: buildMokuteki(t),
+    kingaku: Math.round(t.amount),
+    dt: t.transactionDate,
+    nm: sanitizeText(t.counterpartName, 120),
+    adr: sanitizeText(t.counterpartAddress, 120),
+    bikou: buildBikou(t),
+  }));
+
+  return {
+    himoku,
+    totalAmount,
+    sonotaGk: 0, // その他の支出は現時点では0
+    rows,
+  };
+}
+
+function aggregateGrantToHeadquartersSection(
+  transactions: ExpenseTransaction[],
+): GrantToHeadquartersSection {
+  const totalAmount = transactions.reduce((sum, t) => sum + t.amount, 0);
+
+  const rows: GrantToHeadquartersRow[] = transactions.map((t, index) => ({
+    ichirenNo: (index + 1).toString(),
+    shisyutuKmk: buildShisyutuKmk(t),
+    kingaku: Math.round(t.amount),
+    dt: t.transactionDate,
+    honsibuNm: sanitizeText(t.counterpartName, 120),
+    jimuAdr: sanitizeText(t.counterpartAddress, 120),
+    bikou: buildBikou(t),
+  }));
+
+  return {
+    totalAmount,
+    rows,
+  };
+}
+
+// ============================================================
+// Field Builder Functions
+// ============================================================
+
+function buildMokuteki(t: ExpenseTransaction): string {
+  // 優先順位: description > label > friendlyCategory
+  const mokuteki = t.description || t.label || t.friendlyCategory || "";
+  return sanitizeText(mokuteki, 200);
+}
+
+function buildShisyutuKmk(t: ExpenseTransaction): string {
+  // 優先順位: friendlyCategory > label > description
+  const kmk = t.friendlyCategory || t.label || t.description || "交付金";
+  return sanitizeText(kmk, 100);
+}
+
+function buildBikou(t: ExpenseTransaction): string {
+  const mfRowInfo = `MF行番号: ${t.transactionNo || "-"}`;
+  const memoText = sanitizeText(t.memo, 70);
+  const combined = memoText ? `${memoText} / ${mfRowInfo}` : mfRowInfo;
+
+  return sanitizeText(combined, 100) || mfRowInfo;
+}
+
+function resolveTransactionAmount(
+  debitAmount: number,
+  creditAmount: number,
+): number {
+  // 支出の場合は借方(debit)を優先
+  if (Number.isFinite(debitAmount) && debitAmount > 0) {
+    return debitAmount;
+  }
+
+  return Number.isFinite(creditAmount) ? creditAmount : 0;
+}
+
+function sanitizeText(
+  value: string | null | undefined,
+  maxLength?: number,
+): string {
+  if (!value) {
+    return "";
+  }
+
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (maxLength && normalized.length > maxLength) {
+    return normalized.slice(0, maxLength);
+  }
+
+  return normalized;
+}

--- a/admin/src/server/domain/report-data.ts
+++ b/admin/src/server/domain/report-data.ts
@@ -12,6 +12,11 @@ import type {
   LoanIncomeSection,
   OtherIncomeSection,
 } from "./converters/income-converter";
+import type {
+  RegularExpenseData,
+  PoliticalActivityExpenseData,
+  GrantToHeadquartersSection,
+} from "./converters/expense-converter";
 
 /**
  * 寄付データ (SYUUSHI07_07)
@@ -33,20 +38,12 @@ export interface IncomeData {
 }
 
 /**
- * 支出データ (SYUUSHI07_07 ~ SYUUSHI07_16)
+ * 支出データ (SYUUSHI07_14 ~ SYUUSHI07_16)
  */
-// biome-ignore lint/suspicious/noEmptyInterface: Will be populated as sections are implemented
 export interface ExpenseData {
-  // personnelExpenses?: PersonnelExpenseSection;     // (7) 人件費
-  // utilityExpenses?: UtilityExpenseSection;         // (8) 光熱水費
-  // suppliesExpenses?: SuppliesExpenseSection;       // (9) 備品・消耗品費
-  // officeExpenses?: OfficeExpenseSection;           // (10) 事務所費
-  // organizationExpenses?: OrganizationExpenseSection; // (11) 組織活動費
-  // electionExpenses?: ElectionExpenseSection;       // (12) 選挙関係費
-  // publicationExpenses?: PublicationExpenseSection; // (13) 機関紙誌の発行その他の事業費
-  // researchExpenses?: ResearchExpenseSection;       // (14) 調査研究費
-  // donationExpenses?: DonationExpenseSection;       // (15) 寄附・交付金
-  // otherExpenses?: OtherExpenseSection;             // (16) その他の経常経費
+  regularExpenses: RegularExpenseData; // SYUUSHI07_14: 経常経費（光熱水費、備品・消耗品費、事務所費）
+  politicalActivityExpenses: PoliticalActivityExpenseData; // SYUUSHI07_15: 政治活動費（9カテゴリ）
+  grantToHeadquarters: GrantToHeadquartersSection; // SYUUSHI07_16: 本部又は支部に対する交付金
 }
 
 /**

--- a/admin/src/server/domain/serializers/expense-serializer.ts
+++ b/admin/src/server/domain/serializers/expense-serializer.ts
@@ -1,0 +1,234 @@
+/**
+ * Expense Serializer
+ *
+ * Serializes expense-related domain objects into XML format.
+ * This layer is responsible only for XML generation, not data transformation.
+ */
+
+import { fragment } from "xmlbuilder2";
+import type { XMLBuilder } from "xmlbuilder2/lib/interfaces";
+import type {
+  RegularExpenseData,
+  RegularExpenseSection,
+  PoliticalActivityExpenseData,
+  PoliticalActivityExpenseSection,
+  GrantToHeadquartersSection,
+} from "../converters/expense-converter";
+import { formatAmount, formatWarekiDate } from "./utils";
+
+// ============================================================
+// Serializer Functions
+// ============================================================
+
+/**
+ * Serializes RegularExpenseData into XML format for SYUUSHI07_14.
+ */
+export function serializeRegularExpenseData(
+  data: RegularExpenseData,
+): XMLBuilder {
+  const frag = fragment();
+  const root = frag.ele("SYUUSHI07_14");
+
+  // KUBUN1: 光熱水費
+  root.import(serializeRegularExpenseKubun("KUBUN1", data.utilities));
+
+  // KUBUN2: 備品・消耗品費
+  root.import(serializeRegularExpenseKubun("KUBUN2", data.equipmentSupplies));
+
+  // KUBUN3: 事務所費
+  root.import(serializeRegularExpenseKubun("KUBUN3", data.officeExpenses));
+
+  return frag;
+}
+
+/**
+ * Serializes PoliticalActivityExpenseData into XML format for SYUUSHI07_15.
+ */
+export function serializePoliticalActivityExpenseData(
+  data: PoliticalActivityExpenseData,
+): XMLBuilder {
+  const frag = fragment();
+  const root = frag.ele("SYUUSHI07_15");
+
+  // KUBUN1: 組織活動費
+  root.import(
+    serializePoliticalActivityExpenseKubun(
+      "KUBUN1",
+      data.organizationalActivities,
+    ),
+  );
+
+  // KUBUN2: 選挙関係費
+  root.import(
+    serializePoliticalActivityExpenseKubun("KUBUN2", data.electionExpenses),
+  );
+
+  // KUBUN3: 機関紙誌の発行事業費
+  root.import(
+    serializePoliticalActivityExpenseKubun("KUBUN3", data.publicationExpenses),
+  );
+
+  // KUBUN4: 宣伝事業費
+  root.import(
+    serializePoliticalActivityExpenseKubun("KUBUN4", data.advertisingExpenses),
+  );
+
+  // KUBUN5: 政治資金パーティー開催事業費
+  root.import(
+    serializePoliticalActivityExpenseKubun(
+      "KUBUN5",
+      data.fundraisingPartyExpenses,
+    ),
+  );
+
+  // KUBUN6: その他の事業費
+  root.import(
+    serializePoliticalActivityExpenseKubun(
+      "KUBUN6",
+      data.otherBusinessExpenses,
+    ),
+  );
+
+  // KUBUN7: 調査研究費
+  root.import(
+    serializePoliticalActivityExpenseKubun("KUBUN7", data.researchExpenses),
+  );
+
+  // KUBUN8: 寄附・交付金
+  root.import(
+    serializePoliticalActivityExpenseKubun(
+      "KUBUN8",
+      data.donationsGrantsExpenses,
+    ),
+  );
+
+  // KUBUN9: その他の経費
+  root.import(
+    serializePoliticalActivityExpenseKubun("KUBUN9", data.otherExpenses),
+  );
+
+  return frag;
+}
+
+/**
+ * Serializes GrantToHeadquartersSection into XML format for SYUUSHI07_16.
+ */
+export function serializeGrantToHeadquartersSection(
+  section: GrantToHeadquartersSection,
+): XMLBuilder {
+  const frag = fragment();
+  const root = frag.ele("SYUUSHI07_16");
+  const sheet = root.ele("SHEET");
+
+  sheet.ele("KINGAKU_GK").txt(formatAmount(section.totalAmount));
+
+  for (const row of section.rows) {
+    const rowEle = sheet.ele("ROW");
+    rowEle.ele("ICHIREN_NO").txt(row.ichirenNo);
+    rowEle.ele("SHISYUTU_KMK").txt(row.shisyutuKmk);
+    rowEle.ele("KINGAKU").txt(formatAmount(row.kingaku));
+    rowEle.ele("DT").txt(formatWarekiDate(row.dt));
+    rowEle.ele("HONSIBU_NM").txt(row.honsibuNm);
+    rowEle.ele("JIMU_ADR").txt(row.jimuAdr);
+
+    if (row.bikou) {
+      rowEle.ele("BIKOU").txt(row.bikou);
+    } else {
+      rowEle.ele("BIKOU");
+    }
+  }
+
+  return frag;
+}
+
+// ============================================================
+// Helper Functions
+// ============================================================
+
+function serializeRegularExpenseKubun(
+  kubunName: string,
+  section: RegularExpenseSection,
+): XMLBuilder {
+  const frag = fragment();
+  const kubun = frag.ele(kubunName);
+  const sheet = kubun.ele("SHEET");
+
+  sheet.ele("KINGAKU_GK").txt(formatAmount(section.totalAmount));
+
+  if (section.sonotaGk > 0) {
+    sheet.ele("SONOTA_GK").txt(formatAmount(section.sonotaGk));
+  } else {
+    sheet.ele("SONOTA_GK");
+  }
+
+  for (const row of section.rows) {
+    const rowEle = sheet.ele("ROW");
+    rowEle.ele("ICHIREN_NO").txt(row.ichirenNo);
+    rowEle.ele("MOKUTEKI").txt(row.mokuteki);
+    rowEle.ele("KINGAKU").txt(formatAmount(row.kingaku));
+    rowEle.ele("DT").txt(formatWarekiDate(row.dt));
+    rowEle.ele("NM").txt(row.nm);
+    rowEle.ele("ADR").txt(row.adr);
+
+    if (row.bikou) {
+      rowEle.ele("BIKOU").txt(row.bikou);
+    } else {
+      rowEle.ele("BIKOU");
+    }
+
+    if (row.ryousyu !== undefined) {
+      rowEle.ele("RYOUSYU").txt(row.ryousyu.toString());
+    } else {
+      rowEle.ele("RYOUSYU");
+    }
+  }
+
+  return frag;
+}
+
+function serializePoliticalActivityExpenseKubun(
+  kubunName: string,
+  section: PoliticalActivityExpenseSection,
+): XMLBuilder {
+  const frag = fragment();
+  const kubun = frag.ele(kubunName);
+  const sheet = kubun.ele("SHEET");
+
+  if (section.himoku) {
+    sheet.ele("HIMOKU").txt(section.himoku);
+  } else {
+    sheet.ele("HIMOKU");
+  }
+
+  sheet.ele("KINGAKU_GK").txt(formatAmount(section.totalAmount));
+
+  if (section.sonotaGk > 0) {
+    sheet.ele("SONOTA_GK").txt(formatAmount(section.sonotaGk));
+  } else {
+    sheet.ele("SONOTA_GK");
+  }
+
+  for (const row of section.rows) {
+    const rowEle = sheet.ele("ROW");
+    rowEle.ele("ICHIREN_NO").txt(row.ichirenNo);
+    rowEle.ele("MOKUTEKI").txt(row.mokuteki);
+    rowEle.ele("KINGAKU").txt(formatAmount(row.kingaku));
+    rowEle.ele("DT").txt(formatWarekiDate(row.dt));
+    rowEle.ele("NM").txt(row.nm);
+    rowEle.ele("ADR").txt(row.adr);
+
+    if (row.bikou) {
+      rowEle.ele("BIKOU").txt(row.bikou);
+    } else {
+      rowEle.ele("BIKOU");
+    }
+
+    if (row.ryousyu !== undefined) {
+      rowEle.ele("RYOUSYU").txt(row.ryousyu.toString());
+    } else {
+      rowEle.ele("RYOUSYU");
+    }
+  }
+
+  return frag;
+}

--- a/admin/src/server/domain/serializers/report-serializer.ts
+++ b/admin/src/server/domain/serializers/report-serializer.ts
@@ -15,6 +15,11 @@ import {
   serializeLoanIncomeSection,
   serializeOtherIncomeSection,
 } from "./income-serializer";
+import {
+  serializeRegularExpenseData,
+  serializePoliticalActivityExpenseData,
+  serializeGrantToHeadquartersSection,
+} from "./expense-serializer";
 
 // ============================================================
 // Types
@@ -136,6 +141,64 @@ export function serializeReportData(
     sections.push({
       formId: "SYUUSHI07_06",
       xml: serializeOtherIncomeSection(reportData.income.otherIncome),
+    });
+  }
+
+  // SYUUSHI07_14: 経常経費（光熱水費、備品・消耗品費、事務所費）
+  const { utilities, equipmentSupplies, officeExpenses } =
+    reportData.expenses.regularExpenses;
+  const hasRegularExpenseData =
+    utilities.totalAmount > 0 ||
+    utilities.rows.length > 0 ||
+    equipmentSupplies.totalAmount > 0 ||
+    equipmentSupplies.rows.length > 0 ||
+    officeExpenses.totalAmount > 0 ||
+    officeExpenses.rows.length > 0;
+
+  if (hasRegularExpenseData) {
+    sections.push({
+      formId: "SYUUSHI07_14",
+      xml: serializeRegularExpenseData(reportData.expenses.regularExpenses),
+    });
+  }
+
+  // SYUUSHI07_15: 政治活動費（9カテゴリ）
+  const pa = reportData.expenses.politicalActivityExpenses;
+  const hasPoliticalActivityExpenseData =
+    pa.organizationalActivities.totalAmount > 0 ||
+    pa.organizationalActivities.rows.length > 0 ||
+    pa.electionExpenses.totalAmount > 0 ||
+    pa.electionExpenses.rows.length > 0 ||
+    pa.publicationExpenses.totalAmount > 0 ||
+    pa.publicationExpenses.rows.length > 0 ||
+    pa.advertisingExpenses.totalAmount > 0 ||
+    pa.advertisingExpenses.rows.length > 0 ||
+    pa.fundraisingPartyExpenses.totalAmount > 0 ||
+    pa.fundraisingPartyExpenses.rows.length > 0 ||
+    pa.otherBusinessExpenses.totalAmount > 0 ||
+    pa.otherBusinessExpenses.rows.length > 0 ||
+    pa.researchExpenses.totalAmount > 0 ||
+    pa.researchExpenses.rows.length > 0 ||
+    pa.donationsGrantsExpenses.totalAmount > 0 ||
+    pa.donationsGrantsExpenses.rows.length > 0 ||
+    pa.otherExpenses.totalAmount > 0 ||
+    pa.otherExpenses.rows.length > 0;
+
+  if (hasPoliticalActivityExpenseData) {
+    sections.push({
+      formId: "SYUUSHI07_15",
+      xml: serializePoliticalActivityExpenseData(
+        reportData.expenses.politicalActivityExpenses,
+      ),
+    });
+  }
+
+  // SYUUSHI07_16: 本部又は支部に対する交付金
+  const gh = reportData.expenses.grantToHeadquarters;
+  if (gh.totalAmount > 0 || gh.rows.length > 0) {
+    sections.push({
+      formId: "SYUUSHI07_16",
+      xml: serializeGrantToHeadquartersSection(gh),
     });
   }
 

--- a/admin/src/server/domain/types/expense-transaction.ts
+++ b/admin/src/server/domain/types/expense-transaction.ts
@@ -1,0 +1,96 @@
+/**
+ * Expense Transaction Types
+ *
+ * Input types for expense-related transactions fetched from the repository.
+ * These types represent the data structure returned by the database layer.
+ */
+
+/**
+ * 共通フィールド（全支出トランザクション共通）
+ */
+interface BaseExpenseTransaction {
+  transactionNo: string;
+  transactionDate: Date;
+  friendlyCategory: string | null;
+  label: string | null;
+  description: string | null;
+  memo: string | null;
+  debitAmount: number;
+  creditAmount: number;
+  // 支払先情報（現在はダミー値を返す）
+  counterpartName: string; // 支払先氏名/名称
+  counterpartAddress: string; // 支払先住所
+}
+
+/**
+ * SYUUSHI07_14 KUBUN1: 光熱水費のトランザクション
+ */
+export interface UtilityExpenseTransaction extends BaseExpenseTransaction {}
+
+/**
+ * SYUUSHI07_14 KUBUN2: 備品・消耗品費のトランザクション
+ */
+export interface EquipmentSuppliesExpenseTransaction
+  extends BaseExpenseTransaction {}
+
+/**
+ * SYUUSHI07_14 KUBUN3: 事務所費のトランザクション
+ */
+export interface OfficeExpenseTransaction extends BaseExpenseTransaction {}
+
+/**
+ * SYUUSHI07_15 KUBUN1: 組織活動費のトランザクション
+ */
+export interface OrganizationalExpenseTransaction
+  extends BaseExpenseTransaction {}
+
+/**
+ * SYUUSHI07_15 KUBUN2: 選挙関係費のトランザクション
+ */
+export interface ElectionExpenseTransaction extends BaseExpenseTransaction {}
+
+/**
+ * SYUUSHI07_15 KUBUN3: 機関紙誌の発行事業費のトランザクション
+ */
+export interface PublicationExpenseTransaction extends BaseExpenseTransaction {}
+
+/**
+ * SYUUSHI07_15 KUBUN4: 宣伝事業費のトランザクション
+ */
+export interface AdvertisingExpenseTransaction extends BaseExpenseTransaction {}
+
+/**
+ * SYUUSHI07_15 KUBUN5: 政治資金パーティー開催事業費のトランザクション
+ */
+export interface FundraisingPartyExpenseTransaction
+  extends BaseExpenseTransaction {}
+
+/**
+ * SYUUSHI07_15 KUBUN6: その他の事業費のトランザクション
+ */
+export interface OtherBusinessExpenseTransaction
+  extends BaseExpenseTransaction {}
+
+/**
+ * SYUUSHI07_15 KUBUN7: 調査研究費のトランザクション
+ */
+export interface ResearchExpenseTransaction extends BaseExpenseTransaction {}
+
+/**
+ * SYUUSHI07_15 KUBUN8: 寄附・交付金のトランザクション
+ */
+export interface DonationsGrantsExpenseTransaction
+  extends BaseExpenseTransaction {}
+
+/**
+ * SYUUSHI07_15 KUBUN9: その他の経費のトランザクション
+ */
+export interface OtherExpenseTransaction extends BaseExpenseTransaction {}
+
+/**
+ * SYUUSHI07_16: 本部又は支部に対する交付金のトランザクション
+ */
+export interface GrantToHeadquartersTransaction extends BaseExpenseTransaction {
+  counterpartName: string; // 本支部名称
+  counterpartAddress: string; // 主たる事務所の所在地
+}

--- a/admin/src/server/repositories/interfaces/report-transaction-repository.interface.ts
+++ b/admin/src/server/repositories/interfaces/report-transaction-repository.interface.ts
@@ -5,6 +5,21 @@ import type {
   LoanIncomeTransaction,
   OtherIncomeTransaction,
 } from "@/server/domain/types/income-transaction";
+import type {
+  UtilityExpenseTransaction,
+  EquipmentSuppliesExpenseTransaction,
+  OfficeExpenseTransaction,
+  OrganizationalExpenseTransaction,
+  ElectionExpenseTransaction,
+  PublicationExpenseTransaction,
+  AdvertisingExpenseTransaction,
+  FundraisingPartyExpenseTransaction,
+  OtherBusinessExpenseTransaction,
+  ResearchExpenseTransaction,
+  DonationsGrantsExpenseTransaction,
+  OtherExpenseTransaction,
+  GrantToHeadquartersTransaction,
+} from "@/server/domain/types/expense-transaction";
 
 export interface TransactionFilters {
   politicalOrganizationId: string;
@@ -47,6 +62,101 @@ export interface IReportTransactionRepository {
   findOtherIncomeTransactions(
     filters: TransactionFilters,
   ): Promise<OtherIncomeTransaction[]>;
+
+  // ============================================================
+  // 支出トランザクション（SYUUSHI07_14, 15, 16）
+  // ============================================================
+
+  /**
+   * SYUUSHI07_14 KUBUN1: 光熱水費のトランザクションを取得
+   */
+  findUtilityExpenseTransactions(
+    filters: TransactionFilters,
+  ): Promise<UtilityExpenseTransaction[]>;
+
+  /**
+   * SYUUSHI07_14 KUBUN2: 備品・消耗品費のトランザクションを取得
+   */
+  findEquipmentSuppliesExpenseTransactions(
+    filters: TransactionFilters,
+  ): Promise<EquipmentSuppliesExpenseTransaction[]>;
+
+  /**
+   * SYUUSHI07_14 KUBUN3: 事務所費のトランザクションを取得
+   */
+  findOfficeExpenseTransactions(
+    filters: TransactionFilters,
+  ): Promise<OfficeExpenseTransaction[]>;
+
+  /**
+   * SYUUSHI07_15 KUBUN1: 組織活動費のトランザクションを取得
+   */
+  findOrganizationalExpenseTransactions(
+    filters: TransactionFilters,
+  ): Promise<OrganizationalExpenseTransaction[]>;
+
+  /**
+   * SYUUSHI07_15 KUBUN2: 選挙関係費のトランザクションを取得
+   */
+  findElectionExpenseTransactions(
+    filters: TransactionFilters,
+  ): Promise<ElectionExpenseTransaction[]>;
+
+  /**
+   * SYUUSHI07_15 KUBUN3: 機関紙誌の発行事業費のトランザクションを取得
+   */
+  findPublicationExpenseTransactions(
+    filters: TransactionFilters,
+  ): Promise<PublicationExpenseTransaction[]>;
+
+  /**
+   * SYUUSHI07_15 KUBUN4: 宣伝事業費のトランザクションを取得
+   */
+  findAdvertisingExpenseTransactions(
+    filters: TransactionFilters,
+  ): Promise<AdvertisingExpenseTransaction[]>;
+
+  /**
+   * SYUUSHI07_15 KUBUN5: 政治資金パーティー開催事業費のトランザクションを取得
+   */
+  findFundraisingPartyExpenseTransactions(
+    filters: TransactionFilters,
+  ): Promise<FundraisingPartyExpenseTransaction[]>;
+
+  /**
+   * SYUUSHI07_15 KUBUN6: その他の事業費のトランザクションを取得
+   */
+  findOtherBusinessExpenseTransactions(
+    filters: TransactionFilters,
+  ): Promise<OtherBusinessExpenseTransaction[]>;
+
+  /**
+   * SYUUSHI07_15 KUBUN7: 調査研究費のトランザクションを取得
+   */
+  findResearchExpenseTransactions(
+    filters: TransactionFilters,
+  ): Promise<ResearchExpenseTransaction[]>;
+
+  /**
+   * SYUUSHI07_15 KUBUN8: 寄附・交付金のトランザクションを取得
+   */
+  findDonationsGrantsExpenseTransactions(
+    filters: TransactionFilters,
+  ): Promise<DonationsGrantsExpenseTransaction[]>;
+
+  /**
+   * SYUUSHI07_15 KUBUN9: その他の経費のトランザクションを取得
+   */
+  findOtherExpenseTransactions(
+    filters: TransactionFilters,
+  ): Promise<OtherExpenseTransaction[]>;
+
+  /**
+   * SYUUSHI07_16: 本部又は支部に対する交付金のトランザクションを取得
+   */
+  findGrantToHeadquartersTransactions(
+    filters: TransactionFilters,
+  ): Promise<GrantToHeadquartersTransaction[]>;
 }
 
 // Re-export for consumers
@@ -56,4 +166,17 @@ export type {
   GrantIncomeTransaction,
   LoanIncomeTransaction,
   OtherIncomeTransaction,
+  UtilityExpenseTransaction,
+  EquipmentSuppliesExpenseTransaction,
+  OfficeExpenseTransaction,
+  OrganizationalExpenseTransaction,
+  ElectionExpenseTransaction,
+  PublicationExpenseTransaction,
+  AdvertisingExpenseTransaction,
+  FundraisingPartyExpenseTransaction,
+  OtherBusinessExpenseTransaction,
+  ResearchExpenseTransaction,
+  DonationsGrantsExpenseTransaction,
+  OtherExpenseTransaction,
+  GrantToHeadquartersTransaction,
 };

--- a/admin/src/server/repositories/prisma-report-transaction.repository.ts
+++ b/admin/src/server/repositories/prisma-report-transaction.repository.ts
@@ -7,11 +7,25 @@ import type {
   OtherIncomeTransaction,
   PersonalDonationTransaction,
   TransactionFilters,
+  UtilityExpenseTransaction,
+  EquipmentSuppliesExpenseTransaction,
+  OfficeExpenseTransaction,
+  OrganizationalExpenseTransaction,
+  ElectionExpenseTransaction,
+  PublicationExpenseTransaction,
+  AdvertisingExpenseTransaction,
+  FundraisingPartyExpenseTransaction,
+  OtherBusinessExpenseTransaction,
+  ResearchExpenseTransaction,
+  DonationsGrantsExpenseTransaction,
+  OtherExpenseTransaction,
+  GrantToHeadquartersTransaction,
 } from "./interfaces/report-transaction-repository.interface";
 import { PL_CATEGORIES } from "@/shared/utils/category-mapping";
 
 // カテゴリキー定数（shared/utils/category-mapping.ts の日本語キー経由で取得）
 const CATEGORY_KEYS = {
+  // 収入
   // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
   INDIVIDUAL_DONATION: PL_CATEGORIES["個人からの寄附"].key,
   // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
@@ -21,7 +35,33 @@ const CATEGORY_KEYS = {
   // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
   GRANT: PL_CATEGORIES["本部又は支部から供与された交付金に係る収入"].key,
   // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
-  OTHER: PL_CATEGORIES["その他の収入"].key,
+  OTHER_INCOME: PL_CATEGORIES["その他の収入"].key,
+  // 支出（経常経費）
+  // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+  UTILITIES: PL_CATEGORIES["光熱水費"].key,
+  // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+  EQUIPMENT_SUPPLIES: PL_CATEGORIES["備品・消耗品費"].key,
+  // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+  OFFICE_EXPENSES: PL_CATEGORIES["事務所費"].key,
+  // 支出（政治活動費）
+  // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+  ORGANIZATIONAL_ACTIVITIES: PL_CATEGORIES["組織活動費"].key,
+  // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+  ELECTION_EXPENSES: PL_CATEGORIES["選挙関係費"].key,
+  // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+  PUBLICATION_EXPENSES: PL_CATEGORIES["機関紙誌の発行事業費"].key,
+  // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+  ADVERTISING_EXPENSES: PL_CATEGORIES["宣伝事業費"].key,
+  // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+  FUNDRAISING_PARTY_EXPENSES: PL_CATEGORIES["政治資金パーティー開催事業費"].key,
+  // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+  OTHER_BUSINESS_EXPENSES: PL_CATEGORIES["その他の事業費"].key,
+  // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+  RESEARCH_EXPENSES: PL_CATEGORIES["調査研究費"].key,
+  // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+  DONATIONS_GRANTS_EXPENSES: PL_CATEGORIES["寄附・交付金"].key,
+  // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+  OTHER_EXPENSES: PL_CATEGORIES["その他の経費"].key,
 } as const;
 
 export class PrismaReportTransactionRepository
@@ -195,7 +235,7 @@ export class PrismaReportTransactionRepository
         politicalOrganizationId: BigInt(filters.politicalOrganizationId),
         financialYear: filters.financialYear,
         transactionType: "income",
-        categoryKey: CATEGORY_KEYS.OTHER,
+        categoryKey: CATEGORY_KEYS.OTHER_INCOME,
       },
       orderBy: [{ transactionDate: "asc" }, { id: "asc" }],
       select: {
@@ -218,5 +258,203 @@ export class PrismaReportTransactionRepository
       debitAmount: Number(t.debitAmount),
       creditAmount: Number(t.creditAmount),
     }));
+  }
+
+  // ============================================================
+  // 支出トランザクション（SYUUSHI07_14, 15, 16）
+  // ============================================================
+
+  /**
+   * SYUUSHI07_14 KUBUN1: 光熱水費のトランザクションを取得
+   */
+  async findUtilityExpenseTransactions(
+    filters: TransactionFilters,
+  ): Promise<UtilityExpenseTransaction[]> {
+    return this.findExpenseTransactions(filters, CATEGORY_KEYS.UTILITIES);
+  }
+
+  /**
+   * SYUUSHI07_14 KUBUN2: 備品・消耗品費のトランザクションを取得
+   */
+  async findEquipmentSuppliesExpenseTransactions(
+    filters: TransactionFilters,
+  ): Promise<EquipmentSuppliesExpenseTransaction[]> {
+    return this.findExpenseTransactions(
+      filters,
+      CATEGORY_KEYS.EQUIPMENT_SUPPLIES,
+    );
+  }
+
+  /**
+   * SYUUSHI07_14 KUBUN3: 事務所費のトランザクションを取得
+   */
+  async findOfficeExpenseTransactions(
+    filters: TransactionFilters,
+  ): Promise<OfficeExpenseTransaction[]> {
+    return this.findExpenseTransactions(filters, CATEGORY_KEYS.OFFICE_EXPENSES);
+  }
+
+  /**
+   * SYUUSHI07_15 KUBUN1: 組織活動費のトランザクションを取得
+   */
+  async findOrganizationalExpenseTransactions(
+    filters: TransactionFilters,
+  ): Promise<OrganizationalExpenseTransaction[]> {
+    return this.findExpenseTransactions(
+      filters,
+      CATEGORY_KEYS.ORGANIZATIONAL_ACTIVITIES,
+    );
+  }
+
+  /**
+   * SYUUSHI07_15 KUBUN2: 選挙関係費のトランザクションを取得
+   */
+  async findElectionExpenseTransactions(
+    filters: TransactionFilters,
+  ): Promise<ElectionExpenseTransaction[]> {
+    return this.findExpenseTransactions(
+      filters,
+      CATEGORY_KEYS.ELECTION_EXPENSES,
+    );
+  }
+
+  /**
+   * SYUUSHI07_15 KUBUN3: 機関紙誌の発行事業費のトランザクションを取得
+   */
+  async findPublicationExpenseTransactions(
+    filters: TransactionFilters,
+  ): Promise<PublicationExpenseTransaction[]> {
+    return this.findExpenseTransactions(
+      filters,
+      CATEGORY_KEYS.PUBLICATION_EXPENSES,
+    );
+  }
+
+  /**
+   * SYUUSHI07_15 KUBUN4: 宣伝事業費のトランザクションを取得
+   */
+  async findAdvertisingExpenseTransactions(
+    filters: TransactionFilters,
+  ): Promise<AdvertisingExpenseTransaction[]> {
+    return this.findExpenseTransactions(
+      filters,
+      CATEGORY_KEYS.ADVERTISING_EXPENSES,
+    );
+  }
+
+  /**
+   * SYUUSHI07_15 KUBUN5: 政治資金パーティー開催事業費のトランザクションを取得
+   */
+  async findFundraisingPartyExpenseTransactions(
+    filters: TransactionFilters,
+  ): Promise<FundraisingPartyExpenseTransaction[]> {
+    return this.findExpenseTransactions(
+      filters,
+      CATEGORY_KEYS.FUNDRAISING_PARTY_EXPENSES,
+    );
+  }
+
+  /**
+   * SYUUSHI07_15 KUBUN6: その他の事業費のトランザクションを取得
+   */
+  async findOtherBusinessExpenseTransactions(
+    filters: TransactionFilters,
+  ): Promise<OtherBusinessExpenseTransaction[]> {
+    return this.findExpenseTransactions(
+      filters,
+      CATEGORY_KEYS.OTHER_BUSINESS_EXPENSES,
+    );
+  }
+
+  /**
+   * SYUUSHI07_15 KUBUN7: 調査研究費のトランザクションを取得
+   */
+  async findResearchExpenseTransactions(
+    filters: TransactionFilters,
+  ): Promise<ResearchExpenseTransaction[]> {
+    return this.findExpenseTransactions(
+      filters,
+      CATEGORY_KEYS.RESEARCH_EXPENSES,
+    );
+  }
+
+  /**
+   * SYUUSHI07_15 KUBUN8: 寄附・交付金のトランザクションを取得
+   */
+  async findDonationsGrantsExpenseTransactions(
+    filters: TransactionFilters,
+  ): Promise<DonationsGrantsExpenseTransaction[]> {
+    return this.findExpenseTransactions(
+      filters,
+      CATEGORY_KEYS.DONATIONS_GRANTS_EXPENSES,
+    );
+  }
+
+  /**
+   * SYUUSHI07_15 KUBUN9: その他の経費のトランザクションを取得
+   */
+  async findOtherExpenseTransactions(
+    filters: TransactionFilters,
+  ): Promise<OtherExpenseTransaction[]> {
+    return this.findExpenseTransactions(filters, CATEGORY_KEYS.OTHER_EXPENSES);
+  }
+
+  /**
+   * SYUUSHI07_16: 本部又は支部に対する交付金のトランザクションを取得
+   * 寄附・交付金カテゴリの中から交付金部分を取得
+   */
+  async findGrantToHeadquartersTransactions(
+    filters: TransactionFilters,
+  ): Promise<GrantToHeadquartersTransaction[]> {
+    return this.findExpenseTransactions(
+      filters,
+      CATEGORY_KEYS.DONATIONS_GRANTS_EXPENSES,
+    );
+  }
+
+  // ============================================================
+  // Private Helper Methods
+  // ============================================================
+
+  /**
+   * 支出トランザクションの共通取得メソッド
+   */
+  private async findExpenseTransactions<T>(
+    filters: TransactionFilters,
+    categoryKey: string,
+  ): Promise<T[]> {
+    const transactions = await this.prisma.transaction.findMany({
+      where: {
+        politicalOrganizationId: BigInt(filters.politicalOrganizationId),
+        financialYear: filters.financialYear,
+        transactionType: "expense",
+        categoryKey,
+      },
+      orderBy: [{ transactionDate: "asc" }, { id: "asc" }],
+      select: {
+        transactionNo: true,
+        transactionDate: true,
+        friendlyCategory: true,
+        label: true,
+        description: true,
+        memo: true,
+        debitAmount: true,
+        creditAmount: true,
+      },
+    });
+
+    return transactions.map((t) => ({
+      transactionNo: t.transactionNo,
+      transactionDate: t.transactionDate,
+      friendlyCategory: t.friendlyCategory,
+      label: t.label,
+      description: t.description,
+      memo: t.memo,
+      debitAmount: Number(t.debitAmount),
+      creditAmount: Number(t.creditAmount),
+      // TODO: CounterPartテーブル実装後に実際の値を取得する
+      counterpartName: "（仮）支払先名称",
+      counterpartAddress: "（仮）東京都千代田区永田町1-1-1",
+    })) as T[];
   }
 }

--- a/admin/src/server/usecases/assemblers/expense-assembler.ts
+++ b/admin/src/server/usecases/assemblers/expense-assembler.ts
@@ -1,0 +1,105 @@
+/**
+ * Expense Assembler
+ *
+ * AppService that assembles ExpenseData by fetching data from repositories
+ * and converting to domain objects.
+ */
+import "server-only";
+
+import type { IReportTransactionRepository } from "../../repositories/interfaces/report-transaction-repository.interface";
+import {
+  convertToRegularExpenseData,
+  convertToPoliticalActivityExpenseData,
+  convertToGrantToHeadquartersSection,
+} from "../../domain/converters/expense-converter";
+import type {
+  RegularExpenseData,
+  PoliticalActivityExpenseData,
+  GrantToHeadquartersSection,
+} from "../../domain/converters/expense-converter";
+
+// ============================================================
+// Types
+// ============================================================
+
+export interface ExpenseAssemblerInput {
+  politicalOrganizationId: string;
+  financialYear: number;
+}
+
+export interface ExpenseData {
+  regularExpenses: RegularExpenseData; // SYUUSHI07_14
+  politicalActivityExpenses: PoliticalActivityExpenseData; // SYUUSHI07_15
+  grantToHeadquarters: GrantToHeadquartersSection; // SYUUSHI07_16
+}
+
+// ============================================================
+// Assembler
+// ============================================================
+
+export class ExpenseAssembler {
+  constructor(private repository: IReportTransactionRepository) {}
+
+  async assemble(input: ExpenseAssemblerInput): Promise<ExpenseData> {
+    const filters = {
+      politicalOrganizationId: input.politicalOrganizationId,
+      financialYear: input.financialYear,
+    };
+
+    // SYUUSHI07_14: 経常経費（光熱水費、備品・消耗品費、事務所費）
+    const [utilities, equipmentSupplies, officeExpenses] = await Promise.all([
+      this.repository.findUtilityExpenseTransactions(filters),
+      this.repository.findEquipmentSuppliesExpenseTransactions(filters),
+      this.repository.findOfficeExpenseTransactions(filters),
+    ]);
+
+    // SYUUSHI07_15: 政治活動費（9カテゴリ）
+    const [
+      organizationalActivities,
+      electionExpenses,
+      publicationExpenses,
+      advertisingExpenses,
+      fundraisingPartyExpenses,
+      otherBusinessExpenses,
+      researchExpenses,
+      donationsGrantsExpenses,
+      otherExpenses,
+    ] = await Promise.all([
+      this.repository.findOrganizationalExpenseTransactions(filters),
+      this.repository.findElectionExpenseTransactions(filters),
+      this.repository.findPublicationExpenseTransactions(filters),
+      this.repository.findAdvertisingExpenseTransactions(filters),
+      this.repository.findFundraisingPartyExpenseTransactions(filters),
+      this.repository.findOtherBusinessExpenseTransactions(filters),
+      this.repository.findResearchExpenseTransactions(filters),
+      this.repository.findDonationsGrantsExpenseTransactions(filters),
+      this.repository.findOtherExpenseTransactions(filters),
+    ]);
+
+    // SYUUSHI07_16: 本部又は支部に対する交付金
+    const grantToHeadquartersTransactions =
+      await this.repository.findGrantToHeadquartersTransactions(filters);
+
+    return {
+      regularExpenses: convertToRegularExpenseData(
+        utilities,
+        equipmentSupplies,
+        officeExpenses,
+      ),
+      politicalActivityExpenses: convertToPoliticalActivityExpenseData(
+        organizationalActivities,
+        electionExpenses,
+        publicationExpenses,
+        advertisingExpenses,
+        fundraisingPartyExpenses,
+        otherBusinessExpenses,
+        researchExpenses,
+        donationsGrantsExpenses,
+        otherExpenses,
+      ),
+      grantToHeadquarters: convertToGrantToHeadquartersSection(
+        grantToHeadquartersTransactions,
+      ),
+    };
+  }
+}

--- a/admin/src/server/usecases/xml-export-usecase.ts
+++ b/admin/src/server/usecases/xml-export-usecase.ts
@@ -7,6 +7,7 @@ import {
 import type { ReportData } from "../domain/report-data";
 import type { DonationAssembler } from "./assemblers/donation-assembler";
 import type { IncomeAssembler } from "./assemblers/income-assembler";
+import type { ExpenseAssembler } from "./assemblers/expense-assembler";
 
 // ============================================================
 // Types
@@ -35,6 +36,7 @@ export class XmlExportUsecase {
   constructor(
     private donationAssembler: DonationAssembler,
     private incomeAssembler: IncomeAssembler,
+    private expenseAssembler: ExpenseAssembler,
   ) {}
 
   async execute(input: XmlExportInput): Promise<XmlExportResult> {
@@ -68,15 +70,16 @@ export class XmlExportUsecase {
       financialYear: input.financialYear,
     };
 
-    const [donations, income] = await Promise.all([
+    const [donations, income, expenses] = await Promise.all([
       this.donationAssembler.assemble(assemblerInput),
       this.incomeAssembler.assemble(assemblerInput),
+      this.expenseAssembler.assemble(assemblerInput),
     ]);
 
     return {
       donations,
       income,
-      expenses: {},
+      expenses,
     };
   }
 }

--- a/admin/tests/server/usecases/assemblers/income-assembler.test.ts
+++ b/admin/tests/server/usecases/assemblers/income-assembler.test.ts
@@ -26,6 +26,20 @@ describe("IncomeAssembler", () => {
       findLoanIncomeTransactions: jest.fn(),
       findGrantIncomeTransactions: jest.fn(),
       findOtherIncomeTransactions: jest.fn(),
+      // Expense methods (not used in IncomeAssembler tests)
+      findUtilityExpenseTransactions: jest.fn(),
+      findEquipmentSuppliesExpenseTransactions: jest.fn(),
+      findOfficeExpenseTransactions: jest.fn(),
+      findOrganizationalExpenseTransactions: jest.fn(),
+      findElectionExpenseTransactions: jest.fn(),
+      findPublicationExpenseTransactions: jest.fn(),
+      findAdvertisingExpenseTransactions: jest.fn(),
+      findFundraisingPartyExpenseTransactions: jest.fn(),
+      findOtherBusinessExpenseTransactions: jest.fn(),
+      findResearchExpenseTransactions: jest.fn(),
+      findDonationsGrantsExpenseTransactions: jest.fn(),
+      findOtherExpenseTransactions: jest.fn(),
+      findGrantToHeadquartersTransactions: jest.fn(),
     };
     assembler = new IncomeAssembler(mockRepository);
   });

--- a/admin/tests/server/usecases/xml-export-usecase.test.ts
+++ b/admin/tests/server/usecases/xml-export-usecase.test.ts
@@ -5,12 +5,75 @@ import {
 } from "@/server/usecases/xml-export-usecase";
 import type { DonationAssembler } from "@/server/usecases/assemblers/donation-assembler";
 import type { IncomeAssembler } from "@/server/usecases/assemblers/income-assembler";
+import type { ExpenseAssembler } from "@/server/usecases/assemblers/expense-assembler";
 import type { IncomeData } from "@/server/domain/report-data";
+
+// Empty expense data for tests
+const emptyExpenseData = {
+  regularExpenses: {
+    utilities: { totalAmount: 0, sonotaGk: 0, rows: [] },
+    equipmentSupplies: { totalAmount: 0, sonotaGk: 0, rows: [] },
+    officeExpenses: { totalAmount: 0, sonotaGk: 0, rows: [] },
+  },
+  politicalActivityExpenses: {
+    organizationalActivities: {
+      himoku: "組織活動費",
+      totalAmount: 0,
+      sonotaGk: 0,
+      rows: [],
+    },
+    electionExpenses: {
+      himoku: "選挙関係費",
+      totalAmount: 0,
+      sonotaGk: 0,
+      rows: [],
+    },
+    publicationExpenses: {
+      himoku: "機関紙誌の発行事業費",
+      totalAmount: 0,
+      sonotaGk: 0,
+      rows: [],
+    },
+    advertisingExpenses: {
+      himoku: "宣伝事業費",
+      totalAmount: 0,
+      sonotaGk: 0,
+      rows: [],
+    },
+    fundraisingPartyExpenses: {
+      himoku: "政治資金パーティー開催事業費",
+      totalAmount: 0,
+      sonotaGk: 0,
+      rows: [],
+    },
+    otherBusinessExpenses: {
+      himoku: "その他の事業費",
+      totalAmount: 0,
+      sonotaGk: 0,
+      rows: [],
+    },
+    researchExpenses: {
+      himoku: "調査研究費",
+      totalAmount: 0,
+      sonotaGk: 0,
+      rows: [],
+    },
+    donationsGrantsExpenses: {
+      himoku: "寄附・交付金",
+      totalAmount: 0,
+      sonotaGk: 0,
+      rows: [],
+    },
+    otherExpenses: { himoku: "その他の経費", totalAmount: 0, sonotaGk: 0, rows: [] },
+  },
+  grantToHeadquarters: { totalAmount: 0, rows: [] },
+};
 
 describe("XmlExportUsecase", () => {
   let usecase: XmlExportUsecase;
   let mockDonationAssembler: jest.Mocked<DonationAssembler>;
   let mockIncomeAssembler: jest.Mocked<IncomeAssembler>;
+  let mockExpenseAssembler: jest.Mocked<ExpenseAssembler>;
 
   beforeEach(() => {
     mockDonationAssembler = {
@@ -25,7 +88,14 @@ describe("XmlExportUsecase", () => {
     mockIncomeAssembler = {
       assemble: jest.fn(),
     } as unknown as jest.Mocked<IncomeAssembler>;
-    usecase = new XmlExportUsecase(mockDonationAssembler, mockIncomeAssembler);
+    mockExpenseAssembler = {
+      assemble: jest.fn().mockResolvedValue(emptyExpenseData),
+    } as unknown as jest.Mocked<ExpenseAssembler>;
+    usecase = new XmlExportUsecase(
+      mockDonationAssembler,
+      mockIncomeAssembler,
+      mockExpenseAssembler,
+    );
     jest.clearAllMocks();
   });
 


### PR DESCRIPTION
以下の問題点があることがわかった

# 問題点
「寄附」と「交付金」が区別できない
SYUUSHI07_15 KUBUN8 には「寄附」のみを出すべき
SYUUSHI07_16 には「交付金」のみを出すべき
現状は両方に同じデータが出力される（先ほど指摘した重複問題の根本原因）
本来は2つのカテゴリに分けるべき

"寄附（政治活動費）": {
  key: "political-donations-expense",
  // → SYUUSHI07_15 KUBUN8
},
"本部・支部への交付金": {
  key: "grant-to-headquarters",
  // → SYUUSHI07_16
}

# 結論
カテゴリの粒度が不足しています。現状のまま出力すると、「寄附・交付金」カテゴリのトランザクションが：
SYUUSHI07_15 KUBUN8（寄附・交付金）
SYUUSHI07_16（本部又は支部に対する交付金）
の両方に重複出力されます。 修正方針としては：
category-mapping.ts で「寄附」と「交付金」を分離する
または、トランザクション側で label や description を使って判別するロジックを追加する
どちらにするかはデータ入力フローの設計次第ですが、このままPRを出すと仕様的にバグになります。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * XML エクスポート機能に経費データを追加しました。通常経費、政治活動経費、本部への送金など複数の経費カテゴリーのエクスポートに対応しました。

* **改善**
  * エクスポート処理の依存関係を拡張し、経費情報のより包括的な取り扱いが可能になりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->