### PR TITLE
chore: wtp設定ファイルとガイドを追加

### DIFF
--- a/.wtp.yml
+++ b/.wtp.yml
@@ -1,3 +1,7 @@
+# wtp: git worktree を便利に使うためのCLIツールの設定ファイル
+# ワークツリー作成時に環境変数のコピーと依存関係インストールを自動化する
+# 使い方: brew install satococoa/tap/wtp && wtp add -b feature/xxx
+
 version: "1.0"
 
 defaults:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,8 +80,11 @@ contexts/{コンテキスト名}/
 
 - TypeScript の import は `@/` から始まる絶対パスを使用する（相対パス禁止）
 
-## GitHub操作ルール
+## wtp (git worktree) の利用
 
+並行開発が必要な場合は wtp を使う。詳細は [docs/wtp-guide.md](docs/wtp-guide.md) を参照。
+
+## GitHub操作ルール
 - ユーザーからPRを出して、と言われたときは、現在の作業のフィーチャーブランチを切りコミットを行ってからPRを出すようにする
 - developやmainへの直接pushは禁止です
 - Prismaのマイグレーションを含む差分は自動デプロイで環境を壊しうるので、ユーザーに許可を取ってから実行してください

--- a/docs/wtp-guide.md
+++ b/docs/wtp-guide.md
@@ -1,0 +1,89 @@
+# wtp (git worktree) 使い方ガイド
+
+wtp は git worktree を便利に使うための CLI ツール。
+並行して複数のブランチで作業したいときに使う。
+
+## インストール
+
+```bash
+brew install satococoa/tap/wtp
+```
+
+## 基本コマンド
+
+### ワークツリーの作成
+
+```bash
+# 新しいブランチを作成してワークツリーを追加
+wtp add -b feature/new-feature
+
+# 既存のブランチからワークツリーを追加
+wtp add feature/existing-branch
+```
+
+ブランチ名の `/` はディレクトリ構造に変換される。
+例: `feature/new-feature` → `.git/worktrees/feature/new-feature/`
+
+### ワークツリーへの移動
+
+```bash
+# 指定したワークツリーに移動
+wtp cd feature/new-feature
+
+# メインのワークツリー（元のディレクトリ）に戻る
+wtp cd @
+```
+
+### ワークツリーの一覧
+
+```bash
+wtp list
+```
+
+### ワークツリーの削除
+
+```bash
+# ワークツリーのみ削除
+wtp remove feature/new-feature
+
+# ワークツリーとブランチを一緒に削除
+wtp remove --with-branch feature/new-feature
+```
+
+## このリポジトリの設定
+
+`.wtp.yml` により、ワークツリー作成時に以下が自動実行される：
+
+1. 環境変数ファイルのコピー（`.env`, `webapp/.env.local`, `admin/.env.local`）
+2. `pnpm install`
+3. `pnpm db:generate`（Prisma クライアント生成）
+
+## ユースケース
+
+### 緊急のバグ修正
+
+現在の作業を中断せずに hotfix を作成：
+
+```bash
+# hotfix 用のワークツリーを作成
+wtp add -b hotfix/urgent-bug
+
+# hotfix に移動して修正
+wtp cd hotfix/urgent-bug
+# ... 修正作業 ...
+
+# 元の作業に戻る
+wtp cd @
+
+# 後片付け
+wtp remove --with-branch hotfix/urgent-bug
+```
+
+### 複数機能の並行開発
+
+```bash
+wtp add -b feature/auth
+wtp add -b feature/dashboard
+
+# 別々のターミナルで各ワークツリーを開いて並行作業
+```


### PR DESCRIPTION
## Summary
- git worktree管理ツール wtp の設定ファイル (`.wtp.yml`) を追加
- ワークツリー作成時に環境変数のコピーと依存関係インストールを自動化
- Claude向けに使い方ガイド (`docs/wtp-guide.md`) を追加し、CLAUDE.mdから参照

## Test plan
- [ ] `brew install satococoa/tap/wtp` でインストール
- [ ] `wtp add -b test/wtp-test` でワークツリー作成を確認
- [ ] 環境変数ファイルがコピーされ、依存関係がインストールされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)