### PR TITLE
docs: CLAUDE.mdにドメインロジックの実装ルールを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,11 +64,16 @@ contexts/{コンテキスト名}/
 ├── application/
 │   └── usecases/    # loaderやactionから呼び出されるトップレベル関数
 ├── domain/
-│   ├── services/    # ドメインロジック
+│   ├── services/    # ドメインサービス（後述の例外ケース用）
 │   └── models/      # ドメインモデル
 └── infrastructure/
     └── repositories/  # データベースアクセス層
 ```
+
+### ドメインロジックの実装ルール
+
+- ドメインロジックは原則としてドメインモデルに実装する
+- ドメインサービスは複数エンティティをまたぐ場合や外部連携が必要な場合のみ使用
 
 ### import ルール
 


### PR DESCRIPTION
## Summary
- CLAUDE.mdにドメインロジックの実装ルールを追加
- ドメインロジックは原則としてドメインモデルに実装する方針を明記
- ドメインサービスの使用ケースを明確化（複数エンティティまたぎ・外部連携）

## Changes
- `services` ディレクトリのコメントを「ドメインロジック」から「ドメインサービス（後述の例外ケース用）」に更新
- 「ドメインロジックの実装ルール」セクションを新規追加

## Test plan
- [x] ドキュメントの変更のみのためテスト不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)