### PR TITLE
chore: biome行幅を80から100文字に変更

### DIFF
--- a/admin/src/app/(auth)/layout.tsx
+++ b/admin/src/app/(auth)/layout.tsx
@@ -1,17 +1,9 @@
 import "server-only";
 import { redirect } from "next/navigation";
 import Sidebar from "@/client/components/layout/Sidebar";
-import {
-  logout,
-  getCurrentUser,
-  getCurrentUserRole,
-} from "@/server/contexts/auth";
+import { logout, getCurrentUser, getCurrentUserRole } from "@/server/contexts/auth";
 
-export default async function AuthLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default async function AuthLayout({ children }: { children: React.ReactNode }) {
   const user = await getCurrentUser();
 
   if (!user) {

--- a/admin/src/app/(auth)/political-organizations/[orgId]/page.tsx
+++ b/admin/src/app/(auth)/political-organizations/[orgId]/page.tsx
@@ -22,9 +22,7 @@ export default async function EditPoliticalOrganizationPage({
     return (
       <div className="bg-primary-panel rounded-xl p-4">
         <div className="text-red-500 text-center p-10">
-          {error instanceof Error
-            ? error.message
-            : "政治団体の取得に失敗しました"}
+          {error instanceof Error ? error.message : "政治団体の取得に失敗しました"}
         </div>
       </div>
     );

--- a/admin/src/app/(auth)/political-organizations/[orgId]/report-profile/page.tsx
+++ b/admin/src/app/(auth)/political-organizations/[orgId]/report-profile/page.tsx
@@ -11,10 +11,7 @@ interface ReportProfilePageProps {
   searchParams: Promise<{ year?: string }>;
 }
 
-export default async function ReportProfilePage({
-  params,
-  searchParams,
-}: ReportProfilePageProps) {
+export default async function ReportProfilePage({ params, searchParams }: ReportProfilePageProps) {
   const { orgId } = await params;
   const { year } = await searchParams;
 
@@ -29,9 +26,7 @@ export default async function ReportProfilePage({
     return (
       <div className="bg-primary-panel rounded-xl p-4">
         <div className="text-red-500 text-center p-10">
-          {error instanceof Error
-            ? error.message
-            : "政治団体の取得に失敗しました"}
+          {error instanceof Error ? error.message : "政治団体の取得に失敗しました"}
         </div>
       </div>
     );
@@ -61,11 +56,7 @@ export default async function ReportProfilePage({
       </h1>
 
       <div className="block mb-4">
-        <YearSelector
-          orgId={orgId}
-          financialYear={financialYear}
-          currentYear={currentYear}
-        />
+        <YearSelector orgId={orgId} financialYear={financialYear} currentYear={currentYear} />
       </div>
 
       <ReportProfileForm

--- a/admin/src/app/(auth)/political-organizations/page.tsx
+++ b/admin/src/app/(auth)/political-organizations/page.tsx
@@ -38,17 +38,12 @@ export default async function PoliticalOrganizationsPage() {
               <div key={org.id} className="bg-primary-input rounded-xl p-4">
                 <div className="flex justify-between items-start gap-4">
                   <div className="flex-1">
-                    <h3 className="text-lg font-medium text-white mb-2 mt-0">
-                      {org.displayName}
-                    </h3>
+                    <h3 className="text-lg font-medium text-white mb-2 mt-0">{org.displayName}</h3>
                     {org.description && (
-                      <p className="text-primary-muted mb-3 mt-0">
-                        {org.description}
-                      </p>
+                      <p className="text-primary-muted mb-3 mt-0">{org.description}</p>
                     )}
                     <div className="text-primary-muted text-sm">
-                      作成日:{" "}
-                      {new Date(org.createdAt).toLocaleDateString("ja-JP")}
+                      作成日: {new Date(org.createdAt).toLocaleDateString("ja-JP")}
                     </div>
                   </div>
                   <div className="flex gap-2">

--- a/admin/src/app/(auth)/user-info/page.tsx
+++ b/admin/src/app/(auth)/user-info/page.tsx
@@ -9,10 +9,7 @@ export default async function UserInfoPage() {
     return <div className="card">ユーザー情報が見つかりません</div>;
   }
 
-  const createdAt =
-    user.createdAt instanceof Date
-      ? user.createdAt
-      : new Date(user.createdAt ?? 0);
+  const createdAt = user.createdAt instanceof Date ? user.createdAt : new Date(user.createdAt ?? 0);
 
   return (
     <div className="card">

--- a/admin/src/app/(public)/auth/setup/page.tsx
+++ b/admin/src/app/(public)/auth/setup/page.tsx
@@ -28,8 +28,8 @@ export default async function SetupPage({ searchParams }: SetupPageProps) {
               Complete your account setup
             </h2>
             <p className="mt-2 text-center text-sm text-gray-600">
-              You&apos;ve been invited to join Poli Money Alpha. Please set up
-              your password to continue.
+              You&apos;ve been invited to join Poli Money Alpha. Please set up your password to
+              continue.
             </p>
           </div>
           <SetupForm userEmail={user.email} />

--- a/admin/src/app/(public)/layout.tsx
+++ b/admin/src/app/(public)/layout.tsx
@@ -1,10 +1,6 @@
 import "server-only";
 
-export default function PublicLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function PublicLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="public-layout">
       <main>{children}</main>

--- a/admin/src/app/(public)/login/processor.tsx
+++ b/admin/src/app/(public)/login/processor.tsx
@@ -21,11 +21,7 @@ export default function InviteProcessor() {
         try {
           const res = await completeInviteSession(accessToken, refreshToken);
           if (res.ok) {
-            window.history.replaceState(
-              {},
-              document.title,
-              window.location.pathname,
-            );
+            window.history.replaceState({}, document.title, window.location.pathname);
             window.location.replace("/auth/setup?from=invite");
           } else {
             const err = encodeURIComponent(res.error || "invite_error");

--- a/admin/src/app/api/auth/setup-password/route.ts
+++ b/admin/src/app/api/auth/setup-password/route.ts
@@ -7,10 +7,7 @@ export async function POST(request: Request) {
     const { password } = await request.json();
 
     if (!password || typeof password !== "string") {
-      return NextResponse.json(
-        { error: "Password is required" },
-        { status: 400 },
-      );
+      return NextResponse.json({ error: "Password is required" }, { status: 400 });
     }
 
     const user = await getCurrentUser();
@@ -27,9 +24,6 @@ export async function POST(request: Request) {
     return NextResponse.json({ message: "Password set successfully" });
   } catch (error) {
     console.error("Setup password error:", error);
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }

--- a/admin/src/app/api/balance-snapshots/route.ts
+++ b/admin/src/app/api/balance-snapshots/route.ts
@@ -8,10 +8,7 @@ export async function GET(request: NextRequest) {
     const orgId = searchParams.get("orgId");
 
     if (!orgId) {
-      return NextResponse.json(
-        { error: "政治団体IDが必要です" },
-        { status: 400 },
-      );
+      return NextResponse.json({ error: "政治団体IDが必要です" }, { status: 400 });
     }
 
     const snapshots = await loadBalanceSnapshotsData(orgId);

--- a/admin/src/app/api/transactions/route.ts
+++ b/admin/src/app/api/transactions/route.ts
@@ -12,18 +12,13 @@ export async function GET(request: NextRequest) {
     const page = parseInt(searchParams.get("page") || "1", 10);
     const perPage = parseInt(searchParams.get("perPage") || "50", 10);
     const orgIds = searchParams.get("orgIds");
-    const transactionType = searchParams.get("transactionType") as
-      | "income"
-      | "expense"
-      | undefined;
+    const transactionType = searchParams.get("transactionType") as "income" | "expense" | undefined;
     const dateFromParam = searchParams.get("dateFrom");
     const dateFrom = dateFromParam ? new Date(dateFromParam) : undefined;
     const dateToParam = searchParams.get("dateTo");
     const dateTo = dateToParam ? new Date(dateToParam) : undefined;
     const financialYearParam = searchParams.get("financialYear");
-    const financialYear = financialYearParam
-      ? parseInt(financialYearParam, 10)
-      : undefined;
+    const financialYear = financialYearParam ? parseInt(financialYearParam, 10) : undefined;
 
     // Parse org IDs array from comma-separated string
     const politicalOrganizationIds = orgIds
@@ -46,9 +41,6 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(result);
   } catch (error) {
     console.error("Error fetching transactions:", error);
-    return NextResponse.json(
-      { error: "Failed to fetch transactions" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to fetch transactions" }, { status: 500 });
   }
 }

--- a/admin/src/app/api/users/create-from-invite/route.ts
+++ b/admin/src/app/api/users/create-from-invite/route.ts
@@ -7,10 +7,7 @@ export async function POST(request: Request) {
     const { authId, email } = await request.json();
 
     if (!authId || !email) {
-      return NextResponse.json(
-        { error: "Missing authId or email" },
-        { status: 400 },
-      );
+      return NextResponse.json({ error: "Missing authId or email" }, { status: 400 });
     }
 
     // Check if user already exists
@@ -36,9 +33,6 @@ export async function POST(request: Request) {
     });
   } catch (error) {
     console.error("Error creating user from invitation:", error);
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }

--- a/admin/src/app/api/users/invite/route.ts
+++ b/admin/src/app/api/users/invite/route.ts
@@ -15,16 +15,12 @@ export async function POST(request: Request) {
     if (!result.ok) {
       // バリデーションエラーのみクライアントに返し、それ以外は内部エラーとして隠す
       const isValidationError =
-        result.error === "Email is required" ||
-        result.error === "Invalid email format";
+        result.error === "Email is required" || result.error === "Invalid email format";
       if (isValidationError) {
         return NextResponse.json({ error: result.error }, { status: 400 });
       }
       console.error("Invite user failed:", result.error);
-      return NextResponse.json(
-        { error: "Internal server error" },
-        { status: 500 },
-      );
+      return NextResponse.json({ error: "Internal server error" }, { status: 500 });
     }
 
     return NextResponse.json({
@@ -32,9 +28,6 @@ export async function POST(request: Request) {
     });
   } catch (error) {
     console.error("Error sending invitation:", error);
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }

--- a/admin/src/app/api/users/role/route.ts
+++ b/admin/src/app/api/users/role/route.ts
@@ -16,10 +16,7 @@ export async function PATCH(request: NextRequest) {
     const { userId, role } = body;
 
     if (!userId || !role) {
-      return NextResponse.json(
-        { error: "Missing userId or role" },
-        { status: 400 },
-      );
+      return NextResponse.json({ error: "Missing userId or role" }, { status: 400 });
     }
 
     if (!["admin", "user"].includes(role)) {
@@ -35,9 +32,6 @@ export async function PATCH(request: NextRequest) {
     return NextResponse.json(result.user);
   } catch (error) {
     console.error("Error updating user role:", error);
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }

--- a/admin/src/app/api/users/route.ts
+++ b/admin/src/app/api/users/route.ts
@@ -14,9 +14,6 @@ export async function GET() {
     return NextResponse.json(users);
   } catch (error) {
     console.error("Error fetching users:", error);
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }

--- a/admin/src/app/api/xml-export/route.ts
+++ b/admin/src/app/api/xml-export/route.ts
@@ -10,23 +10,15 @@ import { IncomeAssembler } from "@/server/contexts/report/application/services/i
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
-  const politicalOrganizationId = url.searchParams.get(
-    "politicalOrganizationId",
-  );
+  const politicalOrganizationId = url.searchParams.get("politicalOrganizationId");
   const financialYearRaw = url.searchParams.get("financialYear");
 
   if (!politicalOrganizationId) {
-    return NextResponse.json(
-      { error: "politicalOrganizationId is required" },
-      { status: 400 },
-    );
+    return NextResponse.json({ error: "politicalOrganizationId is required" }, { status: 400 });
   }
 
   if (!financialYearRaw) {
-    return NextResponse.json(
-      { error: "financialYear is required" },
-      { status: 400 },
-    );
+    return NextResponse.json({ error: "financialYear is required" }, { status: 400 });
   }
 
   const financialYear = Number.parseInt(financialYearRaw, 10);
@@ -42,17 +34,12 @@ export async function GET(request: Request) {
   }
 
   if (!Number.isFinite(financialYear)) {
-    return NextResponse.json(
-      { error: "financialYear must be a valid number" },
-      { status: 400 },
-    );
+    return NextResponse.json({ error: "financialYear must be a valid number" }, { status: 400 });
   }
 
   try {
     const transactionRepository = new PrismaReportTransactionRepository(prisma);
-    const profileRepository = new PrismaOrganizationReportProfileRepository(
-      prisma,
-    );
+    const profileRepository = new PrismaOrganizationReportProfileRepository(prisma);
     const donationAssembler = new DonationAssembler(transactionRepository);
     const incomeAssembler = new IncomeAssembler(transactionRepository);
     const expenseAssembler = new ExpenseAssembler(transactionRepository);
@@ -78,9 +65,6 @@ export async function GET(request: Request) {
     });
   } catch (error) {
     console.error("Failed to generate XML:", error);
-    return NextResponse.json(
-      { error: "Failed to generate XML" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to generate XML" }, { status: 500 });
   }
 }

--- a/admin/src/app/layout.tsx
+++ b/admin/src/app/layout.tsx
@@ -10,11 +10,7 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ja">
       <body>

--- a/admin/src/client/components/auth/LoginForm.tsx
+++ b/admin/src/client/components/auth/LoginForm.tsx
@@ -32,18 +32,9 @@ export default function LoginForm({ action, error }: LoginFormProps) {
         </label>
         <label className="w-full">
           <div className="muted mb-2">Password</div>
-          <input
-            className="input w-full"
-            name="password"
-            type="password"
-            required
-          />
+          <input className="input w-full" name="password" type="password" required />
         </label>
-        <button
-          className="button mt-4 w-full"
-          type="submit"
-          disabled={isLoading}
-        >
+        <button className="button mt-4 w-full" type="submit" disabled={isLoading}>
           {isLoading ? "ログイン中..." : "ログイン"}
         </button>
         {error && <div className="muted mt-2">{error}</div>}

--- a/admin/src/client/components/auth/SetupForm.tsx
+++ b/admin/src/client/components/auth/SetupForm.tsx
@@ -87,9 +87,7 @@ export default function SetupForm({ userEmail }: SetupFormProps) {
           </div>
         </div>
 
-        {error && (
-          <div className="text-red-600 text-sm text-center">{error}</div>
-        )}
+        {error && <div className="text-red-600 text-sm text-center">{error}</div>}
 
         <div>
           <button

--- a/admin/src/client/components/balance-snapshots/BalanceSnapshotForm.tsx
+++ b/admin/src/client/components/balance-snapshots/BalanceSnapshotForm.tsx
@@ -89,15 +89,9 @@ export default function BalanceSnapshotForm({
 
   return (
     <div>
-      <form
-        onSubmit={handleSubmit}
-        className="flex gap-4 items-start max-w-2xl"
-      >
+      <form onSubmit={handleSubmit} className="flex gap-4 items-start max-w-2xl">
         <div className="w-48">
-          <label
-            htmlFor={dateInputId}
-            className="block text-sm font-medium text-white mb-2"
-          >
+          <label htmlFor={dateInputId} className="block text-sm font-medium text-white mb-2">
             残高日付:
           </label>
           <input
@@ -112,16 +106,11 @@ export default function BalanceSnapshotForm({
             }`}
             required
           />
-          {dateError && (
-            <p className="text-red-400 text-sm mt-1">{dateError}</p>
-          )}
+          {dateError && <p className="text-red-400 text-sm mt-1">{dateError}</p>}
         </div>
 
         <div className="w-48">
-          <label
-            htmlFor={balanceInputId}
-            className="block text-sm font-medium text-white mb-2"
-          >
+          <label htmlFor={balanceInputId} className="block text-sm font-medium text-white mb-2">
             残高 (円):
           </label>
           <input
@@ -137,18 +126,13 @@ export default function BalanceSnapshotForm({
         </div>
 
         <div className="mt-7">
-          <Button
-            type="submit"
-            disabled={!snapshotDate || !balance || isSubmitting || !!dateError}
-          >
+          <Button type="submit" disabled={!snapshotDate || !balance || isSubmitting || !!dateError}>
             {isSubmitting ? "登録中..." : "残高を登録"}
           </Button>
         </div>
       </form>
 
-      {successMessage && (
-        <div className="mt-4 text-green-400 text-sm">{successMessage}</div>
-      )}
+      {successMessage && <div className="mt-4 text-green-400 text-sm">{successMessage}</div>}
     </div>
   );
 }

--- a/admin/src/client/components/balance-snapshots/BalanceSnapshotList.tsx
+++ b/admin/src/client/components/balance-snapshots/BalanceSnapshotList.tsx
@@ -8,9 +8,7 @@ interface BalanceSnapshotListProps {
   snapshots: BalanceSnapshot[];
 }
 
-export default function BalanceSnapshotList({
-  snapshots,
-}: BalanceSnapshotListProps) {
+export default function BalanceSnapshotList({ snapshots }: BalanceSnapshotListProps) {
   const [deletingId, setDeletingId] = useState<string | null>(null);
 
   const handleDelete = async (id: string) => {
@@ -48,18 +46,10 @@ export default function BalanceSnapshotList({
       <table className="w-full border-collapse">
         <thead>
           <tr className="border-b border-primary-border">
-            <th className="px-2 py-3 text-left text-sm font-semibold text-white">
-              残高日付
-            </th>
-            <th className="px-2 py-3 text-right text-sm font-semibold text-white">
-              残高
-            </th>
-            <th className="px-2 py-3 text-left text-sm font-semibold text-white">
-              登録日時
-            </th>
-            <th className="px-2 py-3 text-center text-sm font-semibold text-white w-20">
-              操作
-            </th>
+            <th className="px-2 py-3 text-left text-sm font-semibold text-white">残高日付</th>
+            <th className="px-2 py-3 text-right text-sm font-semibold text-white">残高</th>
+            <th className="px-2 py-3 text-left text-sm font-semibold text-white">登録日時</th>
+            <th className="px-2 py-3 text-center text-sm font-semibold text-white w-20">操作</th>
           </tr>
         </thead>
         <tbody>

--- a/admin/src/client/components/balance-snapshots/BalanceSnapshotsClient.tsx
+++ b/admin/src/client/components/balance-snapshots/BalanceSnapshotsClient.tsx
@@ -14,9 +14,7 @@ interface BalanceSnapshotsClientProps {
   organizations: PoliticalOrganization[];
 }
 
-export default function BalanceSnapshotsClient({
-  organizations,
-}: BalanceSnapshotsClientProps) {
+export default function BalanceSnapshotsClient({ organizations }: BalanceSnapshotsClientProps) {
   const [selectedOrgId, setSelectedOrgId] = useState<string>("");
   const [snapshots, setSnapshots] = useState<BalanceSnapshot[]>([]);
   const [loading, setLoading] = useState(false);
@@ -111,9 +109,7 @@ export default function BalanceSnapshotsClient({
           </div>
 
           <div>
-            <h3 className="text-lg font-medium mb-4">
-              残高スナップショット一覧
-            </h3>
+            <h3 className="text-lg font-medium mb-4">残高スナップショット一覧</h3>
             {loading ? (
               <div className="text-center py-4">
                 <p className="text-primary-muted">読み込み中...</p>

--- a/admin/src/client/components/csv-import/CsvPreview.tsx
+++ b/admin/src/client/components/csv-import/CsvPreview.tsx
@@ -22,15 +22,13 @@ export default function CsvPreview({
   onPreviewComplete,
   previewAction,
 }: CsvPreviewProps) {
-  const [previewResult, setPreviewResult] = useState<PreviewMfCsvResult | null>(
-    null,
-  );
+  const [previewResult, setPreviewResult] = useState<PreviewMfCsvResult | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
-  const [activeTab, setActiveTab] = useState<
-    "all" | "insert" | "update" | "invalid" | "skip"
-  >("all");
+  const [activeTab, setActiveTab] = useState<"all" | "insert" | "update" | "invalid" | "skip">(
+    "all",
+  );
   const perPage = 10;
   const onPreviewCompleteRef = useRef(onPreviewComplete);
 
@@ -61,8 +59,7 @@ export default function CsvPreview({
         setPreviewResult(result);
         onPreviewCompleteRef.current?.(result);
       } catch (err) {
-        const errorMessage =
-          err instanceof Error ? err.message : "CSVのプレビューに失敗しました";
+        const errorMessage = err instanceof Error ? err.message : "CSVのプレビューに失敗しました";
         setError(errorMessage);
       } finally {
         setLoading(false);
@@ -81,9 +78,7 @@ export default function CsvPreview({
     }
   };
 
-  const handleTabChange = (
-    tab: "all" | "insert" | "update" | "invalid" | "skip",
-  ) => {
+  const handleTabChange = (tab: "all" | "insert" | "update" | "invalid" | "skip") => {
     setActiveTab(tab);
     setCurrentPage(1);
   };
@@ -97,9 +92,7 @@ export default function CsvPreview({
       return sortedTransactions;
     }
 
-    return sortedTransactions.filter(
-      (transaction) => transaction.status === activeTab,
-    );
+    return sortedTransactions.filter((transaction) => transaction.status === activeTab);
   };
 
   const getSortedTransactions = (): PreviewTransaction[] => {
@@ -120,9 +113,7 @@ export default function CsvPreview({
     return filteredTransactions.slice(startIndex, endIndex);
   };
 
-  const totalPages = previewResult
-    ? Math.ceil(getFilteredTransactions().length / perPage)
-    : 0;
+  const totalPages = previewResult ? Math.ceil(getFilteredTransactions().length / perPage) : 0;
 
   if (!file) return null;
 
@@ -149,9 +140,7 @@ export default function CsvPreview({
   const currentRecords = getCurrentPageRecords();
   const filteredTransactions = getFilteredTransactions();
 
-  const getTabCount = (
-    tab: "all" | "insert" | "update" | "invalid" | "skip",
-  ) => {
+  const getTabCount = (tab: "all" | "insert" | "update" | "invalid" | "skip") => {
     if (tab === "all") return previewResult.summary.totalCount;
     return previewResult.transactions.filter((t) => t.status === tab).length;
   };
@@ -207,13 +196,9 @@ export default function CsvPreview({
 
       <div className="mb-4">
         <p className="text-primary-muted">
-          {activeTab === "all" ? "全" : getTabLabel(activeTab)}{" "}
-          {filteredTransactions.length} 件中{" "}
-          {filteredTransactions.length > 0
-            ? (currentPage - 1) * perPage + 1
-            : 0}{" "}
-          - {Math.min(currentPage * perPage, filteredTransactions.length)}{" "}
-          件を表示
+          {activeTab === "all" ? "全" : getTabLabel(activeTab)} {filteredTransactions.length} 件中{" "}
+          {filteredTransactions.length > 0 ? (currentPage - 1) * perPage + 1 : 0} -{" "}
+          {Math.min(currentPage * perPage, filteredTransactions.length)} 件を表示
         </p>
       </div>
 
@@ -221,35 +206,16 @@ export default function CsvPreview({
         <table className="w-full border-collapse">
           <thead>
             <tr className="border-b border-primary-border">
+              <th className="px-2 py-3 text-left text-sm font-semibold text-white">状態</th>
+              <th className="px-2 py-3 text-left text-sm font-semibold text-white">取引日</th>
+              <th className="px-2 py-3 text-left text-sm font-semibold text-white">借方勘定科目</th>
+              <th className="px-2 py-3 text-right text-sm font-semibold text-white">借方金額</th>
+              <th className="px-2 py-3 text-left text-sm font-semibold text-white">貸方勘定科目</th>
+              <th className="px-2 py-3 text-right text-sm font-semibold text-white">貸方金額</th>
+              <th className="px-2 py-3 text-left text-sm font-semibold text-white">種別</th>
+              <th className="px-2 py-3 text-left text-sm font-semibold text-white">カテゴリ</th>
               <th className="px-2 py-3 text-left text-sm font-semibold text-white">
-                状態
-              </th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-white">
-                取引日
-              </th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-white">
-                借方勘定科目
-              </th>
-              <th className="px-2 py-3 text-right text-sm font-semibold text-white">
-                借方金額
-              </th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-white">
-                貸方勘定科目
-              </th>
-              <th className="px-2 py-3 text-right text-sm font-semibold text-white">
-                貸方金額
-              </th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-white">
-                種別
-              </th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-white">
-                カテゴリ
-              </th>
-              <th className="px-2 py-3 text-left text-sm font-semibold text-white">
-                摘要{" "}
-                <span className="text-xs font-normal">
-                  ※サービスには表示されません
-                </span>
+                摘要 <span className="text-xs font-normal">※サービスには表示されません</span>
               </th>
             </tr>
           </thead>

--- a/admin/src/client/components/csv-import/StatisticsTable.tsx
+++ b/admin/src/client/components/csv-import/StatisticsTable.tsx
@@ -50,16 +50,10 @@ export default function StatisticsTable({ statistics }: StatisticsTableProps) {
                 挿入
               </td>
               <td className="border border-primary-border px-4 py-2 text-xs text-white text-center">
-                {formatCell(
-                  statistics.insert.income.count,
-                  statistics.insert.income.amount,
-                )}
+                {formatCell(statistics.insert.income.count, statistics.insert.income.amount)}
               </td>
               <td className="border border-primary-border px-4 py-2 text-xs text-white text-center">
-                {formatCell(
-                  statistics.insert.expense.count,
-                  statistics.insert.expense.amount,
-                )}
+                {formatCell(statistics.insert.expense.count, statistics.insert.expense.amount)}
               </td>
               <td className="border border-primary-border px-4 py-2 text-xs text-white text-center">
                 {formatCell(
@@ -79,16 +73,10 @@ export default function StatisticsTable({ statistics }: StatisticsTableProps) {
                 更新
               </td>
               <td className="border border-primary-border px-4 py-2 text-xs text-white text-center">
-                {formatCell(
-                  statistics.update.income.count,
-                  statistics.update.income.amount,
-                )}
+                {formatCell(statistics.update.income.count, statistics.update.income.amount)}
               </td>
               <td className="border border-primary-border px-4 py-2 text-xs text-white text-center">
-                {formatCell(
-                  statistics.update.expense.count,
-                  statistics.update.expense.amount,
-                )}
+                {formatCell(statistics.update.expense.count, statistics.update.expense.amount)}
               </td>
               <td className="border border-primary-border px-4 py-2 text-xs text-white text-center">
                 {formatCell(
@@ -108,16 +96,10 @@ export default function StatisticsTable({ statistics }: StatisticsTableProps) {
                 無効
               </td>
               <td className="border border-primary-border px-4 py-2 text-xs text-white text-center">
-                {formatCell(
-                  statistics.invalid.income.count,
-                  statistics.invalid.income.amount,
-                )}
+                {formatCell(statistics.invalid.income.count, statistics.invalid.income.amount)}
               </td>
               <td className="border border-primary-border px-4 py-2 text-xs text-white text-center">
-                {formatCell(
-                  statistics.invalid.expense.count,
-                  statistics.invalid.expense.amount,
-                )}
+                {formatCell(statistics.invalid.expense.count, statistics.invalid.expense.amount)}
               </td>
               <td className="border border-primary-border px-4 py-2 text-xs text-white text-center">
                 {formatCell(
@@ -137,16 +119,10 @@ export default function StatisticsTable({ statistics }: StatisticsTableProps) {
                 スキップ
               </td>
               <td className="border border-primary-border px-4 py-2 text-xs text-white text-center">
-                {formatCell(
-                  statistics.skip.income.count,
-                  statistics.skip.income.amount,
-                )}
+                {formatCell(statistics.skip.income.count, statistics.skip.income.amount)}
               </td>
               <td className="border border-primary-border px-4 py-2 text-xs text-white text-center">
-                {formatCell(
-                  statistics.skip.expense.count,
-                  statistics.skip.expense.amount,
-                )}
+                {formatCell(statistics.skip.expense.count, statistics.skip.expense.amount)}
               </td>
               <td className="border border-primary-border px-4 py-2 text-xs text-white text-center">
                 {formatCell(

--- a/admin/src/client/components/csv-import/TransactionRow.tsx
+++ b/admin/src/client/components/csv-import/TransactionRow.tsx
@@ -185,9 +185,7 @@ export default function TransactionRow({
       <td className="px-2 py-3 text-sm text-white">
         {record.debit_account}
         {record.debit_sub_account && (
-          <div className="text-primary-muted text-xs">
-            {record.debit_sub_account}
-          </div>
+          <div className="text-primary-muted text-xs">{record.debit_sub_account}</div>
         )}
       </td>
       <td className="px-2 py-3 text-sm text-right text-white">
@@ -196,15 +194,11 @@ export default function TransactionRow({
       <td className="px-2 py-3 text-sm text-white">
         {record.credit_account}
         {record.credit_sub_account && (
-          <div className="text-primary-muted text-xs">
-            {record.credit_sub_account}
-          </div>
+          <div className="text-primary-muted text-xs">{record.credit_sub_account}</div>
         )}
       </td>
       <td className="px-2 py-3 text-sm text-right text-white">
-        {record.credit_amount
-          ? `¥${record.credit_amount.toLocaleString()}`
-          : "-"}
+        {record.credit_amount ? `¥${record.credit_amount.toLocaleString()}` : "-"}
       </td>
       <td className="px-2 py-3 text-sm text-white">
         <span
@@ -230,11 +224,7 @@ export default function TransactionRow({
       </td>
       <td className="px-2 py-3 text-sm text-white">
         {record.description || "-"}
-        {record.label && (
-          <div className="text-blue-400 text-xs mt-1">
-            ラベル: {record.label}
-          </div>
-        )}
+        {record.label && <div className="text-blue-400 text-xs mt-1">ラベル: {record.label}</div>}
       </td>
     </tr>
   );

--- a/admin/src/client/components/csv-upload/CsvUploadClient.tsx
+++ b/admin/src/client/components/csv-upload/CsvUploadClient.tsx
@@ -25,15 +25,12 @@ export default function CsvUploadClient({
 }: CsvUploadClientProps) {
   const csvFileInputId = useId();
   const [file, setFile] = useState<File | null>(null);
-  const [politicalOrganizationId, setPoliticalOrganizationId] =
-    useState<string>("");
+  const [politicalOrganizationId, setPoliticalOrganizationId] = useState<string>("");
   const [message, setMessage] = useState<string>("");
   const [errors, setErrors] = useState<string[]>([]);
   const [hasError, setHasError] = useState<boolean>(false);
   const [uploading, setUploading] = useState(false);
-  const [previewResult, setPreviewResult] = useState<PreviewMfCsvResult | null>(
-    null,
-  );
+  const [previewResult, setPreviewResult] = useState<PreviewMfCsvResult | null>(null);
 
   const organizationOptions = organizations.map((org) => ({
     value: org.id,
@@ -97,9 +94,7 @@ export default function CsvUploadClient({
       setFile(null);
       setPreviewResult(null);
 
-      const fileInput = document.getElementById(
-        csvFileInputId,
-      ) as HTMLInputElement;
+      const fileInput = document.getElementById(csvFileInputId) as HTMLInputElement;
       if (fileInput) {
         fileInput.value = "";
       }
@@ -129,10 +124,7 @@ export default function CsvUploadClient({
         />
       </div>
       <div>
-        <label
-          htmlFor={csvFileInputId}
-          className="block text-sm font-medium text-white mb-2"
-        >
+        <label htmlFor={csvFileInputId} className="block text-sm font-medium text-white mb-2">
           CSV File:
         </label>
         <input
@@ -157,9 +149,7 @@ export default function CsvUploadClient({
           !file ||
           !politicalOrganizationId ||
           !previewResult ||
-          previewResult.summary.insertCount +
-            previewResult.summary.updateCount ===
-            0 ||
+          previewResult.summary.insertCount + previewResult.summary.updateCount === 0 ||
           uploading;
 
         return (
@@ -167,9 +157,7 @@ export default function CsvUploadClient({
             disabled={isDisabled}
             type="submit"
             className={`bg-primary-accent text-white border-0 rounded-lg px-4 py-2.5 font-medium transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-primary-accent ${
-              isDisabled
-                ? "opacity-50 cursor-not-allowed"
-                : "hover:bg-blue-600 cursor-pointer"
+              isDisabled ? "opacity-50 cursor-not-allowed" : "hover:bg-blue-600 cursor-pointer"
             }`}
           >
             {uploading ? "Processing…" : "このデータを保存する"}

--- a/admin/src/client/components/layout/Sidebar.tsx
+++ b/admin/src/client/components/layout/Sidebar.tsx
@@ -34,9 +34,7 @@ export default function Sidebar({
 
   return (
     <aside className="bg-primary-panel p-4 flex flex-col h-full">
-      <h2 className="text-primary-muted text-lg font-medium mb-3 mt-0">
-        管理画面
-      </h2>
+      <h2 className="text-primary-muted text-lg font-medium mb-3 mt-0">管理画面</h2>
       <nav className="flex flex-col gap-2">
         {navItems.map(
           (item) =>
@@ -45,9 +43,7 @@ export default function Sidebar({
                 key={item.href}
                 href={item.href}
                 className={`text-white no-underline px-2.5 py-2 rounded-lg transition-colors duration-200 ${
-                  isActive(item.href)
-                    ? "bg-primary-hover"
-                    : "hover:bg-primary-hover"
+                  isActive(item.href) ? "bg-primary-hover" : "hover:bg-primary-hover"
                 }`}
               >
                 {item.label}

--- a/admin/src/client/components/political-organizations/DeletePoliticalOrganizationButton.tsx
+++ b/admin/src/client/components/political-organizations/DeletePoliticalOrganizationButton.tsx
@@ -45,9 +45,7 @@ export function DeletePoliticalOrganizationButton({
       onClick={handleDelete}
       disabled={deleting}
       className={`bg-red-600 text-white border-0 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-red-400 ${
-        deleting
-          ? "opacity-50 cursor-not-allowed"
-          : "hover:bg-red-700 cursor-pointer"
+        deleting ? "opacity-50 cursor-not-allowed" : "hover:bg-red-700 cursor-pointer"
       }`}
     >
       {deleting ? "削除中..." : "削除"}

--- a/admin/src/client/components/political-organizations/PoliticalOrganizationForm.tsx
+++ b/admin/src/client/components/political-organizations/PoliticalOrganizationForm.tsx
@@ -14,9 +14,7 @@ interface PoliticalOrganizationFormData {
 
 interface PoliticalOrganizationFormProps {
   initialData?: Partial<PoliticalOrganizationFormData>;
-  onSubmit: (
-    data: PoliticalOrganizationFormData,
-  ) => Promise<{ success: boolean }>;
+  onSubmit: (data: PoliticalOrganizationFormData) => Promise<{ success: boolean }>;
   submitButtonText: string;
   title: string;
 }
@@ -55,9 +53,7 @@ export function PoliticalOrganizationForm({
     }
   };
 
-  const handleInputChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-  ) => {
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = e.target;
     setFormData((prev) => ({
       ...prev,
@@ -86,10 +82,7 @@ export function PoliticalOrganizationForm({
 
       <form onSubmit={handleSubmit} className="mt-5 space-y-5">
         <div>
-          <label
-            htmlFor="displayName"
-            className="block mb-2 font-medium text-white"
-          >
+          <label htmlFor="displayName" className="block mb-2 font-medium text-white">
             表示名 <span className="text-red-500">*</span>
           </label>
           <input
@@ -106,10 +99,7 @@ export function PoliticalOrganizationForm({
         </div>
 
         <div>
-          <label
-            htmlFor="orgName"
-            className="block mb-2 font-medium text-white"
-          >
+          <label htmlFor="orgName" className="block mb-2 font-medium text-white">
             正式名称（任意）
           </label>
           <input
@@ -142,10 +132,7 @@ export function PoliticalOrganizationForm({
         </div>
 
         <div>
-          <label
-            htmlFor="description"
-            className="block mb-2 font-medium text-white"
-          >
+          <label htmlFor="description" className="block mb-2 font-medium text-white">
             説明（任意）
           </label>
           <textarea
@@ -162,9 +149,7 @@ export function PoliticalOrganizationForm({
         <div className="flex gap-3">
           <button
             type="submit"
-            disabled={
-              isLoading || !formData.displayName.trim() || !formData.slug.trim()
-            }
+            disabled={isLoading || !formData.displayName.trim() || !formData.slug.trim()}
             className={`bg-primary-accent text-white border-0 rounded-lg px-4 py-2.5 font-medium transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-primary-accent ${
               isLoading || !formData.displayName.trim() || !formData.slug.trim()
                 ? "opacity-60 cursor-not-allowed"

--- a/admin/src/client/components/report-profile/BasicInfoSection.tsx
+++ b/admin/src/client/components/report-profile/BasicInfoSection.tsx
@@ -8,10 +8,7 @@ interface BasicInfoSectionProps {
   updateFormData: (updates: Partial<OrganizationReportProfileFormData>) => void;
 }
 
-export function BasicInfoSection({
-  formData,
-  updateFormData,
-}: BasicInfoSectionProps) {
+export function BasicInfoSection({ formData, updateFormData }: BasicInfoSectionProps) {
   return (
     <div className="bg-primary-hover rounded-lg p-4">
       <h2 className="text-lg font-semibold text-white mb-4">基本情報</h2>
@@ -40,9 +37,7 @@ export function BasicInfoSection({
           <input
             type="text"
             value={formData.officialNameKana ?? ""}
-            onChange={(e) =>
-              updateFormData({ officialNameKana: e.target.value })
-            }
+            onChange={(e) => updateFormData({ officialNameKana: e.target.value })}
             maxLength={120}
             className="bg-primary-input text-white border border-primary-border rounded-lg px-3 py-2.5 w-full max-w-md mt-2 block font-normal"
             placeholder="セイジダンタイノセイシキメイショウ"
@@ -72,9 +67,7 @@ export function BasicInfoSection({
           <input
             type="text"
             value={formData.officeAddressBuilding ?? ""}
-            onChange={(e) =>
-              updateFormData({ officeAddressBuilding: e.target.value })
-            }
+            onChange={(e) => updateFormData({ officeAddressBuilding: e.target.value })}
             maxLength={60}
             className="bg-primary-input text-white border border-primary-border rounded-lg px-3 py-2.5 w-full max-w-md mt-2 block font-normal"
             placeholder="○○ビル3階"

--- a/admin/src/client/components/report-profile/ContactPersonsSection.tsx
+++ b/admin/src/client/components/report-profile/ContactPersonsSection.tsx
@@ -20,16 +20,10 @@ const emptyContactPerson = (): ContactPerson => ({
   tel: "",
 });
 
-export function ContactPersonsSection({
-  details,
-  updateDetails,
-}: ContactPersonsSectionProps) {
+export function ContactPersonsSection({ details, updateDetails }: ContactPersonsSectionProps) {
   const contactPersons = details.contactPersons ?? [];
 
-  const updateContactPerson = (
-    index: number,
-    updates: Partial<ContactPerson>,
-  ) => {
+  const updateContactPerson = (index: number, updates: Partial<ContactPerson>) => {
     const newContactPersons = [...contactPersons];
     if (index < newContactPersons.length) {
       newContactPersons[index] = { ...newContactPersons[index], ...updates };
@@ -53,9 +47,7 @@ export function ContactPersonsSection({
   return (
     <div className="bg-primary-hover rounded-lg p-4">
       <div className="flex justify-between items-center mb-4">
-        <h2 className="text-lg font-semibold text-white">
-          事務担当者（最大3名）
-        </h2>
+        <h2 className="text-lg font-semibold text-white">事務担当者（最大3名）</h2>
         {contactPersons.length < 3 && (
           <button
             type="button"
@@ -70,8 +62,7 @@ export function ContactPersonsSection({
       <div className="space-y-4">
         {contactPersons.length === 0 && (
           <p className="text-primary-muted text-sm">
-            事務担当者が登録されていません。「+
-            追加」をクリックして追加してください。
+            事務担当者が登録されていません。「+ 追加」をクリックして追加してください。
           </p>
         )}
 
@@ -81,9 +72,7 @@ export function ContactPersonsSection({
             className="bg-primary-panel rounded-lg p-3 border border-primary-border"
           >
             <div className="flex justify-between items-center mb-2">
-              <span className="text-sm text-primary-muted">
-                事務担当者 {index + 1}
-              </span>
+              <span className="text-sm text-primary-muted">事務担当者 {index + 1}</span>
               <button
                 type="button"
                 onClick={() => removeContactPerson(index)}
@@ -98,9 +87,7 @@ export function ContactPersonsSection({
                 <input
                   type="text"
                   value={person.lastName}
-                  onChange={(e) =>
-                    updateContactPerson(index, { lastName: e.target.value })
-                  }
+                  onChange={(e) => updateContactPerson(index, { lastName: e.target.value })}
                   maxLength={30}
                   className="bg-primary-input text-white border border-primary-border rounded-lg px-3 py-2 w-full mt-1 block"
                   placeholder="田中"
@@ -111,9 +98,7 @@ export function ContactPersonsSection({
                 <input
                   type="text"
                   value={person.firstName}
-                  onChange={(e) =>
-                    updateContactPerson(index, { firstName: e.target.value })
-                  }
+                  onChange={(e) => updateContactPerson(index, { firstName: e.target.value })}
                   maxLength={30}
                   className="bg-primary-input text-white border border-primary-border rounded-lg px-3 py-2 w-full mt-1 block"
                   placeholder="一郎"
@@ -124,9 +109,7 @@ export function ContactPersonsSection({
                 <input
                   type="text"
                   value={person.tel}
-                  onChange={(e) =>
-                    updateContactPerson(index, { tel: e.target.value })
-                  }
+                  onChange={(e) => updateContactPerson(index, { tel: e.target.value })}
                   maxLength={20}
                   className="bg-primary-input text-white border border-primary-border rounded-lg px-3 py-2 w-full mt-1 block"
                   placeholder="03-1234-5678"

--- a/admin/src/client/components/report-profile/DietMemberRelationSection.tsx
+++ b/admin/src/client/components/report-profile/DietMemberRelationSection.tsx
@@ -68,9 +68,7 @@ export function DietMemberRelationSection({
 
   const removeMember = (index: number) => {
     if (dietMemberRelation) {
-      const newMembers = (dietMemberRelation.members ?? []).filter(
-        (_, i) => i !== index,
-      );
+      const newMembers = (dietMemberRelation.members ?? []).filter((_, i) => i !== index);
       updateDietMemberRelation({ members: newMembers });
     }
   };
@@ -93,9 +91,7 @@ export function DietMemberRelationSection({
 
   const removePeriod = (index: number) => {
     if (dietMemberRelation) {
-      const newPeriods = (dietMemberRelation.periods ?? []).filter(
-        (_, i) => i !== index,
-      );
+      const newPeriods = (dietMemberRelation.periods ?? []).filter((_, i) => i !== index);
       updateDietMemberRelation({ periods: newPeriods });
     }
   };
@@ -147,9 +143,7 @@ export function DietMemberRelationSection({
 
           <div>
             <div className="flex justify-between items-center mb-2">
-              <h3 className="text-md font-medium text-white">
-                関係する国会議員（最大3名）
-              </h3>
+              <h3 className="text-md font-medium text-white">関係する国会議員（最大3名）</h3>
               {(dietMemberRelation.members?.length ?? 0) < 3 && (
                 <button
                   type="button"
@@ -167,9 +161,7 @@ export function DietMemberRelationSection({
                   className="bg-primary-panel rounded-lg p-3 border border-primary-border"
                 >
                   <div className="flex justify-between items-center mb-2">
-                    <span className="text-sm text-primary-muted">
-                      議員 {index + 1}
-                    </span>
+                    <span className="text-sm text-primary-muted">議員 {index + 1}</span>
                     <button
                       type="button"
                       onClick={() => removeMember(index)}
@@ -184,9 +176,7 @@ export function DietMemberRelationSection({
                       <input
                         type="text"
                         value={member.lastName}
-                        onChange={(e) =>
-                          updateMember(index, { lastName: e.target.value })
-                        }
+                        onChange={(e) => updateMember(index, { lastName: e.target.value })}
                         maxLength={30}
                         className="bg-primary-input text-white border border-primary-border rounded-lg px-3 py-2 w-full mt-1 block"
                       />
@@ -196,9 +186,7 @@ export function DietMemberRelationSection({
                       <input
                         type="text"
                         value={member.firstName}
-                        onChange={(e) =>
-                          updateMember(index, { firstName: e.target.value })
-                        }
+                        onChange={(e) => updateMember(index, { firstName: e.target.value })}
                         maxLength={30}
                         className="bg-primary-input text-white border border-primary-border rounded-lg px-3 py-2 w-full mt-1 block"
                       />
@@ -226,11 +214,7 @@ export function DietMemberRelationSection({
                         value={member.positionType}
                         onChange={(e) =>
                           updateMember(index, {
-                            positionType: e.target.value as
-                              | "1"
-                              | "2"
-                              | "3"
-                              | "4",
+                            positionType: e.target.value as "1" | "2" | "3" | "4",
                           })
                         }
                         className="bg-primary-input text-white border border-primary-border rounded-lg px-3 py-2 w-full mt-1 block"
@@ -249,9 +233,7 @@ export function DietMemberRelationSection({
 
           <div>
             <div className="flex justify-between items-center mb-2">
-              <h3 className="text-md font-medium text-white">
-                指定期間（最大3件）
-              </h3>
+              <h3 className="text-md font-medium text-white">指定期間（最大3件）</h3>
               {(dietMemberRelation.periods?.length ?? 0) < 3 && (
                 <button
                   type="button"
@@ -268,9 +250,7 @@ export function DietMemberRelationSection({
                   <input
                     type="text"
                     value={period.from}
-                    onChange={(e) =>
-                      updatePeriod(index, { from: e.target.value })
-                    }
+                    onChange={(e) => updatePeriod(index, { from: e.target.value })}
                     maxLength={20}
                     className="bg-primary-input text-white border border-primary-border rounded-lg px-3 py-2 w-32"
                     placeholder="R6/4/1"
@@ -279,9 +259,7 @@ export function DietMemberRelationSection({
                   <input
                     type="text"
                     value={period.to}
-                    onChange={(e) =>
-                      updatePeriod(index, { to: e.target.value })
-                    }
+                    onChange={(e) => updatePeriod(index, { to: e.target.value })}
                     maxLength={20}
                     className="bg-primary-input text-white border border-primary-border rounded-lg px-3 py-2 w-32"
                     placeholder="R7/3/31"

--- a/admin/src/client/components/report-profile/FundManagementSection.tsx
+++ b/admin/src/client/components/report-profile/FundManagementSection.tsx
@@ -20,10 +20,7 @@ const emptyPeriod = (): FundManagementPeriod => ({
   to: "",
 });
 
-export function FundManagementSection({
-  details,
-  updateDetails,
-}: FundManagementSectionProps) {
+export function FundManagementSection({ details, updateDetails }: FundManagementSectionProps) {
   const fundManagement = details.fundManagement;
   const isEnabled = !!fundManagement;
 
@@ -60,17 +57,12 @@ export function FundManagementSection({
 
   const removePeriod = (index: number) => {
     if (fundManagement) {
-      const newPeriods = (fundManagement.periods ?? []).filter(
-        (_, i) => i !== index,
-      );
+      const newPeriods = (fundManagement.periods ?? []).filter((_, i) => i !== index);
       updateFundManagement({ periods: newPeriods });
     }
   };
 
-  const updatePeriod = (
-    index: number,
-    updates: Partial<FundManagementPeriod>,
-  ) => {
+  const updatePeriod = (index: number, updates: Partial<FundManagementPeriod>) => {
     if (fundManagement) {
       const newPeriods = [...(fundManagement.periods ?? [])];
       newPeriods[index] = { ...newPeriods[index], ...updates };
@@ -103,9 +95,7 @@ export function FundManagementSection({
             <input
               type="text"
               value={fundManagement.publicPositionName ?? ""}
-              onChange={(e) =>
-                updateFundManagement({ publicPositionName: e.target.value })
-              }
+              onChange={(e) => updateFundManagement({ publicPositionName: e.target.value })}
               maxLength={60}
               className="bg-primary-input text-white border border-primary-border rounded-lg px-3 py-2.5 w-full max-w-md mt-2 block font-normal"
               placeholder="衆議院議員"
@@ -118,12 +108,7 @@ export function FundManagementSection({
               value={fundManagement.publicPositionType ?? ""}
               onChange={(e) =>
                 updateFundManagement({
-                  publicPositionType: e.target.value as
-                    | "1"
-                    | "2"
-                    | "3"
-                    | "4"
-                    | undefined,
+                  publicPositionType: e.target.value as "1" | "2" | "3" | "4" | undefined,
                 })
               }
               className="bg-primary-input text-white border border-primary-border rounded-lg px-3 py-2.5 mt-2 block font-normal"
@@ -180,9 +165,7 @@ export function FundManagementSection({
 
           <div>
             <div className="flex justify-between items-center mb-2">
-              <h3 className="text-md font-medium text-white">
-                指定期間（最大3件）
-              </h3>
+              <h3 className="text-md font-medium text-white">指定期間（最大3件）</h3>
               {(fundManagement.periods?.length ?? 0) < 3 && (
                 <button
                   type="button"
@@ -199,9 +182,7 @@ export function FundManagementSection({
                   <input
                     type="text"
                     value={period.from}
-                    onChange={(e) =>
-                      updatePeriod(index, { from: e.target.value })
-                    }
+                    onChange={(e) => updatePeriod(index, { from: e.target.value })}
                     maxLength={20}
                     className="bg-primary-input text-white border border-primary-border rounded-lg px-3 py-2 w-32"
                     placeholder="R6/4/1"
@@ -210,9 +191,7 @@ export function FundManagementSection({
                   <input
                     type="text"
                     value={period.to}
-                    onChange={(e) =>
-                      updatePeriod(index, { to: e.target.value })
-                    }
+                    onChange={(e) => updatePeriod(index, { to: e.target.value })}
                     maxLength={20}
                     className="bg-primary-input text-white border border-primary-border rounded-lg px-3 py-2 w-32"
                     placeholder="R7/3/31"

--- a/admin/src/client/components/report-profile/OrganizationTypeSection.tsx
+++ b/admin/src/client/components/report-profile/OrganizationTypeSection.tsx
@@ -8,15 +8,10 @@ interface OrganizationTypeSectionProps {
   updateDetails: (updates: Partial<OrganizationReportProfileDetails>) => void;
 }
 
-export function OrganizationTypeSection({
-  details,
-  updateDetails,
-}: OrganizationTypeSectionProps) {
+export function OrganizationTypeSection({ details, updateDetails }: OrganizationTypeSectionProps) {
   return (
     <div className="bg-primary-hover rounded-lg p-4">
-      <h2 className="text-lg font-semibold text-white mb-4">
-        団体区分・活動区域
-      </h2>
+      <h2 className="text-lg font-semibold text-white mb-4">団体区分・活動区域</h2>
 
       <div className="space-y-4">
         <div>
@@ -25,9 +20,7 @@ export function OrganizationTypeSection({
             <input
               type="text"
               value={details.organizationType ?? ""}
-              onChange={(e) =>
-                updateDetails({ organizationType: e.target.value })
-              }
+              onChange={(e) => updateDetails({ organizationType: e.target.value })}
               maxLength={2}
               className="bg-primary-input text-white border border-primary-border rounded-lg px-3 py-2.5 w-24 mt-2 block font-normal"
               placeholder="01"
@@ -61,17 +54,13 @@ export function OrganizationTypeSection({
             <input
               type="text"
               value={details.specificPartyDate ?? ""}
-              onChange={(e) =>
-                updateDetails({ specificPartyDate: e.target.value })
-              }
+              onChange={(e) => updateDetails({ specificPartyDate: e.target.value })}
               maxLength={20}
               className="bg-primary-input text-white border border-primary-border rounded-lg px-3 py-2.5 w-40 mt-2 block font-normal"
               placeholder="R6/4/1"
             />
           </label>
-          <p className="text-primary-muted text-sm mt-1">
-            該当する場合のみ入力（例: R6/4/1）
-          </p>
+          <p className="text-primary-muted text-sm mt-1">該当する場合のみ入力（例: R6/4/1）</p>
         </div>
       </div>
     </div>

--- a/admin/src/client/components/report-profile/ReportProfileForm.tsx
+++ b/admin/src/client/components/report-profile/ReportProfileForm.tsx
@@ -70,18 +70,14 @@ export function ReportProfileForm({
     }
   };
 
-  const updateFormData = (
-    updates: Partial<OrganizationReportProfileFormData>,
-  ) => {
+  const updateFormData = (updates: Partial<OrganizationReportProfileFormData>) => {
     setFormData((prev: OrganizationReportProfileFormData) => ({
       ...prev,
       ...updates,
     }));
   };
 
-  const updateDetails = (
-    updates: Partial<OrganizationReportProfileFormData["details"]>,
-  ) => {
+  const updateDetails = (updates: Partial<OrganizationReportProfileFormData["details"]>) => {
     setFormData((prev: OrganizationReportProfileFormData) => ({
       ...prev,
       details: { ...prev.details, ...updates },
@@ -104,39 +100,22 @@ export function ReportProfileForm({
 
       <BasicInfoSection formData={formData} updateFormData={updateFormData} />
 
-      <RepresentativeSection
-        details={formData.details}
-        updateDetails={updateDetails}
-      />
+      <RepresentativeSection details={formData.details} updateDetails={updateDetails} />
 
-      <ContactPersonsSection
-        details={formData.details}
-        updateDetails={updateDetails}
-      />
+      <ContactPersonsSection details={formData.details} updateDetails={updateDetails} />
 
-      <OrganizationTypeSection
-        details={formData.details}
-        updateDetails={updateDetails}
-      />
+      <OrganizationTypeSection details={formData.details} updateDetails={updateDetails} />
 
-      <FundManagementSection
-        details={formData.details}
-        updateDetails={updateDetails}
-      />
+      <FundManagementSection details={formData.details} updateDetails={updateDetails} />
 
-      <DietMemberRelationSection
-        details={formData.details}
-        updateDetails={updateDetails}
-      />
+      <DietMemberRelationSection details={formData.details} updateDetails={updateDetails} />
 
       <div className="flex gap-3 pt-4">
         <button
           type="submit"
           disabled={isLoading}
           className={`bg-primary-accent text-white border-0 rounded-lg px-4 py-2.5 font-medium transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-primary-accent ${
-            isLoading
-              ? "opacity-60 cursor-not-allowed"
-              : "hover:bg-blue-600 cursor-pointer"
+            isLoading ? "opacity-60 cursor-not-allowed" : "hover:bg-blue-600 cursor-pointer"
           }`}
         >
           {isLoading ? "保存中..." : "保存"}

--- a/admin/src/client/components/report-profile/RepresentativeSection.tsx
+++ b/admin/src/client/components/report-profile/RepresentativeSection.tsx
@@ -8,10 +8,7 @@ interface RepresentativeSectionProps {
   updateDetails: (updates: Partial<OrganizationReportProfileDetails>) => void;
 }
 
-export function RepresentativeSection({
-  details,
-  updateDetails,
-}: RepresentativeSectionProps) {
+export function RepresentativeSection({ details, updateDetails }: RepresentativeSectionProps) {
   const representative = details.representative ?? {
     lastName: "",
     firstName: "",
@@ -20,9 +17,7 @@ export function RepresentativeSection({
 
   return (
     <div className="bg-primary-hover rounded-lg p-4">
-      <h2 className="text-lg font-semibold text-white mb-4">
-        代表者・会計責任者
-      </h2>
+      <h2 className="text-lg font-semibold text-white mb-4">代表者・会計責任者</h2>
 
       <div className="space-y-4">
         <div>

--- a/admin/src/client/components/report-profile/YearSelector.tsx
+++ b/admin/src/client/components/report-profile/YearSelector.tsx
@@ -9,11 +9,7 @@ interface YearSelectorProps {
   currentYear: number;
 }
 
-export function YearSelector({
-  orgId,
-  financialYear,
-  currentYear,
-}: YearSelectorProps) {
+export function YearSelector({ orgId, financialYear, currentYear }: YearSelectorProps) {
   const router = useRouter();
 
   return (
@@ -24,9 +20,7 @@ export function YearSelector({
         className="bg-primary-input text-white border border-primary-border rounded-lg px-3 py-2.5 w-32 mt-2 block font-normal"
         defaultValue={financialYear}
         onChange={(e) => {
-          router.push(
-            `/political-organizations/${orgId}/report-profile?year=${e.target.value}`,
-          );
+          router.push(`/political-organizations/${orgId}/report-profile?year=${e.target.value}`);
         }}
       >
         {Array.from({ length: 10 }, (_, i) => currentYear - i).map((y) => (

--- a/admin/src/client/components/transactions/ClearWebappCacheButton.tsx
+++ b/admin/src/client/components/transactions/ClearWebappCacheButton.tsx
@@ -18,9 +18,7 @@ export function ClearWebappCacheButton() {
         alert(`エラー: ${result.message}`);
       }
     } catch (error) {
-      alert(
-        `エラー: ${error instanceof Error ? error.message : "不明なエラー"}`,
-      );
+      alert(`エラー: ${error instanceof Error ? error.message : "不明なエラー"}`);
     } finally {
       setClearing(false);
     }
@@ -32,9 +30,7 @@ export function ClearWebappCacheButton() {
       onClick={handleClearCache}
       disabled={clearing}
       className={`bg-blue-600 text-white border-0 rounded-lg px-4 py-2.5 font-medium transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-blue-400 ${
-        clearing
-          ? "opacity-50 cursor-not-allowed"
-          : "hover:bg-blue-700 cursor-pointer"
+        clearing ? "opacity-50 cursor-not-allowed" : "hover:bg-blue-700 cursor-pointer"
       }`}
     >
       {clearing ? "クリア中..." : "ウェブアプリのキャッシュをクリア"}

--- a/admin/src/client/components/transactions/DeleteAllButton.tsx
+++ b/admin/src/client/components/transactions/DeleteAllButton.tsx
@@ -48,16 +48,10 @@ export function DeleteAllButton({
       onClick={handleDeleteAll}
       disabled={deleting || disabled}
       className={`bg-red-600 text-white border-0 rounded-lg px-4 py-2.5 font-medium transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-red-400 ${
-        deleting || disabled
-          ? "opacity-50 cursor-not-allowed"
-          : "hover:bg-red-700 cursor-pointer"
+        deleting || disabled ? "opacity-50 cursor-not-allowed" : "hover:bg-red-700 cursor-pointer"
       }`}
     >
-      {deleting
-        ? "削除中..."
-        : organizationId
-          ? "この政治団体の全取引を削除"
-          : "全ての取引を削除"}
+      {deleting ? "削除中..." : organizationId ? "この政治団体の全取引を削除" : "全ての取引を削除"}
     </button>
   );
 }

--- a/admin/src/client/components/transactions/TransactionRow.tsx
+++ b/admin/src/client/components/transactions/TransactionRow.tsx
@@ -124,18 +124,14 @@ export function TransactionRow({ transaction }: TransactionRowProps) {
 
   return (
     <tr className="border-b border-primary-border">
-      <td className="px-2 py-3 text-sm text-white">
-        {formatDate(transaction.transaction_date)}
-      </td>
+      <td className="px-2 py-3 text-sm text-white">{formatDate(transaction.transaction_date)}</td>
       <td className="px-2 py-3 text-sm text-white">
         {transaction.political_organization_name || "-"}
       </td>
       <td className="px-2 py-3 text-sm text-white">
         {transaction.debit_account}
         {transaction.debit_sub_account && (
-          <div className="text-primary-muted text-xs">
-            {transaction.debit_sub_account}
-          </div>
+          <div className="text-primary-muted text-xs">{transaction.debit_sub_account}</div>
         )}
       </td>
       <td className="px-2 py-3 text-sm text-right text-white">
@@ -144,9 +140,7 @@ export function TransactionRow({ transaction }: TransactionRowProps) {
       <td className="px-2 py-3 text-sm text-white">
         {transaction.credit_account}
         {transaction.credit_sub_account && (
-          <div className="text-primary-muted text-xs">
-            {transaction.credit_sub_account}
-          </div>
+          <div className="text-primary-muted text-xs">{transaction.credit_sub_account}</div>
         )}
       </td>
       <td className="px-2 py-3 text-sm text-right text-white">
@@ -179,9 +173,7 @@ export function TransactionRow({ transaction }: TransactionRowProps) {
       <td className="px-2 py-3 text-sm text-white">
         {transaction.description || "-"}
         {transaction.label && (
-          <div className="text-blue-400 text-xs mt-1">
-            ラベル: {transaction.label}
-          </div>
+          <div className="text-blue-400 text-xs mt-1">ラベル: {transaction.label}</div>
         )}
       </td>
     </tr>

--- a/admin/src/client/components/transactions/TransactionsClient.tsx
+++ b/admin/src/client/components/transactions/TransactionsClient.tsx
@@ -144,9 +144,7 @@ export function TransactionsClient({ organizations }: TransactionsClientProps) {
         </div>
       ) : data.transactions.length === 0 ? (
         <div className="text-center py-10">
-          <p className="text-primary-muted">
-            トランザクションが登録されていません
-          </p>
+          <p className="text-primary-muted">トランザクションが登録されていません</p>
         </div>
       ) : (
         <>
@@ -154,12 +152,8 @@ export function TransactionsClient({ organizations }: TransactionsClientProps) {
             <table className="w-full border-collapse">
               <thead>
                 <tr className="border-b border-primary-border">
-                  <th className="px-2 py-3 text-left text-sm font-semibold text-white">
-                    取引日
-                  </th>
-                  <th className="px-2 py-3 text-left text-sm font-semibold text-white">
-                    政治団体
-                  </th>
+                  <th className="px-2 py-3 text-left text-sm font-semibold text-white">取引日</th>
+                  <th className="px-2 py-3 text-left text-sm font-semibold text-white">政治団体</th>
                   <th className="px-2 py-3 text-left text-sm font-semibold text-white">
                     借方勘定科目
                   </th>
@@ -172,26 +166,16 @@ export function TransactionsClient({ organizations }: TransactionsClientProps) {
                   <th className="px-2 py-3 text-right text-sm font-semibold text-white">
                     貸方金額
                   </th>
+                  <th className="px-2 py-3 text-left text-sm font-semibold text-white">種別</th>
+                  <th className="px-2 py-3 text-left text-sm font-semibold text-white">カテゴリ</th>
                   <th className="px-2 py-3 text-left text-sm font-semibold text-white">
-                    種別
-                  </th>
-                  <th className="px-2 py-3 text-left text-sm font-semibold text-white">
-                    カテゴリ
-                  </th>
-                  <th className="px-2 py-3 text-left text-sm font-semibold text-white">
-                    摘要{" "}
-                    <span className="text-xs font-normal">
-                      ※サービスには表示されません
-                    </span>
+                    摘要 <span className="text-xs font-normal">※サービスには表示されません</span>
                   </th>
                 </tr>
               </thead>
               <tbody>
                 {data.transactions.map((transaction) => (
-                  <TransactionRow
-                    key={transaction.id}
-                    transaction={transaction}
-                  />
+                  <TransactionRow key={transaction.id} transaction={transaction} />
                 ))}
               </tbody>
             </table>

--- a/admin/src/client/components/ui/Button.tsx
+++ b/admin/src/client/components/ui/Button.tsx
@@ -11,22 +11,14 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (
-    {
-      className = "",
-      variant = "primary",
-      size = "md",
-      fullWidth = false,
-      children,
-      ...props
-    },
+    { className = "", variant = "primary", size = "md", fullWidth = false, children, ...props },
     ref,
   ) => {
     const baseClasses =
       "font-medium rounded-lg border-0 cursor-pointer transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-accent";
 
     const variantClasses = {
-      primary:
-        "bg-primary-accent text-white hover:bg-blue-600 focus:ring-primary-accent",
+      primary: "bg-primary-accent text-white hover:bg-blue-600 focus:ring-primary-accent",
       secondary:
         "bg-primary-panel text-white border border-primary-border hover:bg-primary-hover focus:ring-primary-muted",
       danger: "bg-red-500 text-white hover:bg-red-600 focus:ring-red-400",

--- a/admin/src/client/components/ui/Card.tsx
+++ b/admin/src/client/components/ui/Card.tsx
@@ -17,8 +17,7 @@ const Card = forwardRef<HTMLDivElement, CardProps>(
       outlined: "bg-transparent border border-primary-border",
     };
 
-    const classes =
-      `${baseClasses} ${variantClasses[variant]} ${className}`.trim();
+    const classes = `${baseClasses} ${variantClasses[variant]} ${className}`.trim();
 
     return (
       <div ref={ref} className={classes} {...props}>

--- a/admin/src/client/components/ui/ClientPagination.tsx
+++ b/admin/src/client/components/ui/ClientPagination.tsx
@@ -8,11 +8,7 @@ interface ClientPaginationProps {
   onPageChange: (page: number) => void;
 }
 
-export function ClientPagination({
-  currentPage,
-  totalPages,
-  onPageChange,
-}: ClientPaginationProps) {
+export function ClientPagination({ currentPage, totalPages, onPageChange }: ClientPaginationProps) {
   const renderPageNumbers = () => {
     if (totalPages <= 0) return null;
 
@@ -38,10 +34,7 @@ export function ClientPagination({
 
     const addEllipsis = (key: string) => {
       pages.push(
-        <span
-          key={`ellipsis-${key}`}
-          className="px-2 text-primary-muted select-none"
-        >
+        <span key={`ellipsis-${key}`} className="px-2 text-primary-muted select-none">
           …
         </span>,
       );

--- a/admin/src/client/components/ui/Input.tsx
+++ b/admin/src/client/components/ui/Input.tsx
@@ -12,9 +12,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
   ({ className = "", error, label, id, ...props }, ref) => {
     const baseClasses =
       "bg-primary-input text-white border border-primary-border rounded-lg px-3 py-2.5 w-full transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-primary-accent focus:border-primary-accent";
-    const errorClasses = error
-      ? "border-red-500 focus:ring-red-500 focus:border-red-500"
-      : "";
+    const errorClasses = error ? "border-red-500 focus:ring-red-500 focus:border-red-500" : "";
 
     const classes = `${baseClasses} ${errorClasses} ${className}`.trim();
 

--- a/admin/src/client/components/ui/Selector.tsx
+++ b/admin/src/client/components/ui/Selector.tsx
@@ -32,10 +32,7 @@ export default function Selector({
   return (
     <div>
       {label && (
-        <label
-          htmlFor={selectId}
-          className="block text-sm font-medium text-white mb-2"
-        >
+        <label htmlFor={selectId} className="block text-sm font-medium text-white mb-2">
           {label}
         </label>
       )}

--- a/admin/src/client/components/ui/StaticPagination.tsx
+++ b/admin/src/client/components/ui/StaticPagination.tsx
@@ -9,11 +9,7 @@ interface StaticPaginationProps {
   basePath: string;
 }
 
-export function StaticPagination({
-  currentPage,
-  totalPages,
-  basePath,
-}: StaticPaginationProps) {
+export function StaticPagination({ currentPage, totalPages, basePath }: StaticPaginationProps) {
   const generatePageUrl = (page: number) => {
     return `${basePath}?page=${page}`;
   };
@@ -42,10 +38,7 @@ export function StaticPagination({
 
     const addEllipsis = (key: string) => {
       pages.push(
-        <span
-          key={`ellipsis-${key}`}
-          className="px-2 text-primary-muted select-none"
-        >
+        <span key={`ellipsis-${key}`} className="px-2 text-primary-muted select-none">
           …
         </span>,
       );

--- a/admin/src/client/components/user-management/UserManagement.tsx
+++ b/admin/src/client/components/user-management/UserManagement.tsx
@@ -32,9 +32,7 @@ export default function UserManagement({
     try {
       await apiClient.updateUserRole({ userId, role: newRole });
       setUsers((prev) =>
-        prev.map((user) =>
-          user.id === userId ? { ...user, role: newRole } : user,
-        ),
+        prev.map((user) => (user.id === userId ? { ...user, role: newRole } : user)),
       );
     } catch (error) {
       console.error("Error updating role:", error);
@@ -60,9 +58,7 @@ export default function UserManagement({
       window.location.reload();
     } catch (error) {
       console.error("Error sending invitation:", error);
-      alert(
-        `招待の送信に失敗しました: ${error instanceof Error ? error.message : "不明なエラー"}`,
-      );
+      alert(`招待の送信に失敗しました: ${error instanceof Error ? error.message : "不明なエラー"}`);
     } finally {
       setIsInviting(false);
     }
@@ -72,9 +68,7 @@ export default function UserManagement({
     <div className="space-y-4">
       {/* Invite User Form */}
       <Card>
-        <h2 className="text-lg font-medium text-white mb-4">
-          新規ユーザー招待
-        </h2>
+        <h2 className="text-lg font-medium text-white mb-4">新規ユーザー招待</h2>
         <form onSubmit={handleInviteUser} className="flex gap-4">
           <div className="flex-1">
             <Input
@@ -113,9 +107,7 @@ export default function UserManagement({
           <tbody className="bg-primary-panel divide-y divide-primary-border">
             {users.map((user) => (
               <tr key={user.id}>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-white">
-                  {user.email}
-                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-white">{user.email}</td>
                 <td className="px-6 py-4 whitespace-nowrap text-sm text-white">
                   <span
                     className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
@@ -133,9 +125,7 @@ export default function UserManagement({
                 <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
                   <select
                     value={user.role}
-                    onChange={(e) =>
-                      handleRoleChange(user.id, e.target.value as UserRole)
-                    }
+                    onChange={(e) => handleRoleChange(user.id, e.target.value as UserRole)}
                     disabled={isLoading}
                     className="bg-primary-input text-white border border-primary-border rounded-md px-3 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-primary-accent"
                   >
@@ -152,9 +142,7 @@ export default function UserManagement({
         </table>
 
         {users.length === 0 && (
-          <div className="text-center py-8 text-primary-muted">
-            ユーザーが見つかりません
-          </div>
+          <div className="text-center py-8 text-primary-muted">ユーザーが見つかりません</div>
         )}
       </Card>
     </div>

--- a/admin/src/client/components/xml-export/XmlExportClient.tsx
+++ b/admin/src/client/components/xml-export/XmlExportClient.tsx
@@ -22,14 +22,9 @@ interface StatusMessage {
 }
 
 export function XmlExportClient({ organizations }: XmlExportClientProps) {
-  const initialFinancialYear = useMemo(
-    () => new Date().getFullYear().toString(),
-    [],
-  );
+  const initialFinancialYear = useMemo(() => new Date().getFullYear().toString(), []);
 
-  const [selectedOrganizationId, setSelectedOrganizationId] = useState(
-    organizations[0]?.id ?? "",
-  );
+  const [selectedOrganizationId, setSelectedOrganizationId] = useState(organizations[0]?.id ?? "");
   const [financialYear, setFinancialYear] = useState(initialFinancialYear);
   const [previewXml, setPreviewXml] = useState("");
   const [status, setStatus] = useState<StatusMessage | null>(null);
@@ -62,8 +57,7 @@ export function XmlExportClient({ organizations }: XmlExportClientProps) {
       console.error(error);
       setStatus({
         type: "error",
-        message:
-          error instanceof Error ? error.message : "不明なエラーが発生しました",
+        message: error instanceof Error ? error.message : "不明なエラーが発生しました",
       });
     } finally {
       setIsPreviewing(false);
@@ -87,9 +81,7 @@ export function XmlExportClient({ organizations }: XmlExportClientProps) {
         const url = window.URL.createObjectURL(blob);
         const link = document.createElement("a");
         link.href = url;
-        link.download =
-          filename ||
-          `marumie_xml_${selectedOrganizationId}_${financialYear}.xml`;
+        link.download = filename || `marumie_xml_${selectedOrganizationId}_${financialYear}.xml`;
         document.body.appendChild(link);
         link.click();
         document.body.removeChild(link);
@@ -103,10 +95,7 @@ export function XmlExportClient({ organizations }: XmlExportClientProps) {
         console.error(error);
         setStatus({
           type: "error",
-          message:
-            error instanceof Error
-              ? error.message
-              : "不明なエラーが発生しました",
+          message: error instanceof Error ? error.message : "不明なエラーが発生しました",
         });
       }
     });
@@ -115,9 +104,7 @@ export function XmlExportClient({ organizations }: XmlExportClientProps) {
   if (organizations.length === 0) {
     return (
       <Card>
-        <p className="text-white">
-          政治団体が登録されていません。先に政治団体を作成してください。
-        </p>
+        <p className="text-white">政治団体が登録されていません。先に政治団体を作成してください。</p>
       </Card>
     );
   }

--- a/admin/src/client/lib/api-client.ts
+++ b/admin/src/client/lib/api-client.ts
@@ -53,9 +53,7 @@ export class ApiClient {
 
     if (!response.ok) {
       const errorData = await response.json().catch(() => ({}));
-      throw new Error(
-        errorData.error || `HTTP error! status: ${response.status}`,
-      );
+      throw new Error(errorData.error || `HTTP error! status: ${response.status}`);
     }
 
     return response.json();
@@ -75,9 +73,7 @@ export class ApiClient {
     });
   }
 
-  async setupPassword(
-    data: SetupPasswordRequest,
-  ): Promise<SetupPasswordResponse> {
+  async setupPassword(data: SetupPasswordRequest): Promise<SetupPasswordResponse> {
     return this.request<SetupPasswordResponse>("/api/auth/setup-password", {
       method: "POST",
       body: JSON.stringify(data),
@@ -85,9 +81,7 @@ export class ApiClient {
   }
 
   async getBalanceSnapshots(orgId: string): Promise<BalanceSnapshot[]> {
-    return this.request<BalanceSnapshot[]>(
-      `/api/balance-snapshots?orgId=${orgId}`,
-    );
+    return this.request<BalanceSnapshot[]>(`/api/balance-snapshots?orgId=${orgId}`);
   }
 
   async downloadXmlExport(
@@ -98,35 +92,26 @@ export class ApiClient {
       financialYear: params.financialYear,
       sections: params.sections.join(","),
     });
-    const response = await fetch(
-      `${this.baseUrl}/api/xml-export?${searchParams.toString()}`,
-    );
+    const response = await fetch(`${this.baseUrl}/api/xml-export?${searchParams.toString()}`);
 
     if (!response.ok) {
       const errorData = await response.json().catch(() => ({}));
-      throw new Error(
-        errorData.error || `HTTP error! status: ${response.status}`,
-      );
+      throw new Error(errorData.error || `HTTP error! status: ${response.status}`);
     }
 
     const blob = await response.blob();
     const contentDisposition = response.headers.get("Content-Disposition");
-    const filename =
-      this.extractFilenameFromContentDisposition(contentDisposition);
+    const filename = this.extractFilenameFromContentDisposition(contentDisposition);
 
     return { blob, filename };
   }
 
-  private extractFilenameFromContentDisposition(
-    contentDisposition: string | null,
-  ): string | null {
+  private extractFilenameFromContentDisposition(contentDisposition: string | null): string | null {
     if (!contentDisposition) {
       return null;
     }
 
-    const filenameStarMatch = contentDisposition.match(
-      /filename\*\s*=\s*UTF-8''([^;]+)/i,
-    );
+    const filenameStarMatch = contentDisposition.match(/filename\*\s*=\s*UTF-8''([^;]+)/i);
     if (filenameStarMatch?.[1]) {
       try {
         return decodeURIComponent(filenameStarMatch[1]);

--- a/admin/src/middleware.ts
+++ b/admin/src/middleware.ts
@@ -9,9 +9,7 @@ async function hashCredentials(credentials: string): Promise<string> {
   return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
 }
 
-async function performBasicAuth(
-  request: NextRequest,
-): Promise<NextResponse | null> {
+async function performBasicAuth(request: NextRequest): Promise<NextResponse | null> {
   const basicAuthSecret = process.env.BASIC_AUTH_SECRET;
 
   // ベーシック認証の環境変数がない場合は認証をスキップ
@@ -87,9 +85,7 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
   });
 
   const publicPaths = ["/login", "/auth/callback", "/auth/setup"];
-  const isPublicPath = publicPaths.some((path) =>
-    request.nextUrl.pathname.startsWith(path),
-  );
+  const isPublicPath = publicPaths.some((path) => request.nextUrl.pathname.startsWith(path));
 
   // publicパスの場合はbasic認証を実行
   if (isPublicPath) {
@@ -124,7 +120,5 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
 }
 
 export const config = {
-  matcher: [
-    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
-  ],
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)"],
 };

--- a/admin/src/server/contexts/auth/application/client.ts
+++ b/admin/src/server/contexts/auth/application/client.ts
@@ -6,9 +6,7 @@ export async function createClient() {
   const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
 
   if (!supabaseUrl || !supabaseAnonKey) {
-    throw new Error(
-      "Missing required environment variables: SUPABASE_URL and SUPABASE_ANON_KEY",
-    );
+    throw new Error("Missing required environment variables: SUPABASE_URL and SUPABASE_ANON_KEY");
   }
 
   return createServerClient(supabaseUrl, supabaseAnonKey, {

--- a/admin/src/server/contexts/auth/application/login.ts
+++ b/admin/src/server/contexts/auth/application/login.ts
@@ -32,10 +32,7 @@ export async function logout() {
   redirect("/login");
 }
 
-export async function completeInviteSession(
-  accessToken: string,
-  refreshToken: string,
-) {
+export async function completeInviteSession(accessToken: string, refreshToken: string) {
   if (!accessToken || !refreshToken) {
     return { ok: false, error: "missing_tokens" };
   }

--- a/admin/src/server/contexts/auth/application/users.ts
+++ b/admin/src/server/contexts/auth/application/users.ts
@@ -26,11 +26,7 @@ export async function getUserByAuthId(authId: string) {
 /**
  * ユーザーを作成
  */
-export async function createUser(data: {
-  authId: string;
-  email: string;
-  role?: UserRole;
-}) {
+export async function createUser(data: { authId: string; email: string; role?: UserRole }) {
   return userRepository.create(data);
 }
 

--- a/admin/src/server/contexts/data-import/application/usecases/get-transactions-usecase.ts
+++ b/admin/src/server/contexts/data-import/application/usecases/get-transactions-usecase.ts
@@ -28,18 +28,13 @@ export interface GetTransactionsResult {
 export class GetTransactionsUsecase {
   constructor(private repository: ITransactionRepository) {}
 
-  async execute(
-    params: GetTransactionsParams = {},
-  ): Promise<GetTransactionsResult> {
+  async execute(params: GetTransactionsParams = {}): Promise<GetTransactionsResult> {
     try {
       const page = Math.max(params.page || 1, 1);
       const perPage = Math.min(Math.max(params.perPage || 50, 1), 100);
 
       const filters: TransactionFilters = {};
-      if (
-        params.politicalOrganizationIds &&
-        params.politicalOrganizationIds.length > 0
-      ) {
+      if (params.politicalOrganizationIds && params.politicalOrganizationIds.length > 0) {
         filters.political_organization_ids = params.politicalOrganizationIds;
       }
       if (params.transactionType) {
@@ -60,10 +55,7 @@ export class GetTransactionsUsecase {
         perPage,
       };
 
-      const result = await this.repository.findWithPagination(
-        filters,
-        pagination,
-      );
+      const result = await this.repository.findWithPagination(filters, pagination);
 
       return {
         transactions: result.items,

--- a/admin/src/server/contexts/data-import/application/usecases/preview-mf-csv-usecase.ts
+++ b/admin/src/server/contexts/data-import/application/usecases/preview-mf-csv-usecase.ts
@@ -45,22 +45,16 @@ export class PreviewMfCsvUsecase {
       }
 
       // Get existing transactions first
-      const transactionNos = csvRecords
-        .map((record) => record.transaction_no)
-        .filter(Boolean);
+      const transactionNos = csvRecords.map((record) => record.transaction_no).filter(Boolean);
 
-      const existingTransactions =
-        await this.transactionRepository.findByTransactionNos(transactionNos, [
-          input.politicalOrganizationId,
-        ]);
+      const existingTransactions = await this.transactionRepository.findByTransactionNos(
+        transactionNos,
+        [input.politicalOrganizationId],
+      );
 
       // Convert records to preview transactions
-      const convertedTransactions: PreviewTransaction[] = csvRecords.map(
-        (record) =>
-          this.recordConverter.convertRow(
-            record,
-            input.politicalOrganizationId,
-          ),
+      const convertedTransactions: PreviewTransaction[] = csvRecords.map((record) =>
+        this.recordConverter.convertRow(record, input.politicalOrganizationId),
       );
 
       // Validate converted transactions including duplicate check

--- a/admin/src/server/contexts/data-import/application/usecases/save-preview-transactions-usecase.ts
+++ b/admin/src/server/contexts/data-import/application/usecases/save-preview-transactions-usecase.ts
@@ -22,9 +22,7 @@ export class SavePreviewTransactionsUsecase {
     private cacheInvalidator: ICacheInvalidator,
   ) {}
 
-  async execute(
-    input: SavePreviewTransactionsInput,
-  ): Promise<SavePreviewTransactionsResult> {
+  async execute(input: SavePreviewTransactionsInput): Promise<SavePreviewTransactionsResult> {
     const result: SavePreviewTransactionsResult = {
       processedCount: 0,
       savedCount: 0,
@@ -45,36 +43,24 @@ export class SavePreviewTransactionsUsecase {
       }
 
       const saveableTransactions = input.validTransactions.filter(
-        (t) =>
-          (t.status === "insert" || t.status === "update") &&
-          t.transaction_type !== null,
+        (t) => (t.status === "insert" || t.status === "update") && t.transaction_type !== null,
       );
 
       result.processedCount = input.validTransactions.length;
-      result.skippedCount = input.validTransactions.filter(
-        (t) => t.status === "skip",
-      ).length;
+      result.skippedCount = input.validTransactions.filter((t) => t.status === "skip").length;
 
       // insertとupdateに分けて処理
-      const insertTransactions = saveableTransactions.filter(
-        (t) => t.status === "insert",
-      );
-      const updateTransactions = saveableTransactions.filter(
-        (t) => t.status === "update",
-      );
+      const insertTransactions = saveableTransactions.filter((t) => t.status === "insert");
+      const updateTransactions = saveableTransactions.filter((t) => t.status === "update");
 
       let savedCount = 0;
 
       // bulk insert
       if (insertTransactions.length > 0) {
         const createInputs = insertTransactions.map((transaction) =>
-          PreviewTransaction.toCreateInput(
-            transaction,
-            input.politicalOrganizationId,
-          ),
+          PreviewTransaction.toCreateInput(transaction, input.politicalOrganizationId),
         );
-        const createdTransactions =
-          await this.transactionRepository.createMany(createInputs);
+        const createdTransactions = await this.transactionRepository.createMany(createInputs);
         savedCount += createdTransactions.length;
       }
 
@@ -87,8 +73,7 @@ export class SavePreviewTransactionsUsecase {
           },
           update: PreviewTransaction.toUpdateInput(transaction),
         }));
-        const updatedTransactions =
-          await this.transactionRepository.updateMany(updateData);
+        const updatedTransactions = await this.transactionRepository.updateMany(updateData);
         savedCount += updatedTransactions.length;
       }
 

--- a/admin/src/server/contexts/data-import/domain/models/preview-transaction.ts
+++ b/admin/src/server/contexts/data-import/domain/models/preview-transaction.ts
@@ -79,9 +79,7 @@ export const PreviewTransaction = {
       political_organization_id: politicalOrganizationId,
       transaction_no: tx.transaction_no,
       transaction_date: tx.transaction_date,
-      financial_year: PreviewTransaction.extractFinancialYear(
-        tx.transaction_date,
-      ),
+      financial_year: PreviewTransaction.extractFinancialYear(tx.transaction_date),
       transaction_type: tx.transaction_type,
       debit_account: tx.debit_account,
       debit_sub_account: tx.debit_sub_account || "",
@@ -115,9 +113,7 @@ export const PreviewTransaction = {
     return {
       transaction_no: tx.transaction_no,
       transaction_date: tx.transaction_date,
-      financial_year: PreviewTransaction.extractFinancialYear(
-        tx.transaction_date,
-      ),
+      financial_year: PreviewTransaction.extractFinancialYear(tx.transaction_date),
       transaction_type: tx.transaction_type,
       debit_account: tx.debit_account,
       debit_sub_account: tx.debit_sub_account || "",

--- a/admin/src/server/contexts/data-import/domain/services/preview-stats-calculator.ts
+++ b/admin/src/server/contexts/data-import/domain/services/preview-stats-calculator.ts
@@ -77,9 +77,7 @@ export function createEmptyPreviewStatistics(): PreviewStatistics {
   };
 }
 
-export function calculatePreviewStatistics(
-  transactions: PreviewTransaction[],
-): PreviewStatistics {
+export function calculatePreviewStatistics(transactions: PreviewTransaction[]): PreviewStatistics {
   const statistics = createEmptyPreviewStatistics();
 
   for (const transaction of transactions) {
@@ -102,9 +100,7 @@ export function calculatePreviewStatistics(
   return statistics;
 }
 
-export function calculatePreviewSummary(
-  transactions: PreviewTransaction[],
-): PreviewSummary {
+export function calculatePreviewSummary(transactions: PreviewTransaction[]): PreviewSummary {
   return {
     totalCount: transactions.length,
     insertCount: transactions.filter((t) => t.status === "insert").length,

--- a/admin/src/server/contexts/data-import/domain/services/transaction-validator.ts
+++ b/admin/src/server/contexts/data-import/domain/services/transaction-validator.ts
@@ -92,21 +92,17 @@ export class TransactionValidator {
     return errors;
   }
 
-  private validateFriendlyCategory(
-    transaction: PreviewTransaction,
-  ): string | null {
+  private validateFriendlyCategory(transaction: PreviewTransaction): string | null {
     const isOffsetTransaction =
       transaction.debit_account === OFFSET_EXPENSE_ACCOUNT ||
       transaction.credit_account === OFFSET_INCOME_ACCOUNT;
 
-    const isNonCashTransaction =
-      transaction.transaction_type === "non_cash_journal";
+    const isNonCashTransaction = transaction.transaction_type === "non_cash_journal";
 
     if (
       !isOffsetTransaction &&
       !isNonCashTransaction &&
-      (!transaction.friendly_category ||
-        transaction.friendly_category.trim() === "")
+      (!transaction.friendly_category || transaction.friendly_category.trim() === "")
     ) {
       return "独自のカテゴリが設定されていません";
     }

--- a/admin/src/server/contexts/data-import/infrastructure/mf/mf-csv-loader.ts
+++ b/admin/src/server/contexts/data-import/infrastructure/mf/mf-csv-loader.ts
@@ -66,9 +66,7 @@ export class MfCsvLoader {
       throw new Error("Invalid CSV format: no headers found");
     }
 
-    const hasValidHeaders = headers.some(
-      (header) => header in this.columnMapping,
-    );
+    const hasValidHeaders = headers.some((header) => header in this.columnMapping);
     if (!hasValidHeaders) {
       throw new Error("Invalid CSV format: no recognized headers found");
     }

--- a/admin/src/server/contexts/data-import/infrastructure/mf/mf-record-converter.ts
+++ b/admin/src/server/contexts/data-import/infrastructure/mf/mf-record-converter.ts
@@ -1,23 +1,13 @@
 import type { MfCsvRecord } from "@/server/contexts/data-import/infrastructure/mf/mf-csv-loader";
-import {
-  PL_CATEGORIES,
-  BS_CATEGORIES,
-  CASH_ACCOUNTS,
-} from "@/shared/utils/category-mapping";
+import { PL_CATEGORIES, BS_CATEGORIES, CASH_ACCOUNTS } from "@/shared/utils/category-mapping";
 import type { TransactionType } from "@/shared/models/transaction";
 import { PreviewTransaction } from "@/server/contexts/data-import/domain/models/preview-transaction";
 
 export class MfRecordConverter {
-  public convertRow(
-    record: MfCsvRecord,
-    politicalOrganizationId: string,
-  ): PreviewTransaction {
+  public convertRow(record: MfCsvRecord, politicalOrganizationId: string): PreviewTransaction {
     const debitAmount = this.parseAmount(record.debit_amount);
     const creditAmount = this.parseAmount(record.credit_amount);
-    const categoryKey = this.determineCategoryKey(
-      record.debit_account,
-      record.credit_account,
-    );
+    const categoryKey = this.determineCategoryKey(record.debit_account, record.credit_account);
     const transactionType = this.determineTransactionType(
       record.debit_account,
       record.credit_account,
@@ -25,9 +15,7 @@ export class MfRecordConverter {
 
     const friendlyCategory = record.friendly_category;
 
-    const label = this.shouldDisplayDescription(record)
-      ? record.description
-      : undefined;
+    const label = this.shouldDisplayDescription(record) ? record.description : undefined;
 
     // Determine status and errors based on conversion
     let status: "insert" | "update" | "invalid" | "skip" = "insert";
@@ -41,8 +29,9 @@ export class MfRecordConverter {
     }
 
     // Parse transaction date with validation
-    const { date: transactionDate, isValid: isDateValid } =
-      this.parseTransactionDate(record.transaction_date);
+    const { date: transactionDate, isValid: isDateValid } = this.parseTransactionDate(
+      record.transaction_date,
+    );
     if (!isDateValid) {
       status = "invalid";
       errors.push(`Invalid date format: ${record.transaction_date}`);
@@ -98,14 +87,10 @@ export class MfRecordConverter {
 
     const descriptionStartsWithDebit = description.startsWith("デビット");
     const containsUpsider =
-      normalizedDescription.includes("upsider") ||
-      normalizedMemo.includes("upsider");
-    const containsAmex =
-      normalizedDescription.includes("amex") || normalizedMemo.includes("amex");
+      normalizedDescription.includes("upsider") || normalizedMemo.includes("upsider");
+    const containsAmex = normalizedDescription.includes("amex") || normalizedMemo.includes("amex");
 
-    return Boolean(
-      descriptionStartsWithDebit || containsUpsider || containsAmex,
-    );
+    return Boolean(descriptionStartsWithDebit || containsUpsider || containsAmex);
   }
 
   private parseAmount(amountStr: string): number {
@@ -119,10 +104,7 @@ export class MfRecordConverter {
     return Number.isNaN(parsed) ? 0 : parsed;
   }
 
-  private determineCategoryKey(
-    debitAccount: string,
-    creditAccount: string,
-  ): string {
+  private determineCategoryKey(debitAccount: string, creditAccount: string): string {
     const isDebitPL = debitAccount in PL_CATEGORIES;
     const isCreditPL = creditAccount in PL_CATEGORIES;
 

--- a/admin/src/server/contexts/data-import/presentation/actions/delete-all-transactions.ts
+++ b/admin/src/server/contexts/data-import/presentation/actions/delete-all-transactions.ts
@@ -5,9 +5,7 @@ import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaTransactionRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-transaction.repository";
 import { DeleteAllTransactionsUsecase } from "@/server/contexts/data-import/application/usecases/delete-all-transactions-usecase";
 
-export async function deleteAllTransactionsAction(
-  organizationId?: string,
-): Promise<{
+export async function deleteAllTransactionsAction(organizationId?: string): Promise<{
   success: boolean;
   deletedCount?: number;
   error?: string;

--- a/admin/src/server/contexts/data-import/presentation/actions/preview-csv.ts
+++ b/admin/src/server/contexts/data-import/presentation/actions/preview-csv.ts
@@ -13,9 +13,7 @@ export interface PreviewCsvRequest {
   politicalOrganizationId: string;
 }
 
-export async function previewCsv(
-  data: PreviewCsvRequest,
-): Promise<PreviewMfCsvResult> {
+export async function previewCsv(data: PreviewCsvRequest): Promise<PreviewMfCsvResult> {
   "use server";
   try {
     const { file, politicalOrganizationId } = data;
@@ -40,9 +38,7 @@ export async function previewCsv(
     return result;
   } catch (error) {
     console.error("Preview CSV error:", error);
-    throw error instanceof Error
-      ? error
-      : new Error("サーバー内部エラーが発生しました");
+    throw error instanceof Error ? error : new Error("サーバー内部エラーが発生しました");
   } finally {
     await prisma.$disconnect();
   }

--- a/admin/src/server/contexts/data-import/presentation/actions/upload-csv.ts
+++ b/admin/src/server/contexts/data-import/presentation/actions/upload-csv.ts
@@ -9,10 +9,7 @@ import type { PreviewTransaction } from "@/server/contexts/data-import/domain/mo
 
 const transactionRepository = new PrismaTransactionRepository(prisma);
 const cacheInvalidator = new WebappCacheInvalidator();
-const uploadUsecase = new SavePreviewTransactionsUsecase(
-  transactionRepository,
-  cacheInvalidator,
-);
+const uploadUsecase = new SavePreviewTransactionsUsecase(transactionRepository, cacheInvalidator);
 
 export interface UploadCsvRequest {
   validTransactions: PreviewTransaction[];
@@ -28,9 +25,7 @@ export interface UploadCsvResponse {
   errors?: string[];
 }
 
-export async function uploadCsv(
-  data: UploadCsvRequest,
-): Promise<UploadCsvResponse> {
+export async function uploadCsv(data: UploadCsvRequest): Promise<UploadCsvResponse> {
   "use server";
   try {
     const { validTransactions, politicalOrganizationId } = data;
@@ -77,8 +72,6 @@ export async function uploadCsv(
     };
   } catch (error) {
     console.error("Upload CSV error:", error);
-    throw error instanceof Error
-      ? error
-      : new Error("サーバー内部エラーが発生しました");
+    throw error instanceof Error ? error : new Error("サーバー内部エラーが発生しました");
   }
 }

--- a/admin/src/server/contexts/data-import/presentation/loaders/load-transactions-data.ts
+++ b/admin/src/server/contexts/data-import/presentation/loaders/load-transactions-data.ts
@@ -11,9 +11,7 @@ import {
 const CACHE_REVALIDATE_SECONDS = 5;
 
 export const loadTransactionsData = unstable_cache(
-  async (
-    params: GetTransactionsParams = {},
-  ): Promise<GetTransactionsResult> => {
+  async (params: GetTransactionsParams = {}): Promise<GetTransactionsResult> => {
     const repository = new PrismaTransactionRepository(prisma);
     const usecase = new GetTransactionsUsecase(repository);
 

--- a/admin/src/server/contexts/report/application/services/donation-assembler.ts
+++ b/admin/src/server/contexts/report/application/services/donation-assembler.ts
@@ -42,9 +42,7 @@ export class DonationAssembler {
       await this.repository.findPersonalDonationTransactions(filters);
 
     return {
-      personalDonations: PersonalDonationSection.fromTransactions(
-        personalDonationTransactions,
-      ),
+      personalDonations: PersonalDonationSection.fromTransactions(personalDonationTransactions),
     };
   }
 }

--- a/admin/src/server/contexts/report/application/services/expense-assembler.ts
+++ b/admin/src/server/contexts/report/application/services/expense-assembler.ts
@@ -75,34 +75,22 @@ export class ExpenseAssembler {
 
     return {
       // SYUUSHI07_14: 経常経費
-      utilityExpenses:
-        UtilityExpenseSection.fromTransactions(utilityTransactions),
-      suppliesExpenses:
-        SuppliesExpenseSection.fromTransactions(suppliesTransactions),
+      utilityExpenses: UtilityExpenseSection.fromTransactions(utilityTransactions),
+      suppliesExpenses: SuppliesExpenseSection.fromTransactions(suppliesTransactions),
       officeExpenses: OfficeExpenseSection.fromTransactions(officeTransactions),
       // SYUUSHI07_15: 政治活動費（全9区分）
-      organizationExpenses: OrganizationExpenseSection.fromTransactions(
-        organizationTransactions,
-      ),
-      electionExpenses:
-        ElectionExpenseSection.fromTransactions(electionTransactions),
-      publicationExpenses: PublicationExpenseSection.fromTransactions(
-        publicationTransactions,
-      ),
-      advertisingExpenses: AdvertisingExpenseSection.fromTransactions(
-        advertisingTransactions,
-      ),
+      organizationExpenses: OrganizationExpenseSection.fromTransactions(organizationTransactions),
+      electionExpenses: ElectionExpenseSection.fromTransactions(electionTransactions),
+      publicationExpenses: PublicationExpenseSection.fromTransactions(publicationTransactions),
+      advertisingExpenses: AdvertisingExpenseSection.fromTransactions(advertisingTransactions),
       fundraisingPartyExpenses: FundraisingPartyExpenseSection.fromTransactions(
         fundraisingPartyTransactions,
       ),
-      otherBusinessExpenses: OtherBusinessExpenseSection.fromTransactions(
-        otherBusinessTransactions,
-      ),
-      researchExpenses:
-        ResearchExpenseSection.fromTransactions(researchTransactions),
-      donationGrantExpenses: DonationGrantExpenseSection.fromTransactions(
-        donationGrantTransactions,
-      ),
+      otherBusinessExpenses:
+        OtherBusinessExpenseSection.fromTransactions(otherBusinessTransactions),
+      researchExpenses: ResearchExpenseSection.fromTransactions(researchTransactions),
+      donationGrantExpenses:
+        DonationGrantExpenseSection.fromTransactions(donationGrantTransactions),
       otherPoliticalExpenses: OtherPoliticalExpenseSection.fromTransactions(
         otherPoliticalTransactions,
       ),

--- a/admin/src/server/contexts/report/application/services/income-assembler.ts
+++ b/admin/src/server/contexts/report/application/services/income-assembler.ts
@@ -37,21 +37,16 @@ export class IncomeAssembler {
       financialYear: input.financialYear,
     };
 
-    const [
-      businessTransactions,
-      loanTransactions,
-      grantTransactions,
-      otherTransactions,
-    ] = await Promise.all([
-      this.repository.findBusinessIncomeTransactions(filters),
-      this.repository.findLoanIncomeTransactions(filters),
-      this.repository.findGrantIncomeTransactions(filters),
-      this.repository.findOtherIncomeTransactions(filters),
-    ]);
+    const [businessTransactions, loanTransactions, grantTransactions, otherTransactions] =
+      await Promise.all([
+        this.repository.findBusinessIncomeTransactions(filters),
+        this.repository.findLoanIncomeTransactions(filters),
+        this.repository.findGrantIncomeTransactions(filters),
+        this.repository.findOtherIncomeTransactions(filters),
+      ]);
 
     return {
-      businessIncome:
-        BusinessIncomeSection.fromTransactions(businessTransactions),
+      businessIncome: BusinessIncomeSection.fromTransactions(businessTransactions),
       loanIncome: LoanIncomeSection.fromTransactions(loanTransactions),
       grantIncome: GrantIncomeSection.fromTransactions(grantTransactions),
       otherIncome: OtherIncomeSection.fromTransactions(otherTransactions),

--- a/admin/src/server/contexts/report/application/usecases/get-organization-profile-usecase.ts
+++ b/admin/src/server/contexts/report/application/usecases/get-organization-profile-usecase.ts
@@ -11,9 +11,7 @@ export interface GetOrganizationProfileInput {
 export class GetOrganizationProfileUsecase {
   constructor(private repository: IOrganizationReportProfileRepository) {}
 
-  async execute(
-    input: GetOrganizationProfileInput,
-  ): Promise<OrganizationReportProfile | null> {
+  async execute(input: GetOrganizationProfileInput): Promise<OrganizationReportProfile | null> {
     return this.repository.findByOrganizationIdAndYear(
       input.politicalOrganizationId,
       input.financialYear,

--- a/admin/src/server/contexts/report/application/usecases/save-organization-profile-usecase.ts
+++ b/admin/src/server/contexts/report/application/usecases/save-organization-profile-usecase.ts
@@ -21,9 +21,7 @@ export interface SaveOrganizationProfileInput {
 export class SaveOrganizationProfileUsecase {
   constructor(private repository: IOrganizationReportProfileRepository) {}
 
-  async execute(
-    input: SaveOrganizationProfileInput,
-  ): Promise<OrganizationReportProfile> {
+  async execute(input: SaveOrganizationProfileInput): Promise<OrganizationReportProfile> {
     if (input.id) {
       const updateInput: UpdateOrganizationReportProfileInput = {
         officialName: input.officialName,

--- a/admin/src/server/contexts/report/domain/models/donation-transaction.ts
+++ b/admin/src/server/contexts/report/domain/models/donation-transaction.ts
@@ -101,10 +101,7 @@ export const PersonalDonationTransaction = {
   /**
    * 明細行に変換する
    */
-  toRow: (
-    tx: PersonalDonationTransaction,
-    index: number,
-  ): PersonalDonationRow => {
+  toRow: (tx: PersonalDonationTransaction, index: number): PersonalDonationRow => {
     return {
       ichirenNo: (index + 1).toString(),
       kifusyaNm: PersonalDonationTransaction.getKifusyaNm(tx),
@@ -130,17 +127,13 @@ export const PersonalDonationSection = {
   /**
    * トランザクションリストからセクションを構築する
    */
-  fromTransactions: (
-    transactions: PersonalDonationTransaction[],
-  ): PersonalDonationSection => {
+  fromTransactions: (transactions: PersonalDonationTransaction[]): PersonalDonationSection => {
     const totalAmount = transactions.reduce(
       (sum, tx) => sum + PersonalDonationTransaction.resolveAmount(tx),
       0,
     );
 
-    const rows = transactions.map((tx, index) =>
-      PersonalDonationTransaction.toRow(tx, index),
-    );
+    const rows = transactions.map((tx, index) => PersonalDonationTransaction.toRow(tx, index));
 
     return {
       totalAmount,

--- a/admin/src/server/contexts/report/domain/models/expense-transaction.ts
+++ b/admin/src/server/contexts/report/domain/models/expense-transaction.ts
@@ -48,8 +48,7 @@ export interface OfficeExpenseTransaction extends BaseExpenseTransaction {}
 /**
  * SYUUSHI07_15 KUBUN1: 組織活動費のトランザクション
  */
-export interface OrganizationExpenseTransaction
-  extends BaseExpenseTransaction {}
+export interface OrganizationExpenseTransaction extends BaseExpenseTransaction {}
 
 /**
  * SYUUSHI07_15 KUBUN2: 選挙関係費のトランザクション
@@ -69,14 +68,12 @@ export interface AdvertisingExpenseTransaction extends BaseExpenseTransaction {}
 /**
  * SYUUSHI07_15 KUBUN5: 政治資金パーティー開催事業費のトランザクション
  */
-export interface FundraisingPartyExpenseTransaction
-  extends BaseExpenseTransaction {}
+export interface FundraisingPartyExpenseTransaction extends BaseExpenseTransaction {}
 
 /**
  * SYUUSHI07_15 KUBUN6: その他の事業費のトランザクション
  */
-export interface OtherBusinessExpenseTransaction
-  extends BaseExpenseTransaction {}
+export interface OtherBusinessExpenseTransaction extends BaseExpenseTransaction {}
 
 /**
  * SYUUSHI07_15 KUBUN7: 調査研究費のトランザクション
@@ -86,14 +83,12 @@ export interface ResearchExpenseTransaction extends BaseExpenseTransaction {}
 /**
  * SYUUSHI07_15 KUBUN8: 寄附・交付金のトランザクション
  */
-export interface DonationGrantExpenseTransaction
-  extends BaseExpenseTransaction {}
+export interface DonationGrantExpenseTransaction extends BaseExpenseTransaction {}
 
 /**
  * SYUUSHI07_15 KUBUN9: その他の経費のトランザクション
  */
-export interface OtherPoliticalExpenseTransaction
-  extends BaseExpenseTransaction {}
+export interface OtherPoliticalExpenseTransaction extends BaseExpenseTransaction {}
 
 // ============================================================
 // Output Types (Domain Objects for XML)
@@ -283,10 +278,7 @@ const ExpenseTransactionBase = {
    * 閾値（10万円）以上かどうかを判定
    */
   isAboveThreshold: (tx: BaseExpenseTransaction): boolean => {
-    return isAboveThreshold(
-      ExpenseTransactionBase.resolveAmount(tx),
-      TEN_MAN_THRESHOLD,
-    );
+    return isAboveThreshold(ExpenseTransactionBase.resolveAmount(tx), TEN_MAN_THRESHOLD);
   },
 
   /**
@@ -336,10 +328,7 @@ export const OrganizationExpenseTransaction = {
    * 明細行に変換する
    * 注: HIMOKUはSHEETレベルの項目であり、ROWには含めない（仕様書準拠）
    */
-  toRow: (
-    tx: OrganizationExpenseTransaction,
-    index: number,
-  ): PoliticalActivityExpenseRow => {
+  toRow: (tx: OrganizationExpenseTransaction, index: number): PoliticalActivityExpenseRow => {
     return {
       ichirenNo: (index + 1).toString(),
       mokuteki: ExpenseTransactionBase.getMokuteki(tx),
@@ -379,9 +368,7 @@ function aggregateExpenseSection<T extends BaseExpenseTransaction>(
     0,
   );
 
-  const rows = detailedTransactions.map((tx, index) =>
-    ExpenseTransactionBase.toRow(tx, index),
-  );
+  const rows = detailedTransactions.map((tx, index) => ExpenseTransactionBase.toRow(tx, index));
 
   return { totalAmount, underThresholdAmount, rows };
 }
@@ -397,9 +384,7 @@ export const UtilityExpenseSection = {
    * - Transactions >= 100,000 yen are listed individually
    * - Transactions < 100,000 yen are aggregated into underThresholdAmount
    */
-  fromTransactions: (
-    transactions: UtilityExpenseTransaction[],
-  ): UtilityExpenseSection => {
+  fromTransactions: (transactions: UtilityExpenseTransaction[]): UtilityExpenseSection => {
     return aggregateExpenseSection(transactions);
   },
 
@@ -422,9 +407,7 @@ export const SuppliesExpenseSection = {
    * - Transactions >= 100,000 yen are listed individually
    * - Transactions < 100,000 yen are aggregated into underThresholdAmount
    */
-  fromTransactions: (
-    transactions: SuppliesExpenseTransaction[],
-  ): SuppliesExpenseSection => {
+  fromTransactions: (transactions: SuppliesExpenseTransaction[]): SuppliesExpenseSection => {
     return aggregateExpenseSection(transactions);
   },
 
@@ -447,9 +430,7 @@ export const OfficeExpenseSection = {
    * - Transactions >= 100,000 yen are listed individually
    * - Transactions < 100,000 yen are aggregated into underThresholdAmount
    */
-  fromTransactions: (
-    transactions: OfficeExpenseTransaction[],
-  ): OfficeExpenseSection => {
+  fromTransactions: (transactions: OfficeExpenseTransaction[]): OfficeExpenseSection => {
     return aggregateExpenseSection(transactions);
   },
 
@@ -482,17 +463,10 @@ export const OrganizationExpenseSection = {
     );
 
     const detailedTransactions = transactions.filter((tx) =>
-      isAboveThreshold(
-        ExpenseTransactionBase.resolveAmount(tx),
-        FIVE_MAN_THRESHOLD,
-      ),
+      isAboveThreshold(ExpenseTransactionBase.resolveAmount(tx), FIVE_MAN_THRESHOLD),
     );
     const underThresholdTransactions = transactions.filter(
-      (tx) =>
-        !isAboveThreshold(
-          ExpenseTransactionBase.resolveAmount(tx),
-          FIVE_MAN_THRESHOLD,
-        ),
+      (tx) => !isAboveThreshold(ExpenseTransactionBase.resolveAmount(tx), FIVE_MAN_THRESHOLD),
     );
 
     const underThresholdAmount = underThresholdTransactions.reduce(
@@ -537,17 +511,10 @@ function aggregatePoliticalActivitySection<T extends BaseExpenseTransaction>(
   );
 
   const detailedTransactions = transactions.filter((tx) =>
-    isAboveThreshold(
-      ExpenseTransactionBase.resolveAmount(tx),
-      FIVE_MAN_THRESHOLD,
-    ),
+    isAboveThreshold(ExpenseTransactionBase.resolveAmount(tx), FIVE_MAN_THRESHOLD),
   );
   const underThresholdTransactions = transactions.filter(
-    (tx) =>
-      !isAboveThreshold(
-        ExpenseTransactionBase.resolveAmount(tx),
-        FIVE_MAN_THRESHOLD,
-      ),
+    (tx) => !isAboveThreshold(ExpenseTransactionBase.resolveAmount(tx), FIVE_MAN_THRESHOLD),
   );
 
   const underThresholdAmount = underThresholdTransactions.reduce(
@@ -577,9 +544,7 @@ function aggregatePoliticalActivitySection<T extends BaseExpenseTransaction>(
  * ElectionExpenseSection に関連するドメインロジック
  */
 export const ElectionExpenseSection = {
-  fromTransactions: (
-    transactions: ElectionExpenseTransaction[],
-  ): ElectionExpenseSection => {
+  fromTransactions: (transactions: ElectionExpenseTransaction[]): ElectionExpenseSection => {
     return aggregatePoliticalActivitySection(transactions);
   },
 
@@ -592,9 +557,7 @@ export const ElectionExpenseSection = {
  * PublicationExpenseSection に関連するドメインロジック
  */
 export const PublicationExpenseSection = {
-  fromTransactions: (
-    transactions: PublicationExpenseTransaction[],
-  ): PublicationExpenseSection => {
+  fromTransactions: (transactions: PublicationExpenseTransaction[]): PublicationExpenseSection => {
     return aggregatePoliticalActivitySection(transactions);
   },
 
@@ -607,9 +570,7 @@ export const PublicationExpenseSection = {
  * AdvertisingExpenseSection に関連するドメインロジック
  */
 export const AdvertisingExpenseSection = {
-  fromTransactions: (
-    transactions: AdvertisingExpenseTransaction[],
-  ): AdvertisingExpenseSection => {
+  fromTransactions: (transactions: AdvertisingExpenseTransaction[]): AdvertisingExpenseSection => {
     return aggregatePoliticalActivitySection(transactions);
   },
 
@@ -652,9 +613,7 @@ export const OtherBusinessExpenseSection = {
  * ResearchExpenseSection に関連するドメインロジック
  */
 export const ResearchExpenseSection = {
-  fromTransactions: (
-    transactions: ResearchExpenseTransaction[],
-  ): ResearchExpenseSection => {
+  fromTransactions: (transactions: ResearchExpenseTransaction[]): ResearchExpenseSection => {
     return aggregatePoliticalActivitySection(transactions);
   },
 

--- a/admin/src/server/contexts/report/domain/models/income-transaction.ts
+++ b/admin/src/server/contexts/report/domain/models/income-transaction.ts
@@ -289,10 +289,7 @@ export const OtherIncomeTransaction = {
    * 閾値（10万円）以上かどうかを判定
    */
   isAboveThreshold: (tx: OtherIncomeTransaction): boolean => {
-    return isAboveThreshold(
-      OtherIncomeTransaction.resolveAmount(tx),
-      TEN_MAN_THRESHOLD,
-    );
+    return isAboveThreshold(OtherIncomeTransaction.resolveAmount(tx), TEN_MAN_THRESHOLD);
   },
 
   /**
@@ -319,17 +316,13 @@ export const BusinessIncomeSection = {
   /**
    * トランザクションリストからセクションを構築する
    */
-  fromTransactions: (
-    transactions: BusinessIncomeTransaction[],
-  ): BusinessIncomeSection => {
+  fromTransactions: (transactions: BusinessIncomeTransaction[]): BusinessIncomeSection => {
     const totalAmount = transactions.reduce(
       (sum, tx) => sum + BusinessIncomeTransaction.resolveAmount(tx),
       0,
     );
 
-    const rows = transactions.map((tx, index) =>
-      BusinessIncomeTransaction.toRow(tx, index),
-    );
+    const rows = transactions.map((tx, index) => BusinessIncomeTransaction.toRow(tx, index));
 
     return { totalAmount, rows };
   },
@@ -349,17 +342,13 @@ export const LoanIncomeSection = {
   /**
    * トランザクションリストからセクションを構築する
    */
-  fromTransactions: (
-    transactions: LoanIncomeTransaction[],
-  ): LoanIncomeSection => {
+  fromTransactions: (transactions: LoanIncomeTransaction[]): LoanIncomeSection => {
     const totalAmount = transactions.reduce(
       (sum, tx) => sum + LoanIncomeTransaction.resolveAmount(tx),
       0,
     );
 
-    const rows = transactions.map((tx, index) =>
-      LoanIncomeTransaction.toRow(tx, index),
-    );
+    const rows = transactions.map((tx, index) => LoanIncomeTransaction.toRow(tx, index));
 
     return { totalAmount, rows };
   },
@@ -379,17 +368,13 @@ export const GrantIncomeSection = {
   /**
    * トランザクションリストからセクションを構築する
    */
-  fromTransactions: (
-    transactions: GrantIncomeTransaction[],
-  ): GrantIncomeSection => {
+  fromTransactions: (transactions: GrantIncomeTransaction[]): GrantIncomeSection => {
     const totalAmount = transactions.reduce(
       (sum, tx) => sum + GrantIncomeTransaction.resolveAmount(tx),
       0,
     );
 
-    const rows = transactions.map((tx, index) =>
-      GrantIncomeTransaction.toRow(tx, index),
-    );
+    const rows = transactions.map((tx, index) => GrantIncomeTransaction.toRow(tx, index));
 
     return { totalAmount, rows };
   },
@@ -413,9 +398,7 @@ export const OtherIncomeSection = {
    * - Transactions >= 100,000 yen are listed individually
    * - Transactions < 100,000 yen are aggregated into underThresholdAmount
    */
-  fromTransactions: (
-    transactions: OtherIncomeTransaction[],
-  ): OtherIncomeSection => {
+  fromTransactions: (transactions: OtherIncomeTransaction[]): OtherIncomeSection => {
     const totalAmount = transactions.reduce(
       (sum, tx) => sum + OtherIncomeTransaction.resolveAmount(tx),
       0,
@@ -433,9 +416,7 @@ export const OtherIncomeSection = {
       0,
     );
 
-    const rows = detailedTransactions.map((tx, index) =>
-      OtherIncomeTransaction.toRow(tx, index),
-    );
+    const rows = detailedTransactions.map((tx, index) => OtherIncomeTransaction.toRow(tx, index));
 
     return { totalAmount, underThresholdAmount, rows };
   },

--- a/admin/src/server/contexts/report/domain/models/report-data.ts
+++ b/admin/src/server/contexts/report/domain/models/report-data.ts
@@ -104,29 +104,15 @@ export const ExpenseData = {
    */
   shouldOutputPoliticalActivitySheet(data: ExpenseData): boolean {
     return (
-      OrganizationExpenseSectionModel.shouldOutputSheet(
-        data.organizationExpenses,
-      ) ||
+      OrganizationExpenseSectionModel.shouldOutputSheet(data.organizationExpenses) ||
       ElectionExpenseSectionModel.shouldOutputSheet(data.electionExpenses) ||
-      PublicationExpenseSectionModel.shouldOutputSheet(
-        data.publicationExpenses,
-      ) ||
-      AdvertisingExpenseSectionModel.shouldOutputSheet(
-        data.advertisingExpenses,
-      ) ||
-      FundraisingPartyExpenseSectionModel.shouldOutputSheet(
-        data.fundraisingPartyExpenses,
-      ) ||
-      OtherBusinessExpenseSectionModel.shouldOutputSheet(
-        data.otherBusinessExpenses,
-      ) ||
+      PublicationExpenseSectionModel.shouldOutputSheet(data.publicationExpenses) ||
+      AdvertisingExpenseSectionModel.shouldOutputSheet(data.advertisingExpenses) ||
+      FundraisingPartyExpenseSectionModel.shouldOutputSheet(data.fundraisingPartyExpenses) ||
+      OtherBusinessExpenseSectionModel.shouldOutputSheet(data.otherBusinessExpenses) ||
       ResearchExpenseSectionModel.shouldOutputSheet(data.researchExpenses) ||
-      DonationGrantExpenseSectionModel.shouldOutputSheet(
-        data.donationGrantExpenses,
-      ) ||
-      OtherPoliticalExpenseSectionModel.shouldOutputSheet(
-        data.otherPoliticalExpenses,
-      )
+      DonationGrantExpenseSectionModel.shouldOutputSheet(data.donationGrantExpenses) ||
+      OtherPoliticalExpenseSectionModel.shouldOutputSheet(data.otherPoliticalExpenses)
     );
   },
 };

--- a/admin/src/server/contexts/report/domain/models/transaction-utils.ts
+++ b/admin/src/server/contexts/report/domain/models/transaction-utils.ts
@@ -8,10 +8,7 @@
  * 借方/貸方から取引金額を解決する（収入用）
  * 収入の場合は貸方金額を優先
  */
-export function resolveIncomeAmount(
-  debitAmount: number,
-  creditAmount: number,
-): number {
+export function resolveIncomeAmount(debitAmount: number, creditAmount: number): number {
   if (Number.isFinite(creditAmount) && creditAmount > 0) {
     return creditAmount;
   }
@@ -22,10 +19,7 @@ export function resolveIncomeAmount(
  * 借方/貸方から取引金額を解決する（支出用）
  * 支出の場合は借方金額を優先
  */
-export function resolveExpenseAmount(
-  debitAmount: number,
-  creditAmount: number,
-): number {
+export function resolveExpenseAmount(debitAmount: number, creditAmount: number): number {
   if (Number.isFinite(debitAmount) && debitAmount > 0) {
     return debitAmount;
   }
@@ -35,10 +29,7 @@ export function resolveExpenseAmount(
 /**
  * テキストを正規化する（空白の統一、トリム、最大長制限）
  */
-export function sanitizeText(
-  value: string | null | undefined,
-  maxLength?: number,
-): string {
+export function sanitizeText(value: string | null | undefined, maxLength?: number): string {
   if (!value) {
     return "";
   }
@@ -64,10 +55,7 @@ export const FIVE_MAN_THRESHOLD = 50_000;
 /**
  * 金額が閾値以上かどうかを判定
  */
-export function isAboveThreshold(
-  amount: number,
-  threshold: number = TEN_MAN_THRESHOLD,
-): boolean {
+export function isAboveThreshold(amount: number, threshold: number = TEN_MAN_THRESHOLD): boolean {
   return amount >= threshold;
 }
 

--- a/admin/src/server/contexts/report/domain/repositories/organization-report-profile-repository.interface.ts
+++ b/admin/src/server/contexts/report/domain/repositories/organization-report-profile-repository.interface.ts
@@ -16,9 +16,7 @@ export interface IOrganizationReportProfileRepository {
   /**
    * Create a new organization report profile.
    */
-  create(
-    input: CreateOrganizationReportProfileInput,
-  ): Promise<OrganizationReportProfile>;
+  create(input: CreateOrganizationReportProfileInput): Promise<OrganizationReportProfile>;
 
   /**
    * Update an existing organization report profile.

--- a/admin/src/server/contexts/report/domain/repositories/report-transaction-repository.interface.ts
+++ b/admin/src/server/contexts/report/domain/repositories/report-transaction-repository.interface.ts
@@ -37,37 +37,27 @@ export interface IReportTransactionRepository {
   /**
    * SYUUSHI07_03: 事業による収入のトランザクションを取得
    */
-  findBusinessIncomeTransactions(
-    filters: TransactionFilters,
-  ): Promise<BusinessIncomeTransaction[]>;
+  findBusinessIncomeTransactions(filters: TransactionFilters): Promise<BusinessIncomeTransaction[]>;
 
   /**
    * SYUUSHI07_04: 借入金のトランザクションを取得
    */
-  findLoanIncomeTransactions(
-    filters: TransactionFilters,
-  ): Promise<LoanIncomeTransaction[]>;
+  findLoanIncomeTransactions(filters: TransactionFilters): Promise<LoanIncomeTransaction[]>;
 
   /**
    * SYUUSHI07_05: 交付金のトランザクションを取得
    */
-  findGrantIncomeTransactions(
-    filters: TransactionFilters,
-  ): Promise<GrantIncomeTransaction[]>;
+  findGrantIncomeTransactions(filters: TransactionFilters): Promise<GrantIncomeTransaction[]>;
 
   /**
    * SYUUSHI07_06: その他の収入のトランザクションを取得
    */
-  findOtherIncomeTransactions(
-    filters: TransactionFilters,
-  ): Promise<OtherIncomeTransaction[]>;
+  findOtherIncomeTransactions(filters: TransactionFilters): Promise<OtherIncomeTransaction[]>;
 
   /**
    * SYUUSHI07_14 KUBUN1: 光熱水費のトランザクションを取得
    */
-  findUtilityExpenseTransactions(
-    filters: TransactionFilters,
-  ): Promise<UtilityExpenseTransaction[]>;
+  findUtilityExpenseTransactions(filters: TransactionFilters): Promise<UtilityExpenseTransaction[]>;
 
   /**
    * SYUUSHI07_14 KUBUN2: 備品・消耗品費のトランザクションを取得
@@ -79,9 +69,7 @@ export interface IReportTransactionRepository {
   /**
    * SYUUSHI07_14 KUBUN3: 事務所費のトランザクションを取得
    */
-  findOfficeExpenseTransactions(
-    filters: TransactionFilters,
-  ): Promise<OfficeExpenseTransaction[]>;
+  findOfficeExpenseTransactions(filters: TransactionFilters): Promise<OfficeExpenseTransaction[]>;
 
   /**
    * SYUUSHI07_15 KUBUN1: 組織活動費のトランザクションを取得

--- a/admin/src/server/contexts/report/domain/services/donation-serializer.ts
+++ b/admin/src/server/contexts/report/domain/services/donation-serializer.ts
@@ -20,9 +20,7 @@ import {
 /**
  * Serializes a PersonalDonationSection into XML format for SYUUSHI07_07 KUBUN1.
  */
-export function serializePersonalDonationSection(
-  section: PersonalDonationSection,
-): XMLBuilder {
+export function serializePersonalDonationSection(section: PersonalDonationSection): XMLBuilder {
   const frag = fragment();
   const root = frag.ele("SYUUSHI07_07");
   const kubun1 = root.ele("KUBUN1");

--- a/admin/src/server/contexts/report/domain/services/expense-serializer.ts
+++ b/admin/src/server/contexts/report/domain/services/expense-serializer.ts
@@ -62,10 +62,7 @@ export function serializeExpenseSection(
  */
 function serializeExpenseKubun(
   kubunElement: XMLBuilder,
-  section:
-    | UtilityExpenseSection
-    | SuppliesExpenseSection
-    | OfficeExpenseSection,
+  section: UtilityExpenseSection | SuppliesExpenseSection | OfficeExpenseSection,
 ): void {
   const sheet = kubunElement.ele("SHEET");
 

--- a/admin/src/server/contexts/report/domain/services/income-serializer.ts
+++ b/admin/src/server/contexts/report/domain/services/income-serializer.ts
@@ -25,9 +25,7 @@ import {
 /**
  * Serializes a BusinessIncomeSection into XML format for SYUUSHI07_03.
  */
-export function serializeBusinessIncomeSection(
-  section: BusinessIncomeSection,
-): XMLBuilder {
+export function serializeBusinessIncomeSection(section: BusinessIncomeSection): XMLBuilder {
   const frag = fragment();
   const root = frag.ele("SYUUSHI07_03");
   const sheet = root.ele("SHEET");
@@ -53,9 +51,7 @@ export function serializeBusinessIncomeSection(
 /**
  * Serializes a LoanIncomeSection into XML format for SYUUSHI07_04.
  */
-export function serializeLoanIncomeSection(
-  section: LoanIncomeSection,
-): XMLBuilder {
+export function serializeLoanIncomeSection(section: LoanIncomeSection): XMLBuilder {
   const frag = fragment();
   const root = frag.ele("SYUUSHI07_04");
   const sheet = root.ele("SHEET");
@@ -81,9 +77,7 @@ export function serializeLoanIncomeSection(
 /**
  * Serializes a GrantIncomeSection into XML format for SYUUSHI07_05.
  */
-export function serializeGrantIncomeSection(
-  section: GrantIncomeSection,
-): XMLBuilder {
+export function serializeGrantIncomeSection(section: GrantIncomeSection): XMLBuilder {
   const frag = fragment();
   const root = frag.ele("SYUUSHI07_05");
   const sheet = root.ele("SHEET");
@@ -111,9 +105,7 @@ export function serializeGrantIncomeSection(
 /**
  * Serializes an OtherIncomeSection into XML format for SYUUSHI07_06.
  */
-export function serializeOtherIncomeSection(
-  section: OtherIncomeSection,
-): XMLBuilder {
+export function serializeOtherIncomeSection(section: OtherIncomeSection): XMLBuilder {
   const frag = fragment();
   const root = frag.ele("SYUUSHI07_06");
   const sheet = root.ele("SHEET");

--- a/admin/src/server/contexts/report/domain/services/profile-serializer.ts
+++ b/admin/src/server/contexts/report/domain/services/profile-serializer.ts
@@ -15,9 +15,7 @@ import type {
 /**
  * Serializes an OrganizationReportProfile into XML format for SYUUSHI07_01.
  */
-export function serializeProfileSection(
-  profile: OrganizationReportProfile,
-): XMLBuilder {
+export function serializeProfileSection(profile: OrganizationReportProfile): XMLBuilder {
   const frag = fragment();
   const root = frag.ele("SYUUSHI07_01");
   const details = profile.details;
@@ -47,10 +45,7 @@ function serializeRepresentative(
   root.ele("DAI_NM2").txt(details.representative?.firstName ?? "");
 }
 
-function serializeAccountant(
-  root: XMLBuilder,
-  details: OrganizationReportProfileDetails,
-): void {
+function serializeAccountant(root: XMLBuilder, details: OrganizationReportProfileDetails): void {
   root.ele("KAI_NM1").txt(details.accountant?.lastName ?? "");
   root.ele("KAI_NM2").txt(details.accountant?.firstName ?? "");
 }

--- a/admin/src/server/contexts/report/domain/services/report-serializer.ts
+++ b/admin/src/server/contexts/report/domain/services/report-serializer.ts
@@ -14,10 +14,7 @@ import {
   LoanIncomeSection,
   OtherIncomeSection,
 } from "@/server/contexts/report/domain/models/income-transaction";
-import {
-  ExpenseData,
-  type ReportData,
-} from "@/server/contexts/report/domain/models/report-data";
+import { ExpenseData, type ReportData } from "@/server/contexts/report/domain/models/report-data";
 import { serializePersonalDonationSection } from "@/server/contexts/report/domain/services/donation-serializer";
 import {
   serializeExpenseSection,
@@ -90,10 +87,7 @@ export type XmlSectionType = (typeof KNOWN_FORM_IDS)[number];
 /**
  * Serializes ReportData into a complete XML document string.
  */
-export function serializeReportData(
-  reportData: ReportData,
-  head: Partial<XmlHead> = {},
-): string {
+export function serializeReportData(reportData: ReportData, head: Partial<XmlHead> = {}): string {
   const sections: { formId: XmlSectionType; xml: XMLBuilder }[] = [];
 
   // SYUUSHI07_01: 第14号様式（その1）団体の基本情報
@@ -103,23 +97,15 @@ export function serializeReportData(
   });
 
   // SYUUSHI07_07: 第14号様式（その7）寄附の明細
-  if (
-    PersonalDonationSection.shouldOutputSheet(
-      reportData.donations.personalDonations,
-    )
-  ) {
+  if (PersonalDonationSection.shouldOutputSheet(reportData.donations.personalDonations)) {
     sections.push({
       formId: "SYUUSHI07_07",
-      xml: serializePersonalDonationSection(
-        reportData.donations.personalDonations,
-      ),
+      xml: serializePersonalDonationSection(reportData.donations.personalDonations),
     });
   }
 
   // SYUUSHI07_03: 第14号様式（その3）事業による収入
-  if (
-    BusinessIncomeSection.shouldOutputSheet(reportData.income.businessIncome)
-  ) {
+  if (BusinessIncomeSection.shouldOutputSheet(reportData.income.businessIncome)) {
     sections.push({
       formId: "SYUUSHI07_03",
       xml: serializeBusinessIncomeSection(reportData.income.businessIncome),
@@ -242,9 +228,7 @@ function buildSyuushiFlgSection(availableFormIds: string[]): XMLBuilder {
     ),
   );
 
-  const flagString = KNOWN_FORM_IDS.map((formId) =>
-    formSet.has(formId) ? "1" : "0",
-  )
+  const flagString = KNOWN_FORM_IDS.map((formId) => (formSet.has(formId) ? "1" : "0"))
     .join("")
     .padEnd(FLAG_STRING_LENGTH, "0")
     .slice(0, FLAG_STRING_LENGTH);

--- a/admin/src/server/contexts/report/infrastructure/repositories/prisma-organization-report-profile.repository.ts
+++ b/admin/src/server/contexts/report/infrastructure/repositories/prisma-organization-report-profile.repository.ts
@@ -34,9 +34,7 @@ export class PrismaOrganizationReportProfileRepository
     return this.mapToModel(profile);
   }
 
-  async create(
-    input: CreateOrganizationReportProfileInput,
-  ): Promise<OrganizationReportProfile> {
+  async create(input: CreateOrganizationReportProfileInput): Promise<OrganizationReportProfile> {
     const profile = await this.prisma.organizationReportProfile.create({
       data: {
         politicalOrganizationId: BigInt(input.politicalOrganizationId),
@@ -63,9 +61,7 @@ export class PrismaOrganizationReportProfileRepository
         officialNameKana: input.officialNameKana,
         officeAddress: input.officeAddress,
         officeAddressBuilding: input.officeAddressBuilding,
-        details: input.details
-          ? (input.details as Prisma.InputJsonValue)
-          : undefined,
+        details: input.details ? (input.details as Prisma.InputJsonValue) : undefined,
       },
     });
 

--- a/admin/src/server/contexts/report/infrastructure/repositories/prisma-report-transaction.repository.ts
+++ b/admin/src/server/contexts/report/infrastructure/repositories/prisma-report-transaction.repository.ts
@@ -79,9 +79,7 @@ interface PoliticalActivityExpenseTransactionRaw {
   counterpartAddress: string;
 }
 
-export class PrismaReportTransactionRepository
-  implements IReportTransactionRepository
-{
+export class PrismaReportTransactionRepository implements IReportTransactionRepository {
   constructor(private prisma: PrismaClient) {}
 
   /**
@@ -203,9 +201,7 @@ export class PrismaReportTransactionRepository
   /**
    * SYUUSHI07_04: 借入金のトランザクションを取得
    */
-  async findLoanIncomeTransactions(
-    filters: TransactionFilters,
-  ): Promise<LoanIncomeTransaction[]> {
+  async findLoanIncomeTransactions(filters: TransactionFilters): Promise<LoanIncomeTransaction[]> {
     const transactions = await this.prisma.transaction.findMany({
       where: {
         politicalOrganizationId: BigInt(filters.politicalOrganizationId),
@@ -488,10 +484,7 @@ export class PrismaReportTransactionRepository
   async findElectionExpenseTransactions(
     filters: TransactionFilters,
   ): Promise<ElectionExpenseTransaction[]> {
-    return this.findPoliticalActivityExpenseTransactions(
-      filters,
-      CATEGORY_KEYS.ELECTION_EXPENSES,
-    );
+    return this.findPoliticalActivityExpenseTransactions(filters, CATEGORY_KEYS.ELECTION_EXPENSES);
   }
 
   /**
@@ -548,10 +541,7 @@ export class PrismaReportTransactionRepository
   async findResearchExpenseTransactions(
     filters: TransactionFilters,
   ): Promise<ResearchExpenseTransaction[]> {
-    return this.findPoliticalActivityExpenseTransactions(
-      filters,
-      CATEGORY_KEYS.RESEARCH_EXPENSES,
-    );
+    return this.findPoliticalActivityExpenseTransactions(filters, CATEGORY_KEYS.RESEARCH_EXPENSES);
   }
 
   /**

--- a/admin/src/server/contexts/report/presentation/actions/export-xml.ts
+++ b/admin/src/server/contexts/report/presentation/actions/export-xml.ts
@@ -20,9 +20,7 @@ export interface ExportXmlResult {
   reportData: ReportData;
 }
 
-export async function exportXml(
-  input: ExportXmlInput,
-): Promise<ExportXmlResult> {
+export async function exportXml(input: ExportXmlInput): Promise<ExportXmlResult> {
   if (!input.politicalOrganizationId?.trim()) {
     throw new Error("政治団体IDは必須です");
   }
@@ -32,9 +30,7 @@ export async function exportXml(
   }
 
   const transactionRepository = new PrismaReportTransactionRepository(prisma);
-  const profileRepository = new PrismaOrganizationReportProfileRepository(
-    prisma,
-  );
+  const profileRepository = new PrismaOrganizationReportProfileRepository(prisma);
   const donationAssembler = new DonationAssembler(transactionRepository);
   const incomeAssembler = new IncomeAssembler(transactionRepository);
   const expenseAssembler = new ExpenseAssembler(transactionRepository);

--- a/admin/src/server/contexts/report/presentation/actions/save-organization-profile.ts
+++ b/admin/src/server/contexts/report/presentation/actions/save-organization-profile.ts
@@ -17,9 +17,7 @@ export interface SaveOrganizationProfileData {
   details?: OrganizationReportProfileDetails;
 }
 
-export async function saveOrganizationProfile(
-  data: SaveOrganizationProfileData,
-) {
+export async function saveOrganizationProfile(data: SaveOrganizationProfileData) {
   try {
     const repository = new PrismaOrganizationReportProfileRepository(prisma);
     const usecase = new SaveOrganizationProfileUsecase(repository);
@@ -35,16 +33,12 @@ export async function saveOrganizationProfile(
       details: data.details,
     });
 
-    revalidatePath(
-      `/political-organizations/${data.politicalOrganizationId}/report-profile`,
-    );
+    revalidatePath(`/political-organizations/${data.politicalOrganizationId}/report-profile`);
     return { success: true, profile };
   } catch (error) {
     console.error("Error saving organization profile:", error);
     throw new Error(
-      error instanceof Error
-        ? error.message
-        : "報告書プロフィールの保存に失敗しました",
+      error instanceof Error ? error.message : "報告書プロフィールの保存に失敗しました",
     );
   }
 }

--- a/admin/src/server/contexts/report/presentation/schemas/organization-report-profile.schema.ts
+++ b/admin/src/server/contexts/report/presentation/schemas/organization-report-profile.schema.ts
@@ -29,10 +29,7 @@ export const fundManagementPeriodSchema = z.object({
 });
 
 export const fundManagementSchema = z.object({
-  publicPositionName: z
-    .string()
-    .max(60, "公職の名称は60文字以内で入力してください")
-    .optional(),
+  publicPositionName: z.string().max(60, "公職の名称は60文字以内で入力してください").optional(),
   publicPositionType: z.enum(["1", "2", "3", "4"]).optional(),
   applicant: fundManagementApplicantSchema.optional(),
   periods: z.array(fundManagementPeriodSchema).max(3).optional(),
@@ -62,17 +59,11 @@ export const organizationReportProfileDetailsSchema = z.object({
   representative: representativeSchema.optional(),
   accountant: accountantSchema.optional(),
   contactPersons: z.array(contactPersonSchema).max(3).optional(),
-  organizationType: z
-    .string()
-    .max(2, "団体区分は2文字以内で入力してください")
-    .optional(),
+  organizationType: z.string().max(2, "団体区分は2文字以内で入力してください").optional(),
   activityArea: z.enum(["1", "2"]).optional(),
   fundManagement: fundManagementSchema.optional(),
   dietMemberRelation: dietMemberRelationSchema.optional(),
-  specificPartyDate: z
-    .string()
-    .max(20, "開催日は20文字以内で入力してください")
-    .optional(),
+  specificPartyDate: z.string().max(20, "開催日は20文字以内で入力してください").optional(),
 });
 
 export const organizationReportProfileFormSchema = z.object({
@@ -102,6 +93,4 @@ export const organizationReportProfileFormSchema = z.object({
   details: organizationReportProfileDetailsSchema.default({}),
 });
 
-export type OrganizationReportProfileFormData = z.infer<
-  typeof organizationReportProfileFormSchema
->;
+export type OrganizationReportProfileFormData = z.infer<typeof organizationReportProfileFormSchema>;

--- a/admin/src/server/contexts/shared/application/usecases/create-balance-snapshot-usecase.ts
+++ b/admin/src/server/contexts/shared/application/usecases/create-balance-snapshot-usecase.ts
@@ -1,7 +1,4 @@
-import type {
-  BalanceSnapshot,
-  CreateBalanceSnapshotInput,
-} from "@/shared/models/balance-snapshot";
+import type { BalanceSnapshot, CreateBalanceSnapshotInput } from "@/shared/models/balance-snapshot";
 import type { IBalanceSnapshotRepository } from "@/server/contexts/shared/domain/repositories/balance-snapshot-repository.interface";
 
 export class CreateBalanceSnapshotUsecase {

--- a/admin/src/server/contexts/shared/application/usecases/create-political-organization-usecase.ts
+++ b/admin/src/server/contexts/shared/application/usecases/create-political-organization-usecase.ts
@@ -19,12 +19,7 @@ export class CreatePoliticalOrganizationUsecase {
         throw new Error("Organization slug is required");
       }
 
-      return await this.repository.create(
-        displayName,
-        slug,
-        orgName,
-        description,
-      );
+      return await this.repository.create(displayName, slug, orgName, description);
     } catch (error) {
       throw new Error(
         `Failed to create organization: ${error instanceof Error ? error.message : "Unknown error"}`,

--- a/admin/src/server/contexts/shared/application/usecases/delete-political-organization-usecase.ts
+++ b/admin/src/server/contexts/shared/application/usecases/delete-political-organization-usecase.ts
@@ -8,14 +8,11 @@ interface DeletePoliticalOrganizationResult {
 }
 
 export class DeletePoliticalOrganizationUsecase {
-  constructor(
-    private politicalOrganizationRepository: IPoliticalOrganizationRepository,
-  ) {}
+  constructor(private politicalOrganizationRepository: IPoliticalOrganizationRepository) {}
 
   async execute(orgId: bigint): Promise<DeletePoliticalOrganizationResult> {
     try {
-      const transactionCount =
-        await this.politicalOrganizationRepository.countTransactions(orgId);
+      const transactionCount = await this.politicalOrganizationRepository.countTransactions(orgId);
 
       if (transactionCount > 0) {
         return {

--- a/admin/src/server/contexts/shared/domain/repositories/user-repository.interface.ts
+++ b/admin/src/server/contexts/shared/domain/repositories/user-repository.interface.ts
@@ -11,11 +11,7 @@ export interface User {
 }
 
 export interface UserRepository {
-  create(data: {
-    authId: string;
-    email: string;
-    role?: UserRole;
-  }): Promise<User>;
+  create(data: { authId: string; email: string; role?: UserRole }): Promise<User>;
   findByAuthId(authId: string): Promise<User | null>;
   findByEmail(email: string): Promise<User | null>;
   findAll(): Promise<User[]>;

--- a/admin/src/server/contexts/shared/infrastructure/repositories/prisma-balance-snapshot.repository.ts
+++ b/admin/src/server/contexts/shared/infrastructure/repositories/prisma-balance-snapshot.repository.ts
@@ -6,9 +6,7 @@ import type {
 } from "@/shared/models/balance-snapshot";
 import type { IBalanceSnapshotRepository } from "@/server/contexts/shared/domain/repositories/balance-snapshot-repository.interface";
 
-export class PrismaBalanceSnapshotRepository
-  implements IBalanceSnapshotRepository
-{
+export class PrismaBalanceSnapshotRepository implements IBalanceSnapshotRepository {
   constructor(private prisma: PrismaClient) {}
 
   async create(input: CreateBalanceSnapshotInput): Promise<BalanceSnapshot> {
@@ -34,9 +32,7 @@ export class PrismaBalanceSnapshotRepository
     return balanceSnapshots.map((bs) => this.mapToBalanceSnapshot(bs));
   }
 
-  private buildWhereClause(
-    filters?: BalanceSnapshotFilters,
-  ): Prisma.BalanceSnapshotWhereInput {
+  private buildWhereClause(filters?: BalanceSnapshotFilters): Prisma.BalanceSnapshotWhereInput {
     const where: Prisma.BalanceSnapshotWhereInput = {};
 
     if (filters?.political_organization_id) {
@@ -57,8 +53,7 @@ export class PrismaBalanceSnapshotRepository
   ): BalanceSnapshot {
     return {
       id: prismaBalanceSnapshot.id.toString(),
-      political_organization_id:
-        prismaBalanceSnapshot.politicalOrganizationId.toString(),
+      political_organization_id: prismaBalanceSnapshot.politicalOrganizationId.toString(),
       snapshot_date: prismaBalanceSnapshot.snapshotDate,
       balance: Number(prismaBalanceSnapshot.balance),
       created_at: prismaBalanceSnapshot.createdAt,

--- a/admin/src/server/contexts/shared/infrastructure/repositories/prisma-political-organization.repository.ts
+++ b/admin/src/server/contexts/shared/infrastructure/repositories/prisma-political-organization.repository.ts
@@ -2,9 +2,7 @@ import type { PrismaClient } from "@prisma/client";
 import type { PoliticalOrganization } from "@/shared/models/political-organization";
 import type { IPoliticalOrganizationRepository } from "@/server/contexts/shared/domain/repositories/political-organization-repository.interface";
 
-export class PrismaPoliticalOrganizationRepository
-  implements IPoliticalOrganizationRepository
-{
+export class PrismaPoliticalOrganizationRepository implements IPoliticalOrganizationRepository {
   constructor(private prisma: PrismaClient) {}
 
   async create(

--- a/admin/src/server/contexts/shared/infrastructure/repositories/prisma-transaction.repository.ts
+++ b/admin/src/server/contexts/shared/infrastructure/repositories/prisma-transaction.repository.ts
@@ -49,9 +49,7 @@ export class PrismaTransactionRepository implements ITransactionRepository {
     };
   }
 
-  private buildWhereClause(
-    filters?: TransactionFilters,
-  ): Prisma.TransactionWhereInput {
+  private buildWhereClause(filters?: TransactionFilters): Prisma.TransactionWhereInput {
     const where: Prisma.TransactionWhereInput = {};
 
     if (filters?.transaction_type) {
@@ -72,10 +70,7 @@ export class PrismaTransactionRepository implements ITransactionRepository {
       };
     }
 
-    if (
-      filters?.political_organization_ids &&
-      filters.political_organization_ids.length > 0
-    ) {
+    if (filters?.political_organization_ids && filters.political_organization_ids.length > 0) {
       where.politicalOrganizationId = {
         in: filters.political_organization_ids.map((id) => BigInt(id)),
       };
@@ -98,10 +93,7 @@ export class PrismaTransactionRepository implements ITransactionRepository {
     return where;
   }
 
-  private async update(
-    id: string,
-    input: UpdateTransactionInput,
-  ): Promise<Transaction> {
+  private async update(id: string, input: UpdateTransactionInput): Promise<Transaction> {
     const updated = await this.prisma.transaction.update({
       where: { id: BigInt(id) },
       data: {
@@ -218,9 +210,7 @@ export class PrismaTransactionRepository implements ITransactionRepository {
     const createdTransactions = await this.prisma.transaction.findMany({
       where: {
         transactionNo: {
-          in: inputs
-            .map((input) => input.transaction_no)
-            .filter((no): no is string => Boolean(no)),
+          in: inputs.map((input) => input.transaction_no).filter((no): no is string => Boolean(no)),
         },
       },
       orderBy: { createdAt: "desc" },
@@ -263,8 +253,7 @@ export class PrismaTransactionRepository implements ITransactionRepository {
   ): Transaction | TransactionWithOrganization {
     const base: Transaction = {
       id: prismaTransaction.id.toString(),
-      political_organization_id:
-        prismaTransaction.politicalOrganizationId.toString(),
+      political_organization_id: prismaTransaction.politicalOrganizationId.toString(),
       transaction_no: prismaTransaction.transactionNo,
       transaction_date: prismaTransaction.transactionDate,
       financial_year: prismaTransaction.financialYear,
@@ -294,8 +283,7 @@ export class PrismaTransactionRepository implements ITransactionRepository {
     if (includeOrganization) {
       return {
         ...base,
-        political_organization_name:
-          prismaTransaction.politicalOrganization?.displayName,
+        political_organization_name: prismaTransaction.politicalOrganization?.displayName,
       } as TransactionWithOrganization;
     }
 

--- a/admin/src/server/contexts/shared/infrastructure/repositories/prisma-user.repository.ts
+++ b/admin/src/server/contexts/shared/infrastructure/repositories/prisma-user.repository.ts
@@ -8,11 +8,7 @@ import type {
 export class PrismaUserRepository implements UserRepository {
   constructor(private prisma: PrismaClient) {}
 
-  async create(data: {
-    authId: string;
-    email: string;
-    role?: UserRole;
-  }): Promise<User> {
+  async create(data: { authId: string; email: string; role?: UserRole }): Promise<User> {
     return await this.prisma.user.create({
       data: {
         authId: data.authId,

--- a/admin/src/server/contexts/shared/infrastructure/services/webapp-cache-invalidator.ts
+++ b/admin/src/server/contexts/shared/infrastructure/services/webapp-cache-invalidator.ts
@@ -5,8 +5,7 @@ import type { ICacheInvalidator } from "@/server/contexts/shared/domain/services
  */
 export class WebappCacheInvalidator implements ICacheInvalidator {
   constructor(
-    private webappUrl: string = process.env.WEBAPP_URL ||
-      "http://localhost:3000",
+    private webappUrl: string = process.env.WEBAPP_URL || "http://localhost:3000",
     private refreshToken: string | undefined = process.env.DATA_REFRESH_TOKEN,
   ) {}
 

--- a/admin/src/server/contexts/shared/presentation/actions/create-balance-snapshot.ts
+++ b/admin/src/server/contexts/shared/presentation/actions/create-balance-snapshot.ts
@@ -40,9 +40,7 @@ export async function createBalanceSnapshot(data: CreateBalanceSnapshotData) {
     console.error("Error creating balance snapshot:", error);
 
     throw new Error(
-      error instanceof Error
-        ? error.message
-        : "残高スナップショットの作成に失敗しました",
+      error instanceof Error ? error.message : "残高スナップショットの作成に失敗しました",
     );
   }
 }

--- a/admin/src/server/contexts/shared/presentation/actions/create-political-organization.ts
+++ b/admin/src/server/contexts/shared/presentation/actions/create-political-organization.ts
@@ -15,9 +15,7 @@ export interface CreatePoliticalOrganizationData {
   description?: string;
 }
 
-export async function createPoliticalOrganization(
-  data: CreatePoliticalOrganizationData,
-) {
+export async function createPoliticalOrganization(data: CreatePoliticalOrganizationData) {
   try {
     const { displayName, orgName, slug, description } = data;
 
@@ -32,8 +30,6 @@ export async function createPoliticalOrganization(
       throw new Error("このスラッグは既に使用されています");
     }
 
-    throw new Error(
-      error instanceof Error ? error.message : "政治団体の作成に失敗しました",
-    );
+    throw new Error(error instanceof Error ? error.message : "政治団体の作成に失敗しました");
   }
 }

--- a/admin/src/server/contexts/shared/presentation/actions/delete-balance-snapshot.ts
+++ b/admin/src/server/contexts/shared/presentation/actions/delete-balance-snapshot.ts
@@ -22,9 +22,7 @@ export async function deleteBalanceSnapshot(id: string) {
     console.error("Error deleting balance snapshot:", error);
 
     throw new Error(
-      error instanceof Error
-        ? error.message
-        : "残高スナップショットの削除に失敗しました",
+      error instanceof Error ? error.message : "残高スナップショットの削除に失敗しました",
     );
   }
 }

--- a/admin/src/server/contexts/shared/presentation/actions/update-political-organization.ts
+++ b/admin/src/server/contexts/shared/presentation/actions/update-political-organization.ts
@@ -46,10 +46,7 @@ export async function updatePoliticalOrganization(
   } catch (error) {
     console.error("Error updating political organization:", error);
 
-    if (
-      error instanceof Error &&
-      error.message.includes("Record to update not found")
-    ) {
+    if (error instanceof Error && error.message.includes("Record to update not found")) {
       throw new Error("政治団体が見つかりません");
     }
 
@@ -57,8 +54,6 @@ export async function updatePoliticalOrganization(
       throw new Error("このスラッグは既に使用されています");
     }
 
-    throw new Error(
-      error instanceof Error ? error.message : "政治団体の更新に失敗しました",
-    );
+    throw new Error(error instanceof Error ? error.message : "政治団体の更新に失敗しました");
   }
 }

--- a/admin/src/server/contexts/shared/presentation/loaders/load-political-organization-data.ts
+++ b/admin/src/server/contexts/shared/presentation/loaders/load-political-organization-data.ts
@@ -28,9 +28,7 @@ export const loadPoliticalOrganizationData = unstable_cache(
       };
     } catch (error) {
       console.error("Error fetching political organization:", error);
-      throw new Error(
-        error instanceof Error ? error.message : "政治団体の取得に失敗しました",
-      );
+      throw new Error(error instanceof Error ? error.message : "政治団体の取得に失敗しました");
     }
   },
   ["political-organization-data"],

--- a/biome.json
+++ b/biome.json
@@ -19,7 +19,7 @@
     "enabled": true,
     "indentStyle": "space",
     "indentWidth": 2,
-    "lineWidth": 80
+    "lineWidth": 100
   },
   "linter": {
     "enabled": true,

--- a/webapp/src/app/api/refresh/route.ts
+++ b/webapp/src/app/api/refresh/route.ts
@@ -10,10 +10,7 @@ export async function POST(request: NextRequest) {
 
     if (!expectedToken) {
       console.error("DATA_REFRESH_TOKEN not configured");
-      return NextResponse.json(
-        { error: "Server configuration error" },
-        { status: 500 },
-      );
+      return NextResponse.json({ error: "Server configuration error" }, { status: 500 });
     }
 
     if (!refreshToken || refreshToken !== expectedToken) {
@@ -33,9 +30,6 @@ export async function POST(request: NextRequest) {
     });
   } catch (error) {
     console.error("Cache refresh error:", error);
-    return NextResponse.json(
-      { error: "Failed to refresh cache" },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: "Failed to refresh cache" }, { status: 500 });
   }
 }

--- a/webapp/src/app/globals.css
+++ b/webapp/src/app/globals.css
@@ -23,11 +23,7 @@
 }
 
 :root {
-  --background: linear-gradient(
-    135deg,
-    rgba(226, 246, 243, 1) 0%,
-    rgba(238, 246, 226, 1) 100%
-  );
+  --background: linear-gradient(135deg, rgba(226, 246, 243, 1) 0%, rgba(238, 246, 226, 1) 100%);
   --foreground: #171717;
 
   /* Figma Design System Colors */

--- a/webapp/src/app/layout.tsx
+++ b/webapp/src/app/layout.tsx
@@ -1,11 +1,5 @@
 import type { Metadata } from "next";
-import {
-  Geist,
-  Geist_Mono,
-  Inter,
-  Noto_Sans,
-  Noto_Sans_JP,
-} from "next/font/google";
+import { Geist, Geist_Mono, Inter, Noto_Sans, Noto_Sans_JP } from "next/font/google";
 import "./globals.css";
 import { GoogleAnalytics } from "@next/third-parties/google";
 import { SpeedInsights } from "@vercel/speed-insights/next";
@@ -47,12 +41,10 @@ const inter = Inter({
 
 export const metadata: Metadata = {
   title: "みらい まる見え政治資金 - チームみらいの政治資金をオープンに",
-  description:
-    "チームみらいの政治資金の流れを透明性を持って公開するプラットフォームです。",
+  description: "チームみらいの政治資金の流れを透明性を持って公開するプラットフォームです。",
   openGraph: {
     title: "みらい まる見え政治資金 - チームみらいの政治資金をオープンに",
-    description:
-      "チームみらいの政治資金の流れを透明性を持って公開するプラットフォームです。",
+    description: "チームみらいの政治資金の流れを透明性を持って公開するプラットフォームです。",
     images: [
       {
         url: "/social/og_image.png",
@@ -67,8 +59,7 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     title: "みらい まる見え政治資金 - チームみらいの政治資金をオープンに",
-    description:
-      "チームみらいの政治資金の流れを透明性を持って公開するプラットフォームです。",
+    description: "チームみらいの政治資金の流れを透明性を持って公開するプラットフォームです。",
     images: ["/social/og_image.png"],
   },
 };

--- a/webapp/src/app/o/[slug]/page.tsx
+++ b/webapp/src/app/o/[slug]/page.tsx
@@ -24,9 +24,7 @@ interface OrgPageProps {
   }>;
 }
 
-export async function generateMetadata({
-  params,
-}: OrgPageProps): Promise<Metadata> {
+export async function generateMetadata({ params }: OrgPageProps): Promise<Metadata> {
   const { slug } = await params;
 
   const { organizations } = await loadOrganizations();
@@ -66,9 +64,7 @@ export default async function OrgPage({ params }: OrgPageProps) {
     return null;
   });
 
-  const updatedAt = formatUpdatedAt(
-    data?.transactionData?.lastUpdatedAt ?? null,
-  );
+  const updatedAt = formatUpdatedAt(data?.transactionData?.lastUpdatedAt ?? null);
 
   return (
     <MainColumn>

--- a/webapp/src/app/o/[slug]/transactions/page.tsx
+++ b/webapp/src/app/o/[slug]/transactions/page.tsx
@@ -31,9 +31,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { slug } = await params;
   const { default: defaultSlug, organizations } = await loadOrganizations();
-  const validSlug = organizations.some((org) => org.slug === slug)
-    ? slug
-    : defaultSlug;
+  const validSlug = organizations.some((org) => org.slug === slug) ? slug : defaultSlug;
 
   const organization = organizations.find((org) => org.slug === validSlug);
 
@@ -43,10 +41,7 @@ export async function generateMetadata({
   };
 }
 
-export default async function TransactionsPage({
-  params,
-  searchParams,
-}: TransactionsPageProps) {
+export default async function TransactionsPage({ params, searchParams }: TransactionsPageProps) {
   const { slug } = await params;
 
   // slugの妥当性をチェックし、必要に応じてリダイレクト
@@ -84,9 +79,7 @@ export default async function TransactionsPage({
 
   // categories: multiple category keys for filtering (comma-separated)
   const categories = searchParamsResolved.categories
-    ? decodeURIComponent(String(searchParamsResolved.categories))
-        .split(",")
-        .filter(Boolean)
+    ? decodeURIComponent(String(searchParamsResolved.categories)).split(",").filter(Boolean)
     : undefined;
 
   const financialYear = 2025; // 固定値
@@ -103,9 +96,7 @@ export default async function TransactionsPage({
       categories,
     });
 
-    const organization = data.politicalOrganizations.find(
-      (org) => org.slug === slug,
-    );
+    const organization = data.politicalOrganizations.find((org) => org.slug === slug);
     const updatedAt = formatUpdatedAt(data.lastUpdatedAt ?? null);
 
     return (
@@ -115,12 +106,7 @@ export default async function TransactionsPage({
           <MainColumnCard>
             <CardHeader
               icon={
-                <Image
-                  src="/icons/icon-cashback.svg"
-                  alt="Cash move icon"
-                  width={30}
-                  height={30}
-                />
+                <Image src="/icons/icon-cashback.svg" alt="Cash move icon" width={30} height={30} />
               }
               organizationName={organization?.displayName || "未登録の政治団体"}
               title="すべての出入金"

--- a/webapp/src/app/privacy/page.tsx
+++ b/webapp/src/app/privacy/page.tsx
@@ -76,9 +76,7 @@ export default function PrivacyPage() {
         </div>
 
         <div>
-          <SubSectionTitle>
-            7. プライバシーポリシーの改訂と通知について
-          </SubSectionTitle>
+          <SubSectionTitle>7. プライバシーポリシーの改訂と通知について</SubSectionTitle>
           <Paragraph>
             このプライバシーポリシーは、必要に応じて内容の見直しを行い、改訂されることがあります。その際、個別の通知は行いませんので、最新の情報については当ウェブサイトをご確認ください。
           </Paragraph>

--- a/webapp/src/client/components/common/AnotherPageLinkSection.tsx
+++ b/webapp/src/client/components/common/AnotherPageLinkSection.tsx
@@ -6,17 +6,13 @@ interface AnotherPageLinkSectionProps {
   currentSlug: string;
 }
 
-export default function AnotherPageLinkSection({
-  currentSlug,
-}: AnotherPageLinkSectionProps) {
+export default function AnotherPageLinkSection({ currentSlug }: AnotherPageLinkSectionProps) {
   const getTargetSlug = () => {
     return currentSlug === "digimin" ? "team-mirai" : "digimin";
   };
 
   const getTargetOrgName = () => {
-    return currentSlug === "digimin"
-      ? "政党・チームみらい"
-      : "党首・安野貴博の政治団体";
+    return currentSlug === "digimin" ? "政党・チームみらい" : "党首・安野貴博の政治団体";
   };
   return (
     <div className="w-full md:flex md:justify-end">

--- a/webapp/src/client/components/common/TransparencySection.tsx
+++ b/webapp/src/client/components/common/TransparencySection.tsx
@@ -4,9 +4,7 @@ interface TransparencySectionProps {
   title: string;
 }
 
-export default function TransparencySection({
-  title,
-}: TransparencySectionProps) {
+export default function TransparencySection({ title }: TransparencySectionProps) {
   return (
     <div className="flex items-center self-stretch bg-gradient-to-br from-[#64D8C6] to-[#BCECD3] rounded-[22px] p-8 sm:p-12">
       <div className="flex flex-col justify-center gap-2 sm:gap-[10.84px]">

--- a/webapp/src/client/components/layout/CardHeader.tsx
+++ b/webapp/src/client/components/layout/CardHeader.tsx
@@ -39,9 +39,7 @@ export default function CardHeader({
         </div>
 
         {/* サブタイトル */}
-        <Subtitle className="text-[--color-text-secondary]">
-          {subtitle}
-        </Subtitle>
+        <Subtitle className="text-[--color-text-secondary]">{subtitle}</Subtitle>
       </div>
 
       {/* 右側：更新時刻（SPでは非表示） */}

--- a/webapp/src/client/components/layout/LegalPageLayout.tsx
+++ b/webapp/src/client/components/layout/LegalPageLayout.tsx
@@ -7,9 +7,7 @@ interface SectionTitleProps {
 
 export function SectionTitle({ children }: SectionTitleProps) {
   return (
-    <h2 className="text-xl sm:text-2xl font-bold text-gray-800 mb-6 font-japanese">
-      {children}
-    </h2>
+    <h2 className="text-xl sm:text-2xl font-bold text-gray-800 mb-6 font-japanese">{children}</h2>
   );
 }
 
@@ -19,9 +17,7 @@ interface SubSectionTitleProps {
 
 export function SubSectionTitle({ children }: SubSectionTitleProps) {
   return (
-    <h3 className="text-base sm:text-lg font-bold text-gray-800 mb-3 font-japanese">
-      {children}
-    </h3>
+    <h3 className="text-base sm:text-lg font-bold text-gray-800 mb-3 font-japanese">{children}</h3>
   );
 }
 
@@ -59,10 +55,7 @@ interface LegalPageLayoutProps {
   children: React.ReactNode;
 }
 
-export default function LegalPageLayout({
-  title,
-  children,
-}: LegalPageLayoutProps) {
+export default function LegalPageLayout({ title, children }: LegalPageLayoutProps) {
   return (
     <MainColumn>
       <MainColumnCard>

--- a/webapp/src/client/components/layout/MainColumn.tsx
+++ b/webapp/src/client/components/layout/MainColumn.tsx
@@ -3,14 +3,9 @@ interface MainColumnProps {
   className?: string;
 }
 
-export default function MainColumn({
-  children,
-  className = "",
-}: MainColumnProps) {
+export default function MainColumn({ children, className = "" }: MainColumnProps) {
   return (
-    <main
-      className={`mx-auto max-w-[1032px] px-5 sm:px-0 py-5 sm:py-6 space-y-12 ${className}`}
-    >
+    <main className={`mx-auto max-w-[1032px] px-5 sm:px-0 py-5 sm:py-6 space-y-12 ${className}`}>
       {children}
     </main>
   );

--- a/webapp/src/client/components/layout/MainColumnCard.tsx
+++ b/webapp/src/client/components/layout/MainColumnCard.tsx
@@ -4,11 +4,7 @@ interface MainColumnCardProps {
   id?: string;
 }
 
-export default function MainColumnCard({
-  children,
-  className = "",
-  id,
-}: MainColumnCardProps) {
+export default function MainColumnCard({ children, className = "", id }: MainColumnCardProps) {
   return (
     <div
       className={`bg-white rounded-[24px] px-[18px] py-8 sm:p-12 space-y-8 scroll-mt-24 ${className}`}

--- a/webapp/src/client/components/layout/footer/Footer.tsx
+++ b/webapp/src/client/components/layout/footer/Footer.tsx
@@ -106,9 +106,7 @@ export default function Footer() {
   const pathname = usePathname();
 
   // 現在のslugを取得（/o/[slug]/... の形式の場合、なければdefaultを使用）
-  const currentSlug = pathname.startsWith("/o/")
-    ? pathname.split("/")[2]
-    : "team-mirai";
+  const currentSlug = pathname.startsWith("/o/") ? pathname.split("/")[2] : "team-mirai";
 
   const textLinks = getTextLinks(currentSlug);
 
@@ -153,9 +151,7 @@ export default function Footer() {
           </div>
 
           {/* PC: 2行目（残り）*/}
-          <div className="hidden lg:flex gap-8">
-            {textLinks.slice(7).map(renderTextLink)}
-          </div>
+          <div className="hidden lg:flex gap-8">{textLinks.slice(7).map(renderTextLink)}</div>
         </div>
 
         {/* SNS Icons */}
@@ -183,9 +179,7 @@ export default function Footer() {
                 <span className="hidden lg:block text-base font-bold text-black">
                   {social.mainText || social.name}
                   {social.subText && (
-                    <span className="text-xs ml-1 opacity-80">
-                      {social.subText}
-                    </span>
+                    <span className="text-xs ml-1 opacity-80">{social.subText}</span>
                   )}
                 </span>
               </a>

--- a/webapp/src/client/components/layout/header/HeaderClient.tsx
+++ b/webapp/src/client/components/layout/header/HeaderClient.tsx
@@ -48,9 +48,7 @@ export default function HeaderClient({ organizations }: HeaderClientProps) {
   const pathname = usePathname();
 
   // 現在のslugを取得（/o/[slug]/... の形式の場合、なければdefaultを使用）
-  const currentSlug = pathname.startsWith("/o/")
-    ? pathname.split("/")[2]
-    : organizations.default;
+  const currentSlug = pathname.startsWith("/o/") ? pathname.split("/")[2] : organizations.default;
   const logoHref = `/o/${organizations.default}/`;
   const navigationItems = getNavigationItems(currentSlug);
 
@@ -128,10 +126,7 @@ export default function HeaderClient({ organizations }: HeaderClientProps) {
                 })}
             </nav>
             <div className="flex items-center w-full max-w-[217px] min-w-0 h-12 flex-shrink">
-              <OrganizationSelector
-                organizations={organizations}
-                initialSlug={currentSlug}
-              />
+              <OrganizationSelector organizations={organizations} initialSlug={currentSlug} />
             </div>
           </div>
         </div>

--- a/webapp/src/client/components/top-page/BalanceSheetSection.tsx
+++ b/webapp/src/client/components/top-page/BalanceSheetSection.tsx
@@ -19,14 +19,7 @@ export default function BalanceSheetSection({
   return (
     <MainColumnCard id="balance-sheet">
       <CardHeader
-        icon={
-          <Image
-            src="/icons/balance.svg"
-            alt="Balance sheet icon"
-            width={30}
-            height={30}
-          />
-        }
+        icon={<Image src="/icons/balance.svg" alt="Balance sheet icon" width={30} height={30} />}
         organizationName={organizationName || "未登録の政治団体"}
         title="現時点での貸借対照表"
         updatedAt={updatedAt}
@@ -43,9 +36,7 @@ export default function BalanceSheetSection({
 
       {/* 更新日時 */}
       <div className="mt-4 text-right md:hidden">
-        <span className="text-xs font-normal text-[#9CA3AF] leading-[1.33]">
-          {updatedAt}
-        </span>
+        <span className="text-xs font-normal text-[#9CA3AF] leading-[1.33]">{updatedAt}</span>
       </div>
     </MainColumnCard>
   );

--- a/webapp/src/client/components/top-page/CashFlowSection.tsx
+++ b/webapp/src/client/components/top-page/CashFlowSection.tsx
@@ -22,23 +22,14 @@ export default function CashFlowSection({
   updatedAt,
   organizationName,
 }: CashFlowSectionProps) {
-  const [activeTab, setActiveTab] = useState<"political" | "friendly">(
-    "friendly",
-  );
+  const [activeTab, setActiveTab] = useState<"political" | "friendly">("friendly");
 
   const currentData = activeTab === "political" ? political : friendly;
 
   return (
     <MainColumnCard id="cash-flow">
       <CardHeader
-        icon={
-          <Image
-            src="/icons/icon-cashflow.svg"
-            alt="Cash flow icon"
-            width={30}
-            height={31}
-          />
-        }
+        icon={<Image src="/icons/icon-cashflow.svg" alt="Cash flow icon" width={30} height={31} />}
         organizationName={organizationName || "未登録の政治団体"}
         title="収支の流れ"
         updatedAt={updatedAt}
@@ -79,17 +70,13 @@ export default function CashFlowSection({
         {currentData ? (
           <SankeyChart data={currentData} />
         ) : (
-          <div className="text-gray-500 mx-4">
-            サンキー図データが取得できませんでした
-          </div>
+          <div className="text-gray-500 mx-4">サンキー図データが取得できませんでした</div>
         )}
       </div>
 
       {/* 更新日時 */}
       <div className="text-right md:hidden">
-        <span className="text-xs font-normal text-[#9CA3AF] leading-[1.33]">
-          {updatedAt}
-        </span>
+        <span className="text-xs font-normal text-[#9CA3AF] leading-[1.33]">{updatedAt}</span>
       </div>
     </MainColumnCard>
   );

--- a/webapp/src/client/components/top-page/DonationSummarySection.tsx
+++ b/webapp/src/client/components/top-page/DonationSummarySection.tsx
@@ -12,9 +12,7 @@ interface DonationSummarySectionProps {
   donationSummary?: DonationSummaryData;
 }
 
-export default function DonationSummarySection({
-  donationSummary,
-}: DonationSummarySectionProps) {
+export default function DonationSummarySection({ donationSummary }: DonationSummarySectionProps) {
   // サーバーサイドで計算された統計情報を使用
   const totalDonationAmount = donationSummary?.totalAmount || 0;
   const dayOverDayChange = donationSummary?.amountDayOverDay || 0;
@@ -45,11 +43,7 @@ export default function DonationSummarySection({
     return { oku, man, en };
   };
 
-  const {
-    oku: totalOku,
-    man: totalMan,
-    en: totalEn,
-  } = formatLargeAmount(totalDonationAmount);
+  const { oku: totalOku, man: totalMan, en: totalEn } = formatLargeAmount(totalDonationAmount);
 
   return (
     <MainColumnCard id="donation-summary">
@@ -83,11 +77,7 @@ export default function DonationSummarySection({
         <p className="text-gray-800 font-bold text-base leading-7 mb-6">
           チームみらいは、皆さまのご支援・ご寄附のおかげで活動を続けられております。
         </p>
-        <Link
-          href="https://team-mir.ai/support/donation"
-          target="_blank"
-          rel="noopener"
-        >
+        <Link href="https://team-mir.ai/support/donation" target="_blank" rel="noopener">
           <MainButton>ご寄附はこちら</MainButton>
         </Link>
       </div>

--- a/webapp/src/client/components/top-page/MonthlyTrendsSection.tsx
+++ b/webapp/src/client/components/top-page/MonthlyTrendsSection.tsx
@@ -24,14 +24,7 @@ export default function MonthlyTrendsSection({
   return (
     <MainColumnCard id="monthly-trends">
       <CardHeader
-        icon={
-          <Image
-            src="/icons/icon-barchart.svg"
-            alt="Bar chart icon"
-            width={30}
-            height={30}
-          />
-        }
+        icon={<Image src="/icons/icon-barchart.svg" alt="Bar chart icon" width={30} height={30} />}
         organizationName={organizationName || "未登録の政治団体"}
         title="月ごとの収支の推移"
         updatedAt={updatedAt}
@@ -45,9 +38,7 @@ export default function MonthlyTrendsSection({
 
       {/* 更新日時 */}
       <div className="mt-4 text-right md:hidden">
-        <span className="text-xs font-normal text-[#9CA3AF] leading-[1.33]">
-          {updatedAt}
-        </span>
+        <span className="text-xs font-normal text-[#9CA3AF] leading-[1.33]">{updatedAt}</span>
       </div>
     </MainColumnCard>
   );

--- a/webapp/src/client/components/top-page/TransactionsSection.tsx
+++ b/webapp/src/client/components/top-page/TransactionsSection.tsx
@@ -33,14 +33,7 @@ export default function TransactionsSection({
   return (
     <MainColumnCard id="transactions">
       <CardHeader
-        icon={
-          <Image
-            src="/icons/icon-cashback.svg"
-            alt="Cash move icon"
-            width={30}
-            height={30}
-          />
-        }
+        icon={<Image src="/icons/icon-cashback.svg" alt="Cash move icon" width={30} height={30} />}
         organizationName={organizationName || "未登録の政治団体"}
         title="すべての出入金"
         updatedAt={updatedAt}
@@ -67,9 +60,7 @@ export default function TransactionsSection({
           </div>
         </div>
       ) : (
-        <div className="text-gray-500 text-center py-8">
-          取引データが取得できませんでした
-        </div>
+        <div className="text-gray-500 text-center py-8">取引データが取得できませんでした</div>
       )}
     </MainColumnCard>
   );

--- a/webapp/src/client/components/top-page/features/charts/BalanceSheetChart.tsx
+++ b/webapp/src/client/components/top-page/features/charts/BalanceSheetChart.tsx
@@ -48,9 +48,7 @@ export default function BalanceSheetChart({ data }: BalanceSheetChartProps) {
 
     return (
       <span className="inline-flex items-baseline gap-0.5">
-        {isDebtExcess && (
-          <span className="text-sm font-bold text-red-600">▲</span>
-        )}
+        {isDebtExcess && <span className="text-sm font-bold text-red-600">▲</span>}
         {parts
           .map((part, index) => ({ part, index }))
           .filter(({ part }) => part !== "")
@@ -59,9 +57,7 @@ export default function BalanceSheetChart({ data }: BalanceSheetChartProps) {
             return (
               <span
                 key={`part-${index}-${part}`}
-                className={
-                  isNumber ? "text-lg font-bold" : "text-xs font-medium"
-                }
+                className={isNumber ? "text-lg font-bold" : "text-xs font-medium"}
                 style={{
                   fontFamily: isNumber
                     ? "'SF Pro', -apple-system, system-ui, sans-serif"
@@ -77,8 +73,7 @@ export default function BalanceSheetChart({ data }: BalanceSheetChartProps) {
   };
 
   // 左側（資産）の計算
-  const leftTotal =
-    data.left.currentAssets + data.left.fixedAssets + data.left.debtExcess;
+  const leftTotal = data.left.currentAssets + data.left.fixedAssets + data.left.debtExcess;
 
   const leftItems: BalanceSheetItem[] = [
     {
@@ -104,9 +99,7 @@ export default function BalanceSheetChart({ data }: BalanceSheetChartProps) {
 
   // 右側（負債・資本）の計算
   const rightTotal =
-    data.right.currentLiabilities +
-    data.right.fixedLiabilities +
-    data.right.netAssets;
+    data.right.currentLiabilities + data.right.fixedLiabilities + data.right.netAssets;
 
   const rightItems: BalanceSheetItem[] = [
     {
@@ -148,9 +141,7 @@ export default function BalanceSheetChart({ data }: BalanceSheetChartProps) {
       >
         {isSmall ? (
           // 小さい場合：一行表示
-          <div
-            className={`text-center ${item.isDebtExcess ? "text-red-600" : "text-black"}`}
-          >
+          <div className={`text-center ${item.isDebtExcess ? "text-red-600" : "text-black"}`}>
             <span
               className="text-sm font-bold"
               style={{ fontFamily: "'Noto Sans JP', sans-serif" }}
@@ -185,14 +176,10 @@ export default function BalanceSheetChart({ data }: BalanceSheetChartProps) {
         aria-label="貸借対照表チャート"
       >
         {/* 左側（資産） */}
-        <div className="flex-1 flex flex-col">
-          {leftItems.map((item) => renderItem(item))}
-        </div>
+        <div className="flex-1 flex flex-col">{leftItems.map((item) => renderItem(item))}</div>
 
         {/* 右側（負債・資本） */}
-        <div className="flex-1 flex flex-col">
-          {rightItems.map((item) => renderItem(item))}
-        </div>
+        <div className="flex-1 flex flex-col">{rightItems.map((item) => renderItem(item))}</div>
       </div>
     </div>
   );

--- a/webapp/src/client/components/top-page/features/charts/DonationChart.tsx
+++ b/webapp/src/client/components/top-page/features/charts/DonationChart.tsx
@@ -23,10 +23,7 @@ interface ChartDataPoint {
   cumulativeAmount: number;
 }
 
-export default function DonationChart({
-  data,
-  height = 287,
-}: DonationChartProps) {
+export default function DonationChart({ data, height = 287 }: DonationChartProps) {
   // BFF側で既に90日分に絞られているので、全データを使用
   const chartData: ChartDataPoint[] = data.map((item) => ({
     date: item.date,
@@ -57,14 +54,9 @@ export default function DonationChart({
   // データが空の場合
   if (chartData.length === 0) {
     return (
-      <div
-        className="bg-gray-50 rounded-lg flex items-center justify-center"
-        style={{ height }}
-      >
+      <div className="bg-gray-50 rounded-lg flex items-center justify-center" style={{ height }}>
         <div className="text-center text-gray-500">
-          <div className="text-lg font-medium mb-2">
-            直近3ヶ月の寄附金額の推移
-          </div>
+          <div className="text-lg font-medium mb-2">直近3ヶ月の寄附金額の推移</div>
           <div className="text-sm">データがありません</div>
         </div>
       </div>

--- a/webapp/src/client/components/top-page/features/charts/InteractiveRect.tsx
+++ b/webapp/src/client/components/top-page/features/charts/InteractiveRect.tsx
@@ -43,9 +43,7 @@ export default function InteractiveRect({
       height={height}
       fill={fill}
       opacity={1}
-      aria-label={`${label || id}: ¥${Math.round(value || 0).toLocaleString(
-        "ja-JP",
-      )}`}
+      aria-label={`${label || id}: ¥${Math.round(value || 0).toLocaleString("ja-JP")}`}
       onMouseEnter={(e) => onMouseEnter(e, { id, label, value })}
       onMouseLeave={onMouseLeave}
       onMouseMove={onMouseMove}

--- a/webapp/src/client/components/top-page/features/charts/SankeyChart.tsx
+++ b/webapp/src/client/components/top-page/features/charts/SankeyChart.tsx
@@ -92,21 +92,13 @@ interface SankeyChartProps {
 
 const getNodeWidth = (nodeType: string | undefined, isMobile: boolean) => {
   if (nodeType === "total") {
-    return !isMobile
-      ? DIMENSIONS.TOTAL_WIDTH_DESKTOP
-      : DIMENSIONS.TOTAL_WIDTH_MOBILE;
+    return !isMobile ? DIMENSIONS.TOTAL_WIDTH_DESKTOP : DIMENSIONS.TOTAL_WIDTH_MOBILE;
   }
-  return !isMobile
-    ? DIMENSIONS.REGULAR_WIDTH_DESKTOP
-    : DIMENSIONS.REGULAR_WIDTH_MOBILE;
+  return !isMobile ? DIMENSIONS.REGULAR_WIDTH_DESKTOP : DIMENSIONS.REGULAR_WIDTH_MOBILE;
 };
 
 // カスタムノードレイヤー（合計ボックスを太くする）
-const CustomNodesLayer = ({
-  nodes,
-}: {
-  nodes: readonly SankeyNodeWithPosition[];
-}) => {
+const CustomNodesLayer = ({ nodes }: { nodes: readonly SankeyNodeWithPosition[] }) => {
   const isMobile = useMobileDetection();
   const { getNodeColor } = useNodeColors();
   const [tooltip, setTooltip] = useState<{
@@ -125,8 +117,7 @@ const CustomNodesLayer = ({
 
     // 支出側（expense, expense-sub）かどうかを判定
     const isExpenseSide =
-      originalNode?.nodeType === "expense" ||
-      originalNode?.nodeType === "expense-sub";
+      originalNode?.nodeType === "expense" || originalNode?.nodeType === "expense-sub";
 
     setTooltip({
       visible: true,
@@ -151,8 +142,7 @@ const CustomNodesLayer = ({
     if (tooltip.visible && tooltip.node) {
       // 支出側（expense, expense-sub）かどうかを判定
       const isExpenseSide =
-        tooltip.node.nodeType === "expense" ||
-        tooltip.node.nodeType === "expense-sub";
+        tooltip.node.nodeType === "expense" || tooltip.node.nodeType === "expense-sub";
 
       setTooltip((prev) => ({
         ...prev,
@@ -213,8 +203,7 @@ const CustomNodesLayer = ({
               minWidth: "max-content",
               // 支出側の場合は右側を基準に配置
               transform:
-                tooltip.node?.nodeType === "expense" ||
-                tooltip.node?.nodeType === "expense-sub"
+                tooltip.node?.nodeType === "expense" || tooltip.node?.nodeType === "expense-sub"
                   ? "translateX(-100%)"
                   : "none",
             }}
@@ -222,9 +211,7 @@ const CustomNodesLayer = ({
             <div style={{ marginBottom: "3px", fontWeight: "700" }}>
               {tooltip.node.label || tooltip.node.id}
             </div>
-            <div
-              style={{ fontSize: "14px", fontWeight: "700", color: "#1E293B" }}
-            >
+            <div style={{ fontSize: "14px", fontWeight: "700", color: "#1E293B" }}>
               ¥{Math.round(tooltip.node.value || 0).toLocaleString("ja-JP")}
             </div>
           </div>,
@@ -276,9 +263,7 @@ const renderTotalNodeLabels = (
       </tspan>
       <tspan
         x={node.x + node.width / 2}
-        dy={
-          !isMobile ? DIMENSIONS.TSPAN_DY_DESKTOP : DIMENSIONS.TSPAN_DY_MOBILE
-        }
+        dy={!isMobile ? DIMENSIONS.TSPAN_DY_DESKTOP : DIMENSIONS.TSPAN_DY_MOBILE}
       >
         {TEXT_CONFIG.TOTAL_LABEL_PERCENTAGE}
       </tspan>
@@ -390,8 +375,7 @@ const renderPrimaryLabel = (
   isMobile: boolean,
 ) => {
   const label = node.label || node.id;
-  const isSubcategory =
-    node.nodeType === "income-sub" || node.nodeType === "expense-sub";
+  const isSubcategory = node.nodeType === "income-sub" || node.nodeType === "expense-sub";
 
   const fontSize = !isMobile
     ? isSubcategory
@@ -447,11 +431,7 @@ const renderPrimaryLabel = (
       dominantBaseline="middle"
     >
       {lines.map((line, index) => (
-        <tspan
-          key={`${node.id}-${index}`}
-          x={x}
-          dy={index === 0 ? 0 : lineHeight}
-        >
+        <tspan key={`${node.id}-${index}`} x={x} dy={index === 0 ? 0 : lineHeight}>
           {line}
         </tspan>
       ))}
@@ -460,34 +440,23 @@ const renderPrimaryLabel = (
 };
 
 // カスタムラベルレイヤー（プライマリ + セカンダリ）
-const CustomLabelsLayer = ({
-  nodes,
-}: {
-  nodes: readonly SankeyNodeWithPosition[];
-}) => {
+const CustomLabelsLayer = ({ nodes }: { nodes: readonly SankeyNodeWithPosition[] }) => {
   const isMobile = useMobileDetection();
   const { getNodeColor, getPercentageTextColor } = useNodeColors();
 
   // 全体の合計値を計算（合計ノードの値を使用）
-  const totalValue =
-    nodes.find((node) => node.label === TEXT_CONFIG.TOTAL_NODE_ID)?.value || 0;
+  const totalValue = nodes.find((node) => node.label === TEXT_CONFIG.TOTAL_NODE_ID)?.value || 0;
 
   return (
     <g>
       {nodes.map((node: SankeyNodeWithPosition) => {
         // ノードタイプで収入・支出を判定
-        const isLeft =
-          node.nodeType === "income" || node.nodeType === "income-sub";
+        const isLeft = node.nodeType === "income" || node.nodeType === "income-sub";
         const x = isLeft
-          ? node.x -
-            (!isMobile
-              ? DIMENSIONS.LABEL_OFFSET_DESKTOP
-              : DIMENSIONS.LABEL_OFFSET_MOBILE)
+          ? node.x - (!isMobile ? DIMENSIONS.LABEL_OFFSET_DESKTOP : DIMENSIONS.LABEL_OFFSET_MOBILE)
           : node.x +
             node.width +
-            (!isMobile
-              ? DIMENSIONS.LABEL_OFFSET_DESKTOP
-              : DIMENSIONS.LABEL_OFFSET_MOBILE);
+            (!isMobile ? DIMENSIONS.LABEL_OFFSET_DESKTOP : DIMENSIONS.LABEL_OFFSET_MOBILE);
         const textAnchor = isLeft ? "end" : "start";
         const percentageY = node.y - DIMENSIONS.PERCENTAGE_OFFSET;
         const percentageText = calculatePercentageText(node.value, totalValue);
@@ -495,9 +464,7 @@ const CustomLabelsLayer = ({
         const elements = [];
 
         if (node.nodeType === "total") {
-          elements.push(
-            ...renderTotalNodeLabels(node, boxColor, percentageY, isMobile),
-          );
+          elements.push(...renderTotalNodeLabels(node, boxColor, percentageY, isMobile));
         } else if (percentageText) {
           const percentageLabel = renderPercentageLabel(
             node,
@@ -532,13 +499,7 @@ export default function SankeyChart({ data }: SankeyChartProps) {
   const { sortNodes, sortLinks } = useSankeySorting(safeData);
 
   // データが空または不正な場合の早期リターン
-  if (
-    !data ||
-    !data.nodes ||
-    !data.links ||
-    data.nodes.length === 0 ||
-    data.links.length === 0
-  ) {
+  if (!data || !data.nodes || !data.links || data.nodes.length === 0 || data.links.length === 0) {
     return (
       <div
         style={{
@@ -570,9 +531,7 @@ export default function SankeyChart({ data }: SankeyChartProps) {
   return (
     <div
       style={{
-        height: !isMobile
-          ? DIMENSIONS.CHART_HEIGHT_DESKTOP
-          : DIMENSIONS.CHART_HEIGHT_MOBILE,
+        height: !isMobile ? DIMENSIONS.CHART_HEIGHT_DESKTOP : DIMENSIONS.CHART_HEIGHT_MOBILE,
       }}
       className="sankey-container !mb-0"
       role="img"
@@ -593,15 +552,10 @@ export default function SankeyChart({ data }: SankeyChartProps) {
       <ResponsiveSankey
         data={processedData}
         label={(node) => {
-          return (
-            (node as { label?: string; id: string }).label ||
-            (node as { id: string }).id
-          );
+          return (node as { label?: string; id: string }).label || (node as { id: string }).id;
         }}
         margin={{
-          top: !isMobile
-            ? CHART_CONFIG.MARGIN_TOP_DESKTOP
-            : CHART_CONFIG.MARGIN_TOP_MOBILE,
+          top: !isMobile ? CHART_CONFIG.MARGIN_TOP_DESKTOP : CHART_CONFIG.MARGIN_TOP_MOBILE,
           right: !isMobile
             ? CHART_CONFIG.MARGIN_HORIZONTAL_DESKTOP
             : CHART_CONFIG.MARGIN_HORIZONTAL_MOBILE,
@@ -618,16 +572,12 @@ export default function SankeyChart({ data }: SankeyChartProps) {
             (node as { label?: string }).label,
           )
         }
-        valueFormat={(v) =>
-          `¥${Math.round(v as number).toLocaleString("ja-JP")}`
-        }
+        valueFormat={(v) => `¥${Math.round(v as number).toLocaleString("ja-JP")}`}
         nodeOpacity={1}
         nodeBorderWidth={0}
         nodeThickness={CHART_CONFIG.NODE_THICKNESS}
         nodeSpacing={
-          !isMobile
-            ? CHART_CONFIG.NODE_SPACING_DESKTOP
-            : CHART_CONFIG.NODE_SPACING_MOBILE
+          !isMobile ? CHART_CONFIG.NODE_SPACING_DESKTOP : CHART_CONFIG.NODE_SPACING_MOBILE
         }
         sort="input"
         linkOpacity={CHART_CONFIG.LINK_OPACITY}
@@ -639,9 +589,7 @@ export default function SankeyChart({ data }: SankeyChartProps) {
         theme={{
           labels: {
             text: {
-              fontSize: !isMobile
-                ? DIMENSIONS.FONT_SIZE_DESKTOP
-                : DIMENSIONS.FONT_SIZE_MOBILE,
+              fontSize: !isMobile ? DIMENSIONS.FONT_SIZE_DESKTOP : DIMENSIONS.FONT_SIZE_MOBILE,
               fontWeight: "bold",
             },
           },

--- a/webapp/src/client/components/top-page/features/charts/useSankeyHelpers.ts
+++ b/webapp/src/client/components/top-page/features/charts/useSankeyHelpers.ts
@@ -43,37 +43,28 @@ export function useMobileDetection() {
 export function useNodeColors() {
   // 統一されたノード色取得関数
   const getNodeColor = useCallback(
-    (
-      nodeType?: string,
-      variant: "fill" | "light" | "box" = "fill",
-      nodeLabel?: string,
-    ): string => {
+    (nodeType?: string, variant: "fill" | "light" | "box" = "fill", nodeLabel?: string): string => {
       // 特別なノードの判定（labelベース）
       if (nodeLabel === "現金残高") {
         if (variant === "light") return COLORS.CASH_BALANCE_LIGHT;
-        if (variant === "box" || variant === "fill")
-          return COLORS.CASH_BALANCE_BOX;
+        if (variant === "box" || variant === "fill") return COLORS.CASH_BALANCE_BOX;
         return COLORS.TEXT;
       }
 
       if (nodeLabel === "昨年からの現金残高") {
         if (variant === "light") return COLORS.CASH_BALANCE_LIGHT;
-        if (variant === "box" || variant === "fill")
-          return COLORS.CASH_BALANCE_BOX;
+        if (variant === "box" || variant === "fill") return COLORS.CASH_BALANCE_BOX;
         return COLORS.TEXT;
       }
 
       if (nodeLabel === "収支") {
         if (variant === "light") return COLORS.CASH_BALANCE_LIGHT;
-        if (variant === "box" || variant === "fill")
-          return COLORS.CASH_BALANCE_BOX;
+        if (variant === "box" || variant === "fill") return COLORS.CASH_BALANCE_BOX;
         return COLORS.TEXT;
       }
 
       if (nodeLabel === "未払費用") {
-        return variant === "light"
-          ? COLORS.PROCESSING_LIGHT
-          : COLORS.PROCESSING_ERROR;
+        return variant === "light" ? COLORS.PROCESSING_LIGHT : COLORS.PROCESSING_ERROR;
       }
 
       // 通常のノードタイプ判定
@@ -91,28 +82,25 @@ export function useNodeColors() {
   );
 
   // パーセンテージテキスト色取得関数
-  const getPercentageTextColor = useCallback(
-    (nodeLabel?: string, boxColor?: string): string => {
-      if (nodeLabel === "未払費用") {
-        return COLORS.EXPENSE;
-      }
+  const getPercentageTextColor = useCallback((nodeLabel?: string, boxColor?: string): string => {
+    if (nodeLabel === "未払費用") {
+      return COLORS.EXPENSE;
+    }
 
-      if (nodeLabel === "現金残高") {
-        return COLORS.TEXT;
-      }
+    if (nodeLabel === "現金残高") {
+      return COLORS.TEXT;
+    }
 
-      if (nodeLabel === "収支") {
-        return COLORS.PERCENTAGE_DARK;
-      }
+    if (nodeLabel === "収支") {
+      return COLORS.PERCENTAGE_DARK;
+    }
 
-      if (nodeLabel === "昨年からの現金残高") {
-        return COLORS.PERCENTAGE_DARK;
-      }
+    if (nodeLabel === "昨年からの現金残高") {
+      return COLORS.PERCENTAGE_DARK;
+    }
 
-      return boxColor || COLORS.TEXT;
-    },
-    [],
-  );
+    return boxColor || COLORS.TEXT;
+  }, []);
 
   return { getNodeColor, getPercentageTextColor };
 }
@@ -135,11 +123,7 @@ export function useLinkColors(data: SankeyData) {
         };
       }
 
-      const targetColor = getNodeColor(
-        targetNode?.nodeType,
-        "light",
-        targetNode?.label,
-      );
+      const targetColor = getNodeColor(targetNode?.nodeType, "light", targetNode?.label);
 
       // すべてのリンクの色はターゲットノードの色で統一
       return {
@@ -156,22 +140,19 @@ export function useLinkColors(data: SankeyData) {
 // ソート関連のカスタムフック
 export function useSankeySorting(data: SankeyData) {
   // ノードの値を計算する関数
-  const calculateNodeValue = useCallback(
-    (nodeId: string, links: SankeyLink[]) => {
-      // 対象ノードに関連するリンクを取得
-      const incomingLinks = links.filter((link) => link.target === nodeId);
-      const outgoingLinks = links.filter((link) => link.source === nodeId);
+  const calculateNodeValue = useCallback((nodeId: string, links: SankeyLink[]) => {
+    // 対象ノードに関連するリンクを取得
+    const incomingLinks = links.filter((link) => link.target === nodeId);
+    const outgoingLinks = links.filter((link) => link.source === nodeId);
 
-      // 入力リンクがある場合はその合計、なければ出力リンクの合計
-      const totalValue =
-        incomingLinks.length > 0
-          ? incomingLinks.reduce((sum, link) => sum + (link.value || 0), 0)
-          : outgoingLinks.reduce((sum, link) => sum + (link.value || 0), 0);
+    // 入力リンクがある場合はその合計、なければ出力リンクの合計
+    const totalValue =
+      incomingLinks.length > 0
+        ? incomingLinks.reduce((sum, link) => sum + (link.value || 0), 0)
+        : outgoingLinks.reduce((sum, link) => sum + (link.value || 0), 0);
 
-      return totalValue;
-    },
-    [],
-  );
+    return totalValue;
+  }, []);
 
   // ヘルパー関数: 親カテゴリIDを取得
   const getParentCategoryId = useCallback(
@@ -183,8 +164,7 @@ export function useSankeySorting(data: SankeyData) {
         return link?.target;
       } else if (nodeType === "expense-sub") {
         const link = data.links.find(
-          (link) =>
-            link.target === nodeId && link.source.startsWith("expense-"),
+          (link) => link.target === nodeId && link.source.startsWith("expense-"),
         );
         return link?.source;
       }
@@ -243,22 +223,14 @@ export function useSankeySorting(data: SankeyData) {
   const sortSubNodes = useCallback(
     (nodes: SankeyNode[], sortedParentNodes: SankeyNode[]) => {
       return [...nodes].sort((a, b) => {
-        const aParent = a.nodeType
-          ? getParentCategoryId(a.id, a.nodeType)
-          : null;
-        const bParent = b.nodeType
-          ? getParentCategoryId(b.id, b.nodeType)
-          : null;
+        const aParent = a.nodeType ? getParentCategoryId(a.id, a.nodeType) : null;
+        const bParent = b.nodeType ? getParentCategoryId(b.id, b.nodeType) : null;
 
         // 親カテゴリが異なる場合は親の順序に従う
         if (aParent && bParent && aParent !== bParent) {
           // ソート済み親ノードの順序を使用
-          const aParentIndex = sortedParentNodes.findIndex(
-            (n) => n.id === aParent,
-          );
-          const bParentIndex = sortedParentNodes.findIndex(
-            (n) => n.id === bParent,
-          );
+          const aParentIndex = sortedParentNodes.findIndex((n) => n.id === aParent);
+          const bParentIndex = sortedParentNodes.findIndex((n) => n.id === bParent);
 
           if (aParentIndex !== -1 && bParentIndex !== -1) {
             return aParentIndex - bParentIndex; // 親の順序に従う
@@ -294,12 +266,8 @@ export function useSankeySorting(data: SankeyData) {
   const sortNodes = useCallback(
     (nodes: SankeyNode[]) => {
       // 親ノードを先にソート
-      const incomeNodes = sortIncomeNodes(
-        nodes.filter((n) => n.nodeType === "income"),
-      );
-      const expenseNodes = sortExpenseNodes(
-        nodes.filter((n) => n.nodeType === "expense"),
-      );
+      const incomeNodes = sortIncomeNodes(nodes.filter((n) => n.nodeType === "income"));
+      const expenseNodes = sortExpenseNodes(nodes.filter((n) => n.nodeType === "expense"));
 
       // ソート済み親ノードを使ってsubノードをソート
       const incomeSubNodes = sortSubNodes(

--- a/webapp/src/client/components/top-page/features/donation-summary/DonationSummaryCards.tsx
+++ b/webapp/src/client/components/top-page/features/donation-summary/DonationSummaryCards.tsx
@@ -30,29 +30,21 @@ export default function DonationSummaryCards({
               <div className="flex items-baseline gap-[2px]">
                 {totalOku > 0 && (
                   <>
-                    <span className="font-bold text-2xl leading-5 text-gray-800">
-                      {totalOku}
-                    </span>
+                    <span className="font-bold text-2xl leading-5 text-gray-800">{totalOku}</span>
                     <span className="font-bold text-xs text-[#6B7280]">億</span>
                   </>
                 )}
                 {totalMan > 0 && (
                   <>
-                    <span className="font-bold text-2xl leading-5 text-gray-800">
-                      {totalMan}
-                    </span>
+                    <span className="font-bold text-2xl leading-5 text-gray-800">{totalMan}</span>
                     <span className="font-bold text-xs text-[#6B7280]">万</span>
                   </>
                 )}
-                <span className="font-bold text-2xl leading-5 text-gray-800">
-                  {totalEn}
-                </span>
+                <span className="font-bold text-2xl leading-5 text-gray-800">{totalEn}</span>
                 <span className="font-bold text-xs text-[#6B7280]">円</span>
               </div>
               <div className="flex items-center gap-[2px] h-4">
-                <span className="text-[#238778] font-normal text-[11px] leading-3">
-                  前日比
-                </span>
+                <span className="text-[#238778] font-normal text-[11px] leading-3">前日比</span>
                 <div className="flex items-center">
                   <span className="font-bold text-[#238778] text-[13px] leading-[13px]">
                     {dayOverDayChange.toLocaleString()}円
@@ -74,15 +66,11 @@ export default function DonationSummaryCards({
         <BaseCard className="!p-4 h-[76px]">
           <div className="flex flex-row justify-between items-center gap-3 h-full">
             <div className="flex flex-col justify-center">
-              <div className="text-[#4B5563] font-bold text-sm">
-                うち企業団体献金
-              </div>
+              <div className="text-[#4B5563] font-bold text-sm">うち企業団体献金</div>
             </div>
             <div className="flex items-end">
               <div className="flex items-baseline gap-[2px]">
-                <span className="font-bold text-2xl leading-5 text-gray-800">
-                  0
-                </span>
+                <span className="font-bold text-2xl leading-5 text-gray-800">0</span>
                 <span className="font-bold text-xs text-[#6B7280]">円</span>
               </div>
             </div>
@@ -97,14 +85,10 @@ export default function DonationSummaryCards({
           <div className="flex flex-col justify-center gap-4">
             <div className="flex flex-row justify-between items-start">
               <div className="flex flex-col justify-center gap-6">
-                <div className="text-gray-800 font-bold text-base">
-                  寄付金額
-                </div>
+                <div className="text-gray-800 font-bold text-base">寄付金額</div>
               </div>
               <div className="flex items-center gap-[2px]">
-                <span className="text-[#238778] font-bold text-[13px] leading-[17px]">
-                  前日比
-                </span>
+                <span className="text-[#238778] font-bold text-[13px] leading-[17px]">前日比</span>
                 <Image
                   src="/icons/icon-arrow-up.svg"
                   alt="上向き矢印"
@@ -115,9 +99,7 @@ export default function DonationSummaryCards({
                 <span className="font-bold text-[#238778] text-[16px] leading-[16px]">
                   {dayOverDayChange.toLocaleString()}
                 </span>
-                <span className="text-[#238778] font-bold text-[13px] leading-[17px]">
-                  円
-                </span>
+                <span className="text-[#238778] font-bold text-[13px] leading-[17px]">円</span>
               </div>
             </div>
             <div className="flex items-baseline gap-1">
@@ -126,9 +108,7 @@ export default function DonationSummaryCards({
                   <span className="font-bold text-[36px] leading-[30px] text-gray-800">
                     {totalOku}
                   </span>
-                  <span className="font-bold text-base leading-[16px] text-gray-800">
-                    億
-                  </span>
+                  <span className="font-bold text-base leading-[16px] text-gray-800">億</span>
                 </>
               )}
               {totalMan > 0 && (
@@ -136,17 +116,11 @@ export default function DonationSummaryCards({
                   <span className="font-bold text-[36px] leading-[30px] text-gray-800">
                     {totalMan}
                   </span>
-                  <span className="font-bold text-base leading-[16px] text-gray-800">
-                    万
-                  </span>
+                  <span className="font-bold text-base leading-[16px] text-gray-800">万</span>
                 </>
               )}
-              <span className="font-bold text-[36px] leading-[30px] text-gray-800">
-                {totalEn}
-              </span>
-              <span className="font-bold text-base leading-[16px] text-gray-800">
-                円
-              </span>
+              <span className="font-bold text-[36px] leading-[30px] text-gray-800">{totalEn}</span>
+              <span className="font-bold text-base leading-[16px] text-gray-800">円</span>
             </div>
           </div>
         </BaseCard>
@@ -154,16 +128,10 @@ export default function DonationSummaryCards({
         {/* 企業団体献金カード */}
         <BaseCard className="w-full md:w-[364px] h-[115px]">
           <div className="flex flex-col justify-center gap-4 h-full">
-            <div className="text-gray-800 font-bold text-base">
-              うち企業団体献金
-            </div>
+            <div className="text-gray-800 font-bold text-base">うち企業団体献金</div>
             <div className="flex items-baseline gap-1">
-              <span className="font-bold text-[36px] leading-[30px] text-gray-800">
-                0
-              </span>
-              <span className="font-bold text-base leading-[16px] text-gray-800">
-                円
-              </span>
+              <span className="font-bold text-[36px] leading-[30px] text-gray-800">0</span>
+              <span className="font-bold text-base leading-[16px] text-gray-800">円</span>
             </div>
           </div>
         </BaseCard>

--- a/webapp/src/client/components/top-page/features/financial-summary/BalanceDetailCard.tsx
+++ b/webapp/src/client/components/top-page/features/financial-summary/BalanceDetailCard.tsx
@@ -14,10 +14,7 @@ interface BalanceItem {
 }
 
 // FormattedAmountを表示用JSXに変換する関数
-function formatAmountDisplay(
-  amount: FormattedAmount,
-  isLarge: boolean = false,
-): ReactElement {
+function formatAmountDisplay(amount: FormattedAmount, isLarge: boolean = false): ReactElement {
   const mainClass = isLarge
     ? "text-gray-800 font-bold font-sf-pro"
     : "text-gray-600 font-bold font-sf-pro";
@@ -72,20 +69,15 @@ export default function BalanceDetailCard({
     });
   }
 
-  const getBalanceItemKey = (item: BalanceItem) =>
-    `${item.label}-${item.amount.main}`;
+  const getBalanceItemKey = (item: BalanceItem) => `${item.label}-${item.amount.main}`;
 
   return (
-    <div
-      className={`border border-gray-200 rounded-2xl py-4 px-5 sm:py-5 sm:px-6 ${className}`}
-    >
+    <div className={`border border-gray-200 rounded-2xl py-4 px-5 sm:py-5 sm:px-6 ${className}`}>
       {/* デスクトップ版レイアウト */}
       <div className="hidden sm:flex flex-row items-end gap-4">
         {/* メイン収支セクション */}
         <div className="flex flex-col justify-center gap-4">
-          <div className="text-gray-800 font-bold text-base leading-7">
-            {mainBalance.title}
-          </div>
+          <div className="text-gray-800 font-bold text-base leading-7">{mainBalance.title}</div>
           <div className="flex items-baseline gap-1 -translate-y-1 text-4xl leading-7 tracking-wide">
             {formatAmountDisplay(mainBalance.amount, true)}
           </div>
@@ -97,13 +89,8 @@ export default function BalanceDetailCard({
         {/* 詳細セクション */}
         <div className="flex flex-col justify-center gap-2">
           {balanceItems.map((item) => (
-            <div
-              key={getBalanceItemKey(item)}
-              className="flex flex-row items-baseline gap-3"
-            >
-              <div className="text-gray-600 font-bold text-sm leading-4">
-                {item.label}
-              </div>
+            <div key={getBalanceItemKey(item)} className="flex flex-row items-baseline gap-3">
+              <div className="text-gray-600 font-bold text-sm leading-4">{item.label}</div>
               <div className="flex items-end gap-1 text-sm leading-4">
                 {formatAmountDisplay(item.amount)}
               </div>
@@ -114,9 +101,7 @@ export default function BalanceDetailCard({
 
       {/* モバイル版レイアウト */}
       <div className="sm:hidden flex flex-row items-center gap-3">
-        <div className="text-gray-800 font-bold text-sm leading-6">
-          {mainBalance.title}
-        </div>
+        <div className="text-gray-800 font-bold text-sm leading-6">{mainBalance.title}</div>
 
         <div className="flex flex-col items-end gap-2 flex-1">
           {/* メイン値 */}
@@ -132,13 +117,8 @@ export default function BalanceDetailCard({
           {/* 詳細項目 */}
           <div className="flex flex-col items-end gap-1">
             {balanceItems.map((item) => (
-              <div
-                key={getBalanceItemKey(item)}
-                className="flex flex-row gap-3"
-              >
-                <div className="text-gray-600 font-bold text-xs leading-4">
-                  {item.label}
-                </div>
+              <div key={getBalanceItemKey(item)} className="flex flex-row gap-3">
+                <div className="text-gray-600 font-bold text-xs leading-4">{item.label}</div>
                 <div className="flex items-end gap-1 text-xs leading-4">
                   {formatAmountDisplay(item.amount)}
                 </div>

--- a/webapp/src/client/components/top-page/features/financial-summary/FinancialSummaryCard.tsx
+++ b/webapp/src/client/components/top-page/features/financial-summary/FinancialSummaryCard.tsx
@@ -21,10 +21,7 @@ export default function FinancialSummaryCard({
   return (
     <BaseCard className={className}>
       <div className="flex flex-row sm:flex-col justify-between sm:justify-start items-center sm:items-start gap-5 sm:gap-4">
-        <div
-          className={`font-bold text-sm sm:text-base`}
-          style={{ color: titleColor }}
-        >
+        <div className={`font-bold text-sm sm:text-base`} style={{ color: titleColor }}>
           {title}
         </div>
         <div className="flex items-baseline gap-1 translate-y-0.5">
@@ -35,10 +32,7 @@ export default function FinancialSummaryCard({
             {amount.main}
           </span>
           {amount.secondary && (
-            <span
-              className="font-bold text-xs sm:text-base"
-              style={{ color: amountColor }}
-            >
+            <span className="font-bold text-xs sm:text-base" style={{ color: amountColor }}>
               {amount.secondary}
             </span>
           )}

--- a/webapp/src/client/components/top-page/features/financial-summary/FinancialSummarySection.tsx
+++ b/webapp/src/client/components/top-page/features/financial-summary/FinancialSummarySection.tsx
@@ -13,9 +13,7 @@ function createSankeyDataHelper(sankeyData: SankeyData) {
 
   // ノード名とタイプから金額を取得（そのノードへの流入合計）
   const getNodeValue = (nodeName: string, nodeType?: string): number => {
-    const node = nodes.find(
-      (n) => n.label === nodeName && (!nodeType || n.nodeType === nodeType),
-    );
+    const node = nodes.find((n) => n.label === nodeName && (!nodeType || n.nodeType === nodeType));
     if (!node) return 0;
 
     return links
@@ -31,23 +29,16 @@ function createSankeyDataHelper(sankeyData: SankeyData) {
     targetNodeType?: string,
   ): number => {
     const sourceNode = nodes.find(
-      (n) =>
-        n.label === sourceNodeName &&
-        (!sourceNodeType || n.nodeType === sourceNodeType),
+      (n) => n.label === sourceNodeName && (!sourceNodeType || n.nodeType === sourceNodeType),
     );
     const targetNode = nodes.find(
-      (n) =>
-        n.label === targetNodeName &&
-        (!targetNodeType || n.nodeType === targetNodeType),
+      (n) => n.label === targetNodeName && (!targetNodeType || n.nodeType === targetNodeType),
     );
 
     if (!sourceNode || !targetNode) return 0;
 
     return links
-      .filter(
-        (link) =>
-          link.source === sourceNode.id && link.target === targetNode.id,
-      )
+      .filter((link) => link.source === sourceNode.id && link.target === targetNode.id)
       .reduce((sum, link) => sum + link.value, 0);
   };
 
@@ -66,12 +57,7 @@ function calculateFinancialData(sankeyData: SankeyData | null) {
   const income = helper.getNodeValue("合計");
 
   // 現金残高の計算（「合計」から「現金残高」への流出）
-  const currentBalance = helper.getLinkValueBetween(
-    "合計",
-    "現金残高",
-    undefined,
-    "expense",
-  );
+  const currentBalance = helper.getLinkValueBetween("合計", "現金残高", undefined, "expense");
 
   // 支出の計算（収入総額から現金残高を引いた値）
   const expense = income - currentBalance;
@@ -88,20 +74,10 @@ function calculateBalanceDetailData(sankeyData: SankeyData | null) {
   const helper = createSankeyDataHelper(sankeyData);
 
   // 現金残高の合計値を取得（合計から現金残高への流入）
-  const cashBalanceTotal = helper.getLinkValueBetween(
-    "合計",
-    "現金残高",
-    undefined,
-    "expense",
-  );
+  const cashBalanceTotal = helper.getLinkValueBetween("合計", "現金残高", undefined, "expense");
 
   // 収支の値を取得（現金残高から収支への流出）
-  const balanceValue = helper.getLinkValueBetween(
-    "現金残高",
-    "収支",
-    "expense",
-    "expense-sub",
-  );
+  const balanceValue = helper.getLinkValueBetween("現金残高", "収支", "expense", "expense-sub");
 
   // 未払費用の値を取得（現金残高から未払費用への流出）
   const unpaidExpenseValue = helper.getLinkValueBetween(
@@ -118,9 +94,7 @@ function calculateBalanceDetailData(sankeyData: SankeyData | null) {
   };
 }
 
-export default function FinancialSummarySection({
-  sankeyData,
-}: FinancialSummarySectionProps) {
+export default function FinancialSummarySection({ sankeyData }: FinancialSummarySectionProps) {
   // 財務データを計算
   const financialData = calculateFinancialData(sankeyData);
   const balanceDetailData = calculateBalanceDetailData(sankeyData);

--- a/webapp/src/client/components/top-page/features/transactions-table/CategoryFilter.tsx
+++ b/webapp/src/client/components/top-page/features/transactions-table/CategoryFilter.tsx
@@ -3,10 +3,7 @@ import "client-only";
 
 import { useState } from "react";
 import Image from "next/image";
-import {
-  PL_CATEGORIES,
-  type CategoryMapping,
-} from "@/shared/utils/category-mapping";
+import { PL_CATEGORIES, type CategoryMapping } from "@/shared/utils/category-mapping";
 
 interface CategoryItem {
   id: string;
@@ -23,9 +20,7 @@ const INCOME_CATEGORIES: CategoryItem[] = Object.entries(PL_CATEGORIES)
   }));
 
 const EXPENSE_CATEGORIES: CategoryItem[] = Object.entries(PL_CATEGORIES)
-  .filter(
-    ([, mapping]: [string, CategoryMapping]) => mapping.type === "expense",
-  )
+  .filter(([, mapping]: [string, CategoryMapping]) => mapping.type === "expense")
   .map(([, mapping]: [string, CategoryMapping]) => ({
     id: mapping.key,
     label: mapping.shortLabel,
@@ -62,32 +57,24 @@ export default function CategoryFilter({
 
   const handleIncomeToggle = (id: string) => {
     setIncomeCategories((prev) =>
-      prev.map((cat) =>
-        cat.id === id ? { ...cat, checked: !cat.checked } : cat,
-      ),
+      prev.map((cat) => (cat.id === id ? { ...cat, checked: !cat.checked } : cat)),
     );
   };
 
   const handleExpenseToggle = (id: string) => {
     setExpenseCategories((prev) =>
-      prev.map((cat) =>
-        cat.id === id ? { ...cat, checked: !cat.checked } : cat,
-      ),
+      prev.map((cat) => (cat.id === id ? { ...cat, checked: !cat.checked } : cat)),
     );
   };
 
   const handleIncomeSelectAll = () => {
     const allChecked = incomeCategories.every((cat) => cat.checked);
-    setIncomeCategories((prev) =>
-      prev.map((cat) => ({ ...cat, checked: !allChecked })),
-    );
+    setIncomeCategories((prev) => prev.map((cat) => ({ ...cat, checked: !allChecked })));
   };
 
   const handleExpenseSelectAll = () => {
     const allChecked = expenseCategories.every((cat) => cat.checked);
-    setExpenseCategories((prev) =>
-      prev.map((cat) => ({ ...cat, checked: !allChecked })),
-    );
+    setExpenseCategories((prev) => prev.map((cat) => ({ ...cat, checked: !allChecked })));
   };
 
   const handleCancel = () => {
@@ -139,9 +126,7 @@ export default function CategoryFilter({
                   </div>
                   <span
                     className={`text-[13px] leading-[1.31] text-left flex-1 ${
-                      incomeCategories.every((cat) => cat.checked)
-                        ? "font-semibold"
-                        : "font-medium"
+                      incomeCategories.every((cat) => cat.checked) ? "font-semibold" : "font-medium"
                     } text-[#47474C]`}
                   >
                     （すべて選択）
@@ -264,18 +249,14 @@ export default function CategoryFilter({
             onClick={handleCancel}
             className="flex justify-center items-center gap-[10px] py-2 px-4 w-[120px] bg-[#F1F5F9] border-[0.5px] border-[#D1D5DB] rounded-[6px] hover:opacity-70 transition-opacity cursor-pointer"
           >
-            <span className="text-[#238778] text-sm font-medium leading-[1.29]">
-              キャンセル
-            </span>
+            <span className="text-[#238778] text-sm font-medium leading-[1.29]">キャンセル</span>
           </button>
           <button
             type="button"
             onClick={handleOk}
             className="flex justify-center items-center gap-[10px] py-2 px-4 w-[120px] bg-[#238778] rounded-[6px] hover:opacity-90 transition-opacity cursor-pointer"
           >
-            <span className="text-white text-sm font-medium leading-[1.29]">
-              OK
-            </span>
+            <span className="text-white text-sm font-medium leading-[1.29]">OK</span>
           </button>
         </div>
       </div>

--- a/webapp/src/client/components/top-page/features/transactions-table/InteractiveTransactionTable.tsx
+++ b/webapp/src/client/components/top-page/features/transactions-table/InteractiveTransactionTable.tsx
@@ -4,9 +4,7 @@ import "client-only";
 import { useRouter, useSearchParams } from "next/navigation";
 import type { DisplayTransaction } from "@/types/display-transaction";
 import TransactionTable from "./TransactionTable";
-import TransactionTableMobileHeader, {
-  type SortOption,
-} from "./TransactionTableMobileHeader";
+import TransactionTableMobileHeader, { type SortOption } from "./TransactionTableMobileHeader";
 import PCPaginator from "./PCPaginator";
 import MobilePaginator from "./MobilePaginator";
 import CsvDownloadLink from "@/client/components/transactions/CsvDownloadLink";
@@ -51,10 +49,7 @@ export default function InteractiveTransactionTable({
   // Parse URL params once
   const currentSort = searchParams.get("sort") as "date" | "amount" | null;
   const currentOrder = searchParams.get("order") as "asc" | "desc" | null;
-  const filterType = searchParams.get("filterType") as
-    | "income"
-    | "expense"
-    | null;
+  const filterType = searchParams.get("filterType") as "income" | "expense" | null;
 
   const handlePageChange = (newPage: number) => {
     const params = new URLSearchParams(searchParams.toString());
@@ -117,11 +112,7 @@ export default function InteractiveTransactionTable({
 
     // Find matching sort option from configuration
     for (const [sortOption, config] of Object.entries(SORT_CONFIGS)) {
-      if (
-        config.sort === sort &&
-        config.order === order &&
-        config.filterType === filterType
-      ) {
+      if (config.sort === sort && config.order === order && config.filterType === filterType) {
         return sortOption as SortOption;
       }
     }

--- a/webapp/src/client/components/top-page/features/transactions-table/MobilePaginator.tsx
+++ b/webapp/src/client/components/top-page/features/transactions-table/MobilePaginator.tsx
@@ -27,9 +27,7 @@ export default function MobilePaginator({
           alt="前のページ"
           width={20}
           height={20}
-          className={`transform rotate-90 ${
-            currentPage === 1 ? "opacity-30" : "opacity-100"
-          }`}
+          className={`transform rotate-90 ${currentPage === 1 ? "opacity-30" : "opacity-100"}`}
         />
       </button>
 

--- a/webapp/src/client/components/top-page/features/transactions-table/PCPaginator.tsx
+++ b/webapp/src/client/components/top-page/features/transactions-table/PCPaginator.tsx
@@ -38,10 +38,7 @@ export default function PCPaginator({
     }
 
     // 中央の場合：currentPage を中心とした maxVisiblePages 個
-    return Array.from(
-      { length: maxVisiblePages },
-      (_, i) => currentPage - halfVisible + i,
-    );
+    return Array.from({ length: maxVisiblePages }, (_, i) => currentPage - halfVisible + i);
   };
 
   const pageNumbers = generatePageNumbers();
@@ -61,9 +58,7 @@ export default function PCPaginator({
           alt="前のページ"
           width={20}
           height={20}
-          className={`transform rotate-90 ${
-            currentPage === 1 ? "opacity-30" : "opacity-100"
-          }`}
+          className={`transform rotate-90 ${currentPage === 1 ? "opacity-30" : "opacity-100"}`}
         />
       </button>
 

--- a/webapp/src/client/components/top-page/features/transactions-table/TransactionTableBody.tsx
+++ b/webapp/src/client/components/top-page/features/transactions-table/TransactionTableBody.tsx
@@ -5,9 +5,7 @@ interface TransactionTableBodyProps {
   transactions: DisplayTransaction[];
 }
 
-export default function TransactionTableBody({
-  transactions,
-}: TransactionTableBodyProps) {
+export default function TransactionTableBody({ transactions }: TransactionTableBodyProps) {
   return (
     <tbody className="bg-white">
       {transactions.map((transaction) => (

--- a/webapp/src/client/components/top-page/features/transactions-table/TransactionTableHeader.tsx
+++ b/webapp/src/client/components/top-page/features/transactions-table/TransactionTableHeader.tsx
@@ -33,9 +33,7 @@ export default function TransactionTableHeader({
               aria-label="日付順でソート"
               aria-describedby="sort-date-description"
             >
-              <span className="text-gray-800 text-sm font-bold leading-[1.5]">
-                日付
-              </span>
+              <span className="text-gray-800 text-sm font-bold leading-[1.5]">日付</span>
               <div className="w-5 h-5 flex items-center justify-center">
                 <Image
                   src="/icons/icon-chevron-down.svg"
@@ -43,20 +41,14 @@ export default function TransactionTableHeader({
                   width={20}
                   height={20}
                   className={`w-5 h-5 transition-transform ${
-                    currentSort === "date"
-                      ? currentOrder === "asc"
-                        ? "rotate-180"
-                        : ""
-                      : ""
+                    currentSort === "date" ? (currentOrder === "asc" ? "rotate-180" : "") : ""
                   } ${currentSort === "date" ? "opacity-100" : "opacity-50"}`}
                 />
               </div>
             </button>
           ) : (
             <div className="flex items-center gap-1 h-5">
-              <span className="text-gray-800 text-sm font-bold leading-[1.5]">
-                日付
-              </span>
+              <span className="text-gray-800 text-sm font-bold leading-[1.5]">日付</span>
             </div>
           )}
         </th>
@@ -73,9 +65,7 @@ export default function TransactionTableHeader({
               className="flex items-center gap-1 h-12 hover:opacity-70 transition-opacity cursor-pointer"
               aria-label="カテゴリーフィルター"
             >
-              <span className="text-gray-800 text-sm font-bold leading-[1.5]">
-                カテゴリー
-              </span>
+              <span className="text-gray-800 text-sm font-bold leading-[1.5]">カテゴリー</span>
               <div className="w-3 h-2 flex items-center justify-center">
                 <Image
                   src="/icons/icon-filter.svg"
@@ -88,9 +78,7 @@ export default function TransactionTableHeader({
             </button>
           ) : (
             <div className="flex items-center gap-1 h-12">
-              <span className="text-gray-800 text-sm font-bold leading-[1.5]">
-                カテゴリー
-              </span>
+              <span className="text-gray-800 text-sm font-bold leading-[1.5]">カテゴリー</span>
             </div>
           )}
           <CategoryFilter
@@ -120,9 +108,7 @@ export default function TransactionTableHeader({
               aria-label="金額順でソート"
               aria-describedby="sort-amount-description"
             >
-              <span className="text-gray-800 text-sm font-bold leading-[1.5]">
-                金額
-              </span>
+              <span className="text-gray-800 text-sm font-bold leading-[1.5]">金額</span>
               <div className="w-5 h-5 flex items-center justify-center">
                 <Image
                   src="/icons/icon-chevron-down.svg"
@@ -130,20 +116,14 @@ export default function TransactionTableHeader({
                   width={20}
                   height={20}
                   className={`w-5 h-5 transition-transform ${
-                    currentSort === "amount"
-                      ? currentOrder === "asc"
-                        ? "rotate-180"
-                        : ""
-                      : ""
+                    currentSort === "amount" ? (currentOrder === "asc" ? "rotate-180" : "") : ""
                   } ${currentSort === "amount" ? "opacity-100" : "opacity-50"}`}
                 />
               </div>
             </button>
           ) : (
             <div className="flex items-center justify-end gap-1 h-5">
-              <span className="text-gray-800 text-sm font-bold leading-[1.5]">
-                金額
-              </span>
+              <span className="text-gray-800 text-sm font-bold leading-[1.5]">金額</span>
             </div>
           )}
         </th>

--- a/webapp/src/client/components/top-page/features/transactions-table/TransactionTableRow.tsx
+++ b/webapp/src/client/components/top-page/features/transactions-table/TransactionTableRow.tsx
@@ -8,9 +8,7 @@ interface TransactionTableRowProps {
   transaction: DisplayTransaction;
 }
 
-export default function TransactionTableRow({
-  transaction,
-}: TransactionTableRowProps) {
+export default function TransactionTableRow({ transaction }: TransactionTableRowProps) {
   const formatCurrency = (amount: number) => {
     return new Intl.NumberFormat("ja-JP", {
       style: "decimal",
@@ -33,9 +31,7 @@ export default function TransactionTableRow({
 
   const getDisplayTitle = (transaction: DisplayTransaction) => {
     const baseTitle = transaction.friendly_category || transaction.category;
-    return transaction.label
-      ? `${baseTitle} - ${transaction.label}`
-      : baseTitle;
+    return transaction.label ? `${baseTitle} - ${transaction.label}` : baseTitle;
   };
 
   const getCategoryColors = (transaction: DisplayTransaction) => {

--- a/webapp/src/client/components/ui/CardSummary.tsx
+++ b/webapp/src/client/components/ui/CardSummary.tsx
@@ -3,10 +3,7 @@ interface CardSummaryProps {
   className?: string;
 }
 
-export default function CardSummary({
-  children,
-  className = "",
-}: CardSummaryProps) {
+export default function CardSummary({ children, className = "" }: CardSummaryProps) {
   return (
     <div
       className={`

--- a/webapp/src/client/components/ui/FinancialSummary.tsx
+++ b/webapp/src/client/components/ui/FinancialSummary.tsx
@@ -3,11 +3,6 @@ interface FinancialSummaryProps {
   className?: string;
 }
 
-export default function FinancialSummary({
-  children,
-  className = "",
-}: FinancialSummaryProps) {
-  return (
-    <div className={`flex items-center gap-6 ${className}`}>{children}</div>
-  );
+export default function FinancialSummary({ children, className = "" }: FinancialSummaryProps) {
+  return <div className={`flex items-center gap-6 ${className}`}>{children}</div>;
 }

--- a/webapp/src/client/components/ui/Selector.tsx
+++ b/webapp/src/client/components/ui/Selector.tsx
@@ -31,9 +31,7 @@ export default function Selector({
 
   const currentValue = value !== undefined ? value : selectedValue;
 
-  const selectedOption = options.find(
-    (option) => option.value === currentValue,
-  );
+  const selectedOption = options.find((option) => option.value === currentValue);
 
   const handleSelect = (newValue: string) => {
     if (value === undefined) {
@@ -99,20 +97,13 @@ export default function Selector({
                   {/* Checkbox */}
                   <div className="flex items-center justify-center w-[18px] h-[18px] mt-0.5">
                     {currentValue === option.value && (
-                      <Image
-                        src="/icons/icon-checkmark.svg"
-                        alt=""
-                        width={13}
-                        height={11}
-                      />
+                      <Image src="/icons/icon-checkmark.svg" alt="" width={13} height={11} />
                     )}
                   </div>
 
                   {/* Option Info */}
                   <div className="flex-1 min-w-0 text-left">
-                    <div className="text-sm font-bold text-gray-600 leading-5">
-                      {option.label}
-                    </div>
+                    <div className="text-sm font-bold text-gray-600 leading-5">{option.label}</div>
                     {option.subtitle && (
                       <div className="text-[9px] text-gray-600 leading-tight mt-1">
                         {option.subtitle}

--- a/webapp/src/client/components/ui/Typography.tsx
+++ b/webapp/src/client/components/ui/Typography.tsx
@@ -31,9 +31,5 @@ export const Label = ({ children, className = "" }: TypographyProps) => (
 );
 
 export const Body = ({ children, className = "" }: TypographyProps) => (
-  <p
-    className={`text-[16px] font-bold leading-[1.75] font-english ${className}`}
-  >
-    {children}
-  </p>
+  <p className={`text-[16px] font-bold leading-[1.75] font-english ${className}`}>{children}</p>
 );

--- a/webapp/src/middleware.ts
+++ b/webapp/src/middleware.ts
@@ -47,7 +47,5 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: [
-    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
-  ],
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)"],
 };

--- a/webapp/src/server/actions/download-transactions-csv.ts
+++ b/webapp/src/server/actions/download-transactions-csv.ts
@@ -11,15 +11,7 @@ export async function downloadTransactionsCsv(slug: string) {
     });
 
     // CSVヘッダー
-    const headers = [
-      "日付",
-      "政治団体名",
-      "タイプ",
-      "金額",
-      "カテゴリ",
-      "詳細区分",
-      "ラベル",
-    ];
+    const headers = ["日付", "政治団体名", "タイプ", "金額", "カテゴリ", "詳細区分", "ラベル"];
 
     // CSVデータを作成
     const csvRows = [

--- a/webapp/src/server/loaders/constants.ts
+++ b/webapp/src/server/loaders/constants.ts
@@ -1,2 +1,1 @@
-export const CACHE_REVALIDATE_SECONDS =
-  process.env.VERCEL_ENV === "production" ? 3600 : 10;
+export const CACHE_REVALIDATE_SECONDS = process.env.VERCEL_ENV === "production" ? 3600 : 10;

--- a/webapp/src/server/loaders/load-top-page-data.ts
+++ b/webapp/src/server/loaders/load-top-page-data.ts
@@ -15,8 +15,7 @@ import {
 } from "@/server/usecases/get-transactions-by-slug-usecase";
 import { CACHE_REVALIDATE_SECONDS } from "./constants";
 
-export interface TopPageDataParams
-  extends Omit<GetTransactionsBySlugParams, "financialYear"> {
+export interface TopPageDataParams extends Omit<GetTransactionsBySlugParams, "financialYear"> {
   financialYear: number; // 必須項目として設定
 }
 
@@ -30,11 +29,8 @@ export const loadTopPageData = unstable_cache(
 
     // 実データを取得する場合
     const transactionRepository = new PrismaTransactionRepository(prisma);
-    const politicalOrganizationRepository =
-      new PrismaPoliticalOrganizationRepository(prisma);
-    const balanceSnapshotRepository = new PrismaBalanceSnapshotRepository(
-      prisma,
-    );
+    const politicalOrganizationRepository = new PrismaPoliticalOrganizationRepository(prisma);
+    const balanceSnapshotRepository = new PrismaBalanceSnapshotRepository(prisma);
 
     // 5つのUsecaseを初期化
     const transactionUsecase = new GetTransactionsBySlugUsecase(
@@ -76,19 +72,18 @@ export const loadTopPageData = unstable_cache(
     ]);
 
     // 第2段階: sankeyの2種類を並列実行
-    const [sankeyPoliticalCategoryData, sankeyFriendlyCategoryData] =
-      await Promise.all([
-        sankeyUsecase.execute({
-          slugs: params.slugs,
-          financialYear: params.financialYear,
-          categoryType: "political-category",
-        }),
-        sankeyUsecase.execute({
-          slugs: params.slugs,
-          financialYear: params.financialYear,
-          categoryType: "friendly-category",
-        }),
-      ]);
+    const [sankeyPoliticalCategoryData, sankeyFriendlyCategoryData] = await Promise.all([
+      sankeyUsecase.execute({
+        slugs: params.slugs,
+        financialYear: params.financialYear,
+        categoryType: "political-category",
+      }),
+      sankeyUsecase.execute({
+        slugs: params.slugs,
+        financialYear: params.financialYear,
+        categoryType: "friendly-category",
+      }),
+    ]);
 
     return {
       transactionData,

--- a/webapp/src/server/loaders/load-transactions-for-csv.ts
+++ b/webapp/src/server/loaders/load-transactions-for-csv.ts
@@ -16,8 +16,7 @@ export const loadTransactionsForCsv = (params: GetTransactionsForCsvParams) => {
   return unstable_cache(
     async () => {
       const transactionRepository = new PrismaTransactionRepository(prisma);
-      const politicalOrganizationRepository =
-        new PrismaPoliticalOrganizationRepository(prisma);
+      const politicalOrganizationRepository = new PrismaPoliticalOrganizationRepository(prisma);
       const usecase = new GetTransactionsForCsvUsecase(
         transactionRepository,
         politicalOrganizationRepository,

--- a/webapp/src/server/loaders/load-transactions-page-data.ts
+++ b/webapp/src/server/loaders/load-transactions-page-data.ts
@@ -10,16 +10,13 @@ import {
 } from "@/server/usecases/get-transactions-by-slug-usecase";
 import { CACHE_REVALIDATE_SECONDS } from "./constants";
 
-export const loadTransactionsPageData = (
-  params: GetTransactionsBySlugParams,
-) => {
+export const loadTransactionsPageData = (params: GetTransactionsBySlugParams) => {
   const cacheKey = ["transactions-page-data", JSON.stringify(params)];
 
   return unstable_cache(
     async () => {
       const transactionRepository = new PrismaTransactionRepository(prisma);
-      const politicalOrganizationRepository =
-        new PrismaPoliticalOrganizationRepository(prisma);
+      const politicalOrganizationRepository = new PrismaPoliticalOrganizationRepository(prisma);
       const usecase = new GetTransactionsBySlugUsecase(
         transactionRepository,
         politicalOrganizationRepository,

--- a/webapp/src/server/repositories/interfaces/balance-snapshot-repository.interface.ts
+++ b/webapp/src/server/repositories/interfaces/balance-snapshot-repository.interface.ts
@@ -14,8 +14,5 @@ export interface TotalBalancesByYear {
 
 export interface IBalanceSnapshotRepository {
   getTotalLatestBalanceByOrgIds(orgIds: string[]): Promise<number>;
-  getTotalLatestBalancesByYear(
-    orgIds: string[],
-    currentYear: number,
-  ): Promise<TotalBalancesByYear>;
+  getTotalLatestBalancesByYear(orgIds: string[], currentYear: number): Promise<TotalBalancesByYear>;
 }

--- a/webapp/src/server/repositories/interfaces/transaction-repository.interface.ts
+++ b/webapp/src/server/repositories/interfaces/transaction-repository.interface.ts
@@ -49,10 +49,7 @@ export interface SortOptions {
 
 export interface ITransactionRepository {
   findById(id: string): Promise<Transaction | null>;
-  findAll(
-    filters?: TransactionFilters,
-    sortOptions?: SortOptions,
-  ): Promise<Transaction[]>;
+  findAll(filters?: TransactionFilters, sortOptions?: SortOptions): Promise<Transaction[]>;
   findWithPagination(
     filters?: TransactionFilters,
     pagination?: PaginationOptions,
@@ -78,10 +75,7 @@ export interface ITransactionRepository {
     politicalOrganizationIds: string[],
     financialYear: number,
   ): Promise<number>;
-  getLiabilityBalance(
-    politicalOrganizationIds: string[],
-    financialYear: number,
-  ): Promise<number>;
+  getLiabilityBalance(politicalOrganizationIds: string[], financialYear: number): Promise<number>;
   getLastUpdatedAt(): Promise<Date | null>;
   findAllWithPoliticalOrganizationName(
     filters?: TransactionFilters,

--- a/webapp/src/server/repositories/prisma-balance-snapshot.repository.ts
+++ b/webapp/src/server/repositories/prisma-balance-snapshot.repository.ts
@@ -5,9 +5,7 @@ import type {
   TotalBalancesByYear,
 } from "./interfaces/balance-snapshot-repository.interface";
 
-export class PrismaBalanceSnapshotRepository
-  implements IBalanceSnapshotRepository
-{
+export class PrismaBalanceSnapshotRepository implements IBalanceSnapshotRepository {
   constructor(private prisma: PrismaClient) {}
 
   async getTotalLatestBalanceByOrgIds(orgIds: string[]): Promise<number> {
@@ -67,10 +65,8 @@ export class PrismaBalanceSnapshotRepository
       ORDER BY year
     `;
 
-    const currentYearBalance =
-      result.find((r) => r.year === currentYear)?.total_balance || "0";
-    const previousYearBalance =
-      result.find((r) => r.year === previousYear)?.total_balance || "0";
+    const currentYearBalance = result.find((r) => r.year === currentYear)?.total_balance || "0";
+    const previousYearBalance = result.find((r) => r.year === previousYear)?.total_balance || "0";
 
     return {
       currentYear: Number(currentYearBalance),

--- a/webapp/src/server/repositories/prisma-political-organization.repository.ts
+++ b/webapp/src/server/repositories/prisma-political-organization.repository.ts
@@ -5,9 +5,7 @@ import type {
 import type { PoliticalOrganization } from "@/shared/models/political-organization";
 import type { IPoliticalOrganizationRepository } from "./interfaces/political-organization-repository.interface";
 
-export class PrismaPoliticalOrganizationRepository
-  implements IPoliticalOrganizationRepository
-{
+export class PrismaPoliticalOrganizationRepository implements IPoliticalOrganizationRepository {
   constructor(private prisma: PrismaClient) {}
 
   async findBySlug(slug: string): Promise<PoliticalOrganization | null> {

--- a/webapp/src/server/usecases/get-all-transactions-by-slug-usecase.ts
+++ b/webapp/src/server/usecases/get-all-transactions-by-slug-usecase.ts
@@ -1,9 +1,6 @@
 import type { PoliticalOrganization } from "@/shared/models/political-organization";
 import type { TransactionFilters } from "@/types/transaction-filters";
-import type {
-  DisplayTransaction,
-  DisplayTransactionType,
-} from "@/types/display-transaction";
+import type { DisplayTransaction, DisplayTransactionType } from "@/types/display-transaction";
 import type { IPoliticalOrganizationRepository } from "../repositories/interfaces/political-organization-repository.interface";
 import type { ITransactionRepository } from "../repositories/interfaces/transaction-repository.interface";
 import { convertToDisplayTransactions } from "../utils/transaction-converter";
@@ -32,12 +29,11 @@ export class GetAllTransactionsBySlugUsecase {
     private politicalOrganizationRepository: IPoliticalOrganizationRepository,
   ) {}
 
-  async execute(
-    params: GetAllTransactionsBySlugParams,
-  ): Promise<GetAllTransactionsBySlugResult> {
+  async execute(params: GetAllTransactionsBySlugParams): Promise<GetAllTransactionsBySlugResult> {
     try {
-      const politicalOrganizations =
-        await this.politicalOrganizationRepository.findBySlugs(params.slugs);
+      const politicalOrganizations = await this.politicalOrganizationRepository.findBySlugs(
+        params.slugs,
+      );
 
       if (politicalOrganizations.length === 0) {
         throw new Error(

--- a/webapp/src/server/usecases/get-monthly-transaction-aggregation-usecase.ts
+++ b/webapp/src/server/usecases/get-monthly-transaction-aggregation-usecase.ts
@@ -23,8 +23,9 @@ export class GetMonthlyTransactionAggregationUsecase {
     params: GetMonthlyTransactionAggregationParams,
   ): Promise<GetMonthlyTransactionAggregationResult> {
     try {
-      const politicalOrganizations =
-        await this.politicalOrganizationRepository.findBySlugs(params.slugs);
+      const politicalOrganizations = await this.politicalOrganizationRepository.findBySlugs(
+        params.slugs,
+      );
 
       if (politicalOrganizations.length === 0) {
         throw new Error(
@@ -34,11 +35,10 @@ export class GetMonthlyTransactionAggregationUsecase {
 
       // Get monthly data for all organizations using IN clause
       const organizationIds = politicalOrganizations.map((org) => org.id);
-      const monthlyData =
-        await this.transactionRepository.getMonthlyAggregation(
-          organizationIds,
-          params.financialYear,
-        );
+      const monthlyData = await this.transactionRepository.getMonthlyAggregation(
+        organizationIds,
+        params.financialYear,
+      );
 
       return { monthlyData };
     } catch (error) {

--- a/webapp/src/server/usecases/get-sankey-aggregation-usecase.ts
+++ b/webapp/src/server/usecases/get-sankey-aggregation-usecase.ts
@@ -21,13 +21,12 @@ export class GetSankeyAggregationUsecase {
     private balanceSnapshotRepository: IBalanceSnapshotRepository,
   ) {}
 
-  async execute(
-    params: GetSankeyAggregationParams,
-  ): Promise<GetSankeyAggregationResult> {
+  async execute(params: GetSankeyAggregationParams): Promise<GetSankeyAggregationResult> {
     try {
       // 政治団体を取得
-      const politicalOrganizations =
-        await this.politicalOrganizationRepository.findBySlugs(params.slugs);
+      const politicalOrganizations = await this.politicalOrganizationRepository.findBySlugs(
+        params.slugs,
+      );
 
       if (politicalOrganizations.length === 0) {
         throw new Error(
@@ -37,17 +36,14 @@ export class GetSankeyAggregationUsecase {
 
       // 集計データを取得（IN句で効率的に）
       const organizationIds = politicalOrganizations.map((org) => org.id);
-      const aggregatedResult =
-        await this.transactionRepository.getCategoryAggregationForSankey(
-          organizationIds,
-          params.financialYear,
-          params.categoryType,
-        );
+      const aggregatedResult = await this.transactionRepository.getCategoryAggregationForSankey(
+        organizationIds,
+        params.financialYear,
+        params.categoryType,
+      );
 
       // 今年と昨年の最新残高データを取得（合計値）
-      const organizationIdsAsString = organizationIds.map((id) =>
-        id.toString(),
-      );
+      const organizationIdsAsString = organizationIds.map((id) => id.toString());
       const [balancesByYear, liabilityBalance] = await Promise.all([
         this.balanceSnapshotRepository.getTotalLatestBalancesByYear(
           organizationIdsAsString,

--- a/webapp/src/server/usecases/get-transactions-by-slug-usecase.ts
+++ b/webapp/src/server/usecases/get-transactions-by-slug-usecase.ts
@@ -1,9 +1,6 @@
 import type { PoliticalOrganization } from "@/shared/models/political-organization";
 import type { TransactionFilters } from "@/types/transaction-filters";
-import type {
-  DisplayTransaction,
-  DisplayTransactionType,
-} from "@/types/display-transaction";
+import type { DisplayTransaction, DisplayTransactionType } from "@/types/display-transaction";
 import type { IPoliticalOrganizationRepository } from "../repositories/interfaces/political-organization-repository.interface";
 import type {
   ITransactionRepository,
@@ -40,12 +37,11 @@ export class GetTransactionsBySlugUsecase {
     private politicalOrganizationRepository: IPoliticalOrganizationRepository,
   ) {}
 
-  async execute(
-    params: GetTransactionsBySlugParams,
-  ): Promise<GetTransactionsBySlugResult> {
+  async execute(params: GetTransactionsBySlugParams): Promise<GetTransactionsBySlugResult> {
     try {
-      const politicalOrganizations =
-        await this.politicalOrganizationRepository.findBySlugs(params.slugs);
+      const politicalOrganizations = await this.politicalOrganizationRepository.findBySlugs(
+        params.slugs,
+      );
 
       if (politicalOrganizations.length === 0) {
         throw new Error(
@@ -87,9 +83,7 @@ export class GetTransactionsBySlugUsecase {
         this.transactionRepository.getLastUpdatedAt(),
       ]);
 
-      const transactions = convertToDisplayTransactions(
-        transactionResult.items,
-      );
+      const transactions = convertToDisplayTransactions(transactionResult.items);
       const total = transactionResult.total;
       const totalPages = Math.ceil(total / perPage);
 

--- a/webapp/src/server/usecases/get-transactions-for-csv-usecase.ts
+++ b/webapp/src/server/usecases/get-transactions-for-csv-usecase.ts
@@ -19,12 +19,11 @@ export class GetTransactionsForCsvUsecase {
     private politicalOrganizationRepository: IPoliticalOrganizationRepository,
   ) {}
 
-  async execute(
-    params: GetTransactionsForCsvParams,
-  ): Promise<GetTransactionsForCsvResult> {
+  async execute(params: GetTransactionsForCsvParams): Promise<GetTransactionsForCsvResult> {
     try {
-      const politicalOrganizations =
-        await this.politicalOrganizationRepository.findBySlugs(params.slugs);
+      const politicalOrganizations = await this.politicalOrganizationRepository.findBySlugs(
+        params.slugs,
+      );
 
       if (politicalOrganizations.length === 0) {
         throw new Error(
@@ -40,9 +39,7 @@ export class GetTransactionsForCsvUsecase {
 
       // JOINで政治団体名も含めて全件取得
       const transactions =
-        await this.transactionRepository.findAllWithPoliticalOrganizationName(
-          filters,
-        );
+        await this.transactionRepository.findAllWithPoliticalOrganizationName(filters);
 
       const total = transactions.length;
 

--- a/webapp/src/server/utils/sankey-category-converter.ts
+++ b/webapp/src/server/utils/sankey-category-converter.ts
@@ -19,10 +19,7 @@ export function convertCategoryAggregationToSankeyData(
 ): SankeyData {
   const renamedAggregation = renameOtherCategories(aggregation);
 
-  let processedAggregation = consolidateSmallItems(
-    renamedAggregation,
-    isFriendlyCategory,
-  );
+  let processedAggregation = consolidateSmallItems(renamedAggregation, isFriendlyCategory);
 
   processedAggregation = adjustBalanceAndCategories(
     processedAggregation,
@@ -114,9 +111,7 @@ export function convertCategoryAggregationToSankeyData(
 
   for (const item of processedAggregation.expense) {
     if (item.subcategory) {
-      const nodeId = createSafariCompatibleId(
-        `expense-sub-${item.subcategory}`,
-      );
+      const nodeId = createSafariCompatibleId(`expense-sub-${item.subcategory}`);
       if (!nodeIds.has(nodeId)) {
         nodes.push({
           id: nodeId,
@@ -191,23 +186,14 @@ function consolidateSmallItems(
     return aggregation;
   }
 
-  const incomeThreshold = calculateDynamicThreshold(
-    aggregation.income,
-    SUBCATEGORY_LIMITS.INCOME,
-  );
+  const incomeThreshold = calculateDynamicThreshold(aggregation.income, SUBCATEGORY_LIMITS.INCOME);
   const expenseThreshold = calculateDynamicThreshold(
     aggregation.expense,
     SUBCATEGORY_LIMITS.EXPENSE,
   );
 
-  const consolidatedIncome = consolidateSmallItemsByType(
-    aggregation.income,
-    incomeThreshold,
-  );
-  const consolidatedExpense = consolidateSmallItemsByType(
-    aggregation.expense,
-    expenseThreshold,
-  );
+  const consolidatedIncome = consolidateSmallItemsByType(aggregation.income, incomeThreshold);
+  const consolidatedExpense = consolidateSmallItemsByType(aggregation.expense, expenseThreshold);
 
   return {
     income: consolidatedIncome,
@@ -220,27 +206,19 @@ function consolidateSmallItemsByType(
   threshold: number,
 ): TransactionCategoryAggregation[] {
   // 閾値で大きいグループと小さいグループに分離
-  const smallItems = items.filter(
-    (item) => item.subcategory && item.totalAmount < threshold,
-  );
-  const largeItems = items.filter(
-    (item) => !item.subcategory || item.totalAmount >= threshold,
-  );
+  const smallItems = items.filter((item) => item.subcategory && item.totalAmount < threshold);
+  const largeItems = items.filter((item) => !item.subcategory || item.totalAmount >= threshold);
 
   // 小さいアイテムをカテゴリごとにグループ化
-  const smallItemsByCategory = new Map<
-    string,
-    TransactionCategoryAggregation[]
-  >();
+  const smallItemsByCategory = new Map<string, TransactionCategoryAggregation[]>();
   for (const item of smallItems) {
     const categoryItems = smallItemsByCategory.get(item.category) || [];
     smallItemsByCategory.set(item.category, [...categoryItems, item]);
   }
 
   // 小さいアイテムを統合処理
-  const consolidatedSmallItems = Array.from(smallItemsByCategory).map(
-    ([category, categoryItems]) =>
-      consolidateCategoryItems(category, categoryItems),
+  const consolidatedSmallItems = Array.from(smallItemsByCategory).map(([category, categoryItems]) =>
+    consolidateCategoryItems(category, categoryItems),
   );
 
   // 大きいアイテムと統合後の小さいアイテムをマージして返す
@@ -257,10 +235,7 @@ function consolidateCategoryItems(
   }
 
   // 複数の場合は統合
-  const totalAmount = categoryItems.reduce(
-    (sum, item) => sum + item.totalAmount,
-    0,
-  );
+  const totalAmount = categoryItems.reduce((sum, item) => sum + item.totalAmount, 0);
   return {
     ...categoryItems[0],
     subcategory: `その他（${category}）`,
@@ -278,9 +253,7 @@ function calculateDynamicThreshold(
     return 0;
   }
 
-  const sortedItems = [...subcategoryItems].sort(
-    (a, b) => b.totalAmount - a.totalAmount,
-  );
+  const sortedItems = [...subcategoryItems].sort((a, b) => b.totalAmount - a.totalAmount);
 
   const totalAmount = items.reduce((sum, item) => sum + item.totalAmount, 0);
   const onePercentThreshold = totalAmount * 0.01;

--- a/webapp/src/server/utils/transaction-converter.ts
+++ b/webapp/src/server/utils/transaction-converter.ts
@@ -1,12 +1,6 @@
 import type { Transaction } from "@/shared/models/transaction";
-import {
-  PL_CATEGORIES,
-  type CategoryMapping,
-} from "@/shared/utils/category-mapping";
-import type {
-  DisplayTransaction,
-  DisplayTransactionType,
-} from "@/types/display-transaction";
+import { PL_CATEGORIES, type CategoryMapping } from "@/shared/utils/category-mapping";
+import type { DisplayTransaction, DisplayTransactionType } from "@/types/display-transaction";
 
 /**
  * アカウント名からカテゴリマッピングを取得する関数
@@ -28,9 +22,7 @@ export function getCategoryMapping(account: string): CategoryMapping {
  * @param transaction 元のTransactionオブジェクト
  * @returns 表示用に変換されたDisplayTransactionオブジェクト
  */
-export function convertToDisplayTransaction(
-  transaction: Transaction,
-): DisplayTransaction {
+export function convertToDisplayTransaction(transaction: Transaction): DisplayTransaction {
   // offset系のトランザクションタイプが渡された場合は警告を出力
   if (
     transaction.transaction_type === "offset_income" ||
@@ -65,8 +57,7 @@ export function convertToDisplayTransaction(
       : transaction.credit_amount;
 
   const absAmount = Math.abs(baseAmount);
-  const amount =
-    transaction.transaction_type === "expense" ? -absAmount : absAmount;
+  const amount = transaction.transaction_type === "expense" ? -absAmount : absAmount;
 
   return {
     id: transaction.id,
@@ -87,8 +78,6 @@ export function convertToDisplayTransaction(
 /**
  * Transaction配列をDisplayTransaction配列に変換する関数
  */
-export function convertToDisplayTransactions(
-  transactions: Transaction[],
-): DisplayTransaction[] {
+export function convertToDisplayTransactions(transactions: Transaction[]): DisplayTransaction[] {
   return transactions.map(convertToDisplayTransaction);
 }

--- a/webapp/src/types/display-transaction.ts
+++ b/webapp/src/types/display-transaction.ts
@@ -2,11 +2,7 @@
 export type DisplayTransactionType = "income" | "expense";
 
 // DB用のTransactionType（全種類を含む）
-export type TransactionType =
-  | "income"
-  | "expense"
-  | "offset_income"
-  | "offset_expense";
+export type TransactionType = "income" | "expense" | "offset_income" | "offset_expense";
 
 export interface DisplayTransaction {
   id: string; // 元のTransaction IDをそのまま利用


### PR DESCRIPTION
## Summary
- biome.jsonのlineWidthを80から100文字に変更
- 業界標準（Next.js, Vercel, shadcn/ui等）に合わせた設定
- 全ファイルにbiome formatを適用（162ファイル自動修正）

## 変更理由
2025年のモダンなReact/TypeScript/Next.jsプロジェクトでは、100文字が標準的な設定となっています。
- Next.js公式推奨: 100
- Vercel Style Guide: 100
- shadcn/ui: 100
- TypeScriptの長い型定義に対応しやすい

## 影響範囲
- 163ファイル
- +668行、-2,021行（純減: 1,353行）
- ロジック変更なし、フォーマットのみ

## Test plan
- [x] `npm run typecheck` 成功
- [x] `npm run lint` 成功
- [x] prisma generate実行済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)