### PR TITLE
refactor(report): ExpenseDataに経常経費シート出力判定ロジックを移動

### DIFF
--- a/admin/src/server/contexts/report/domain/models/report-data.ts
+++ b/admin/src/server/contexts/report/domain/models/report-data.ts
@@ -12,6 +12,11 @@ import type {
   SuppliesExpenseSection,
   UtilityExpenseSection,
 } from "@/server/contexts/report/domain/models/expense-transaction";
+import {
+  OfficeExpenseSection as OfficeExpenseSectionModel,
+  SuppliesExpenseSection as SuppliesExpenseSectionModel,
+  UtilityExpenseSection as UtilityExpenseSectionModel,
+} from "@/server/contexts/report/domain/models/expense-transaction";
 import type {
   BusinessIncomeSection,
   GrantIncomeSection,
@@ -57,6 +62,23 @@ export interface ExpenseData {
   // donationExpenses: DonationExpenseSection;       // SYUUSHI07_15 KUBUN8: 寄附・交付金
   // otherExpenses: OtherExpenseSection;             // SYUUSHI07_15 KUBUN9: その他の経費
 }
+
+/**
+ * ExpenseData のドメインロジック
+ */
+export const ExpenseData = {
+  /**
+   * 経常経費シート (SYUUSHI07_14) を出力すべきかどうかを判定
+   * 光熱水費・備品消耗品費・事務所費のいずれかにデータがあれば出力
+   */
+  shouldOutputRegularExpenseSheet(data: ExpenseData): boolean {
+    return (
+      UtilityExpenseSectionModel.shouldOutputSheet(data.utilityExpenses) ||
+      SuppliesExpenseSectionModel.shouldOutputSheet(data.suppliesExpenses) ||
+      OfficeExpenseSectionModel.shouldOutputSheet(data.officeExpenses)
+    );
+  },
+};
 
 /**
  * ReportData holds all section data for generating the full XML report.

--- a/admin/src/server/contexts/report/domain/services/report-serializer.ts
+++ b/admin/src/server/contexts/report/domain/services/report-serializer.ts
@@ -8,19 +8,17 @@
 import { create } from "xmlbuilder2";
 import type { XMLBuilder } from "xmlbuilder2/lib/interfaces";
 import { PersonalDonationSection } from "@/server/contexts/report/domain/models/donation-transaction";
-import {
-  OfficeExpenseSection,
-  OrganizationExpenseSection,
-  SuppliesExpenseSection,
-  UtilityExpenseSection,
-} from "@/server/contexts/report/domain/models/expense-transaction";
+import { OrganizationExpenseSection } from "@/server/contexts/report/domain/models/expense-transaction";
 import {
   BusinessIncomeSection,
   GrantIncomeSection,
   LoanIncomeSection,
   OtherIncomeSection,
 } from "@/server/contexts/report/domain/models/income-transaction";
-import type { ReportData } from "@/server/contexts/report/domain/models/report-data";
+import {
+  ExpenseData,
+  type ReportData,
+} from "@/server/contexts/report/domain/models/report-data";
 import { serializePersonalDonationSection } from "@/server/contexts/report/domain/services/donation-serializer";
 import {
   serializeExpenseSection,
@@ -154,16 +152,7 @@ export function serializeReportData(
   }
 
   // SYUUSHI07_14: 経常経費の支出（光熱水費・備品消耗品費・事務所費）
-  const shouldOutputExpenseSheet =
-    UtilityExpenseSection.shouldOutputSheet(
-      reportData.expenses.utilityExpenses,
-    ) ||
-    SuppliesExpenseSection.shouldOutputSheet(
-      reportData.expenses.suppliesExpenses,
-    ) ||
-    OfficeExpenseSection.shouldOutputSheet(reportData.expenses.officeExpenses);
-
-  if (shouldOutputExpenseSheet) {
+  if (ExpenseData.shouldOutputRegularExpenseSheet(reportData.expenses)) {
     sections.push({
       formId: "SYUUSHI07_14",
       xml: serializeExpenseSection(


### PR DESCRIPTION
## Summary
- `ExpenseData` に `shouldOutputRegularExpenseSheet` メソッドを追加
- 光熱水費・備品消耗品費・事務所費の OR 判定ロジックをドメインモデルに集約
- `report-serializer` からドメインロジックを除去しシンプルに

## Changes
- **report-data.ts**: `ExpenseData` オブジェクトを追加し、SYUUSHI07_14 シート出力判定ロジックを集約
- **report-serializer.ts**: 3つの `shouldOutputSheet` 呼び出しを `ExpenseData.shouldOutputRegularExpenseSheet()` に置き換え

## Why
CLAUDE.MD のルール「ドメインロジックは原則としてドメインモデルに実装する」に従い、シート出力判定ロジックをサービス層から適切なドメインモデルに移動。

## Test plan
- [x] `npm run typecheck` パス
- [x] `npm run lint` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)