### PR TITLE
docs: add shadcn/ui migration design document

### DIFF
--- a/docs/20251216_1448_shadcn_ui導入設計.md
+++ b/docs/20251216_1448_shadcn_ui導入設計.md
@@ -1,0 +1,470 @@
+# shadcn/ui 導入設計
+
+## 概要
+
+admin 管理画面のUIコンポーネントを shadcn/ui に段階的に移行する。現在は独自実装のコンポーネント（Button、Input、Card等）を使用しているが、統一感の維持とメンテナンス性向上のため、デザインシステムとして shadcn/ui を採用する。
+
+## 背景と目的
+
+### 現状の課題
+
+- UIコンポーネントが独自実装で統一されていない
+- 新規コンポーネント追加時のデザイン指針が不明確
+- アクセシビリティ対応が不十分
+- コンポーネントのバリエーション（variant、size等）の拡張が煩雑
+
+### 目的
+
+1. **統一感のあるUI**: shadcn/ui のデザインシステムで一貫性を確保
+2. **開発効率向上**: 実績あるコンポーネントライブラリで実装速度向上
+3. **アクセシビリティ**: Radix UI ベースのアクセシブルなコンポーネント
+4. **カスタマイズ性**: プロジェクトのニーズに合わせて柔軟に調整可能
+
+### shadcn/ui 選定理由
+
+- **コピー&ペースト型**: node_modules に依存せず、プロジェクト内で完全管理
+- **カスタマイズ容易**: Tailwind CSS ベースで既存のデザインテーマに統合しやすい
+- **TypeScript サポート**: 型安全性が高い
+- **Next.js 15 対応**: App Router、Server Components との相性が良い
+- **段階的導入が可能**: 既存コンポーネントと共存しながら移行できる
+
+## スコープ
+
+### 対象
+
+- admin 管理画面のすべてのUIコンポーネント
+- 新規実装するコンポーネント（取引先管理画面、政治資金報告書編集画面等）
+
+### 対象外
+
+- webapp（公開用フロントエンド）は独自の Material-like デザインのため対象外
+- バックエンドAPIやビジネスロジック
+
+## 現状分析
+
+### 既存のUIコンポーネント
+
+```
+admin/src/client/components/ui/
+├── Button.tsx           # variant: primary/secondary/danger, size: sm/md/lg
+├── Input.tsx            # label、error 表示対応
+├── Card.tsx             # variant: default/outlined
+├── Selector.tsx         # セレクトボックス
+├── ClientPagination.tsx # クライアント側ページネーション
+└── StaticPagination.tsx # 静的ページネーション
+```
+
+### 既存のカラーテーマ
+
+admin は独自のダークテーマを使用：
+
+```css
+@theme {
+  --color-primary-bg: #0b1020;
+  --color-primary-panel: #141a2d;
+  --color-primary-muted: #9aa4bf;
+  --color-primary-accent: #5b8cff;
+  --color-primary-hover: #1d2745;
+  --color-primary-input: #0f1527;
+  --color-primary-border: #263258;
+}
+```
+
+このカラーパレットを shadcn/ui のテーマ設定に適用する必要がある。
+
+### 既存コンポーネントの利用状況
+
+- **Button**: 全画面で多用（ログイン、フォーム送信、削除ボタン等）
+- **Input**: フォーム入力全般
+- **Card**: コンテンツのグルーピング
+- **Selector**: セレクトボックス（組織選択、年度選択等）
+- **Pagination**: トランザクション一覧、CSV取り込みプレビュー等
+
+## 導入計画
+
+### 第1段階: shadcn/ui ベース導入
+
+**目的**: 既存コードに影響を与えず、新規コンポーネントから使える環境を整備
+
+#### 1-1. 必要なパッケージのインストール
+
+```bash
+cd admin
+pnpm add class-variance-authority clsx tailwind-merge
+pnpm add -D @radix-ui/react-slot
+```
+
+#### 1-2. shadcn/ui CLI 初期化
+
+```bash
+cd admin
+npx shadcn@latest init
+```
+
+対話形式で以下を選択：
+
+```
+✔ Preflight and reset: Yes
+✔ CSS variables: Yes (既存のカラーテーマを活かせる)
+✔ Tailwind config: PostCSS (既存設定を維持)
+✔ Import alias: @/* (既存の設定に合わせる)
+✔ React Server Components: Yes (Next.js 15 App Router)
+```
+
+#### 1-3. components.json の作成
+
+```json
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "postcss.config.js",
+    "css": "src/app/styles.css",
+    "baseColor": "slate",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/client/components",
+    "utils": "@/client/lib",
+    "ui": "@/client/components/ui",
+    "lib": "@/client/lib",
+    "hooks": "@/client/hooks"
+  }
+}
+```
+
+#### 1-4. lib/utils.ts の作成
+
+shadcn/ui の cn() ヘルパーを配置：
+
+```typescript
+// admin/src/client/lib/utils.ts
+import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}
+```
+
+#### 1-5. カラーテーマの調整
+
+既存のカラーパレットを shadcn/ui の CSS 変数に変換：
+
+```css
+/* admin/src/app/styles.css */
+@import "tailwindcss";
+
+@theme {
+  /* 既存のカラー変数（維持） */
+  --color-primary-bg: #0b1020;
+  --color-primary-panel: #141a2d;
+  --color-primary-muted: #9aa4bf;
+  --color-primary-accent: #5b8cff;
+  --color-primary-hover: #1d2745;
+  --color-primary-input: #0f1527;
+  --color-primary-border: #263258;
+
+  /* shadcn/ui のカラー変数（既存のカラーにマッピング） */
+  --background: var(--color-primary-bg);
+  --foreground: #ffffff;
+
+  --card: var(--color-primary-panel);
+  --card-foreground: #ffffff;
+
+  --popover: var(--color-primary-panel);
+  --popover-foreground: #ffffff;
+
+  --primary: var(--color-primary-accent);
+  --primary-foreground: #ffffff;
+
+  --secondary: var(--color-primary-hover);
+  --secondary-foreground: #ffffff;
+
+  --muted: var(--color-primary-hover);
+  --muted-foreground: var(--color-primary-muted);
+
+  --accent: var(--color-primary-accent);
+  --accent-foreground: #ffffff;
+
+  --destructive: #ef4444;
+  --destructive-foreground: #ffffff;
+
+  --border: var(--color-primary-border);
+  --input: var(--color-primary-input);
+  --ring: var(--color-primary-accent);
+
+  --radius: 0.5rem;
+}
+```
+
+#### 1-6. 基本コンポーネントのインストール
+
+よく使うコンポーネントを先行インストール：
+
+```bash
+cd admin
+npx shadcn@latest add button
+npx shadcn@latest add input
+npx shadcn@latest add label
+npx shadcn@latest add card
+npx shadcn@latest add select
+npx shadcn@latest add dialog
+npx shadcn@latest add table
+npx shadcn@latest add form
+```
+
+これにより、以下のファイルが生成される：
+
+```
+admin/src/client/components/ui/
+├── button.tsx           # shadcn/ui の Button
+├── input.tsx            # shadcn/ui の Input（既存とファイル名が衝突）
+├── label.tsx
+├── card.tsx             # shadcn/ui の Card（既存とファイル名が衝突）
+├── select.tsx
+├── dialog.tsx
+├── table.tsx
+└── form.tsx
+```
+
+**衝突への対応**:
+
+既存の独自実装（`Button.tsx`、`Input.tsx`、`Card.tsx`）は大文字始まりのファイル名なので、shadcn/ui の小文字ファイル名（`button.tsx`、`input.tsx`、`card.tsx`）と共存可能。段階的に既存コンポーネントを削除していく。
+
+#### 1-7. 動作確認
+
+新規に shadcn/ui コンポーネントを使ったテストページを作成して動作確認：
+
+```tsx
+// admin/src/app/test-shadcn/page.tsx
+import { Button } from "@/client/components/ui/button"
+import { Input } from "@/client/components/ui/input"
+import { Card, CardContent, CardHeader, CardTitle } from "@/client/components/ui/card"
+
+export default function TestShadcnPage() {
+  return (
+    <div className="p-8 space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>shadcn/ui テスト</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Input placeholder="テスト入力" />
+          <div className="flex gap-2">
+            <Button>Primary</Button>
+            <Button variant="secondary">Secondary</Button>
+            <Button variant="destructive">Danger</Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+```
+
+**確認項目**:
+- [ ] shadcn/ui のコンポーネントが正しく表示される
+- [ ] 既存のカラーテーマが適用される
+- [ ] 既存の独自実装コンポーネントも動作する（共存確認）
+
+---
+
+### 第2段階: ページ・コンポーネントごとの移行
+
+**目的**: 既存の独自実装コンポーネントを shadcn/ui に段階的に置き換え
+
+#### 移行の優先順位
+
+影響範囲の小さいページから順に移行：
+
+**Phase 2-1: 独立した新規機能（影響範囲: 小）**
+- 取引先管理画面（これから実装するため、最初から shadcn/ui を使用）
+- 政治資金報告書編集画面（新規実装）
+
+**Phase 2-2: 既存の単純なページ（影響範囲: 中）**
+- ログイン画面 (`admin/src/client/components/auth/LoginForm.tsx`)
+- セットアップ画面 (`admin/src/client/components/auth/SetupForm.tsx`)
+- 組織管理画面 (`admin/src/client/components/political-organizations/`)
+
+**Phase 2-3: 複雑なページ（影響範囲: 大）**
+- トランザクション一覧 (`admin/src/client/components/transactions/`)
+- CSV取り込み (`admin/src/client/components/csv-import/`)
+- 政治資金報告書プロファイル (`admin/src/client/components/report-profile/`)
+
+#### 移行手順（ページ単位）
+
+1. **影響範囲の確認**
+   - そのページで使用している独自コンポーネントをリストアップ
+   - 他ページとの共通コンポーネントを特定
+
+2. **shadcn/ui コンポーネントへの置き換え**
+   - `Button` → `button.tsx`
+   - `Input` → `input.tsx` + `label.tsx`
+   - `Card` → `card.tsx`
+   - `Selector` → `select.tsx`
+
+3. **スタイル調整**
+   - shadcn/ui のデフォルトスタイルに合わせる
+   - 必要に応じて Tailwind クラスで微調整
+
+4. **動作確認**
+   - UI表示が正しいか
+   - フォーム送信、バリデーション等の機能が動作するか
+
+5. **型エラー・Lint エラーの解消**
+   ```bash
+   npm run typecheck:admin
+   npm run lint:admin
+   ```
+
+6. **コミット**
+   - ページ単位で1コミット
+   - コミットメッセージ: `refactor(admin): migrate [ページ名] to shadcn/ui`
+
+#### 移行後のクリーンアップ
+
+すべてのページを移行した後：
+
+1. **独自実装コンポーネントの削除**
+   ```bash
+   rm admin/src/client/components/ui/Button.tsx
+   rm admin/src/client/components/ui/Input.tsx
+   rm admin/src/client/components/ui/Card.tsx
+   rm admin/src/client/components/ui/Selector.tsx
+   ```
+
+2. **未使用のスタイル削除**
+   - `admin/src/app/styles.css` から不要になったグローバルスタイルを削除
+
+3. **動作確認**
+   - すべてのページを手動で確認
+   - ビルドが通ることを確認
+
+4. **ドキュメント更新**
+   - [CLAUDE.md](../CLAUDE.md) に shadcn/ui 使用を明記
+   - README に UI コンポーネントガイドを追加（オプション）
+
+---
+
+## コンポーネント対応表
+
+既存の独自実装と shadcn/ui の対応：
+
+| 既存コンポーネント | shadcn/ui | 備考 |
+|---|---|---|
+| `Button.tsx` | `button.tsx` | variant、size の対応はほぼ同じ |
+| `Input.tsx` | `input.tsx` + `label.tsx` | label は別コンポーネント化 |
+| `Card.tsx` | `card.tsx` | CardHeader、CardContent 等に分割 |
+| `Selector.tsx` | `select.tsx` | Radix UI Select ベース |
+| `ClientPagination.tsx` | カスタム実装 | shadcn/ui に直接の対応なし |
+| `StaticPagination.tsx` | カスタム実装 | shadcn/ui に直接の対応なし |
+
+### Pagination について
+
+shadcn/ui には Pagination コンポーネントがないため、以下の選択肢：
+
+1. **shadcn/ui の Button を使って自前実装**（推奨）
+   - 既存の Pagination ロジックを維持
+   - UI だけ shadcn/ui の Button に置き換え
+
+2. **TanStack Table を導入**
+   - 高機能なテーブルライブラリ
+   - ページネーション、ソート、フィルタを統合管理
+   - 取引先管理画面など新規実装で採用を検討
+
+## 技術スタック
+
+### 追加するパッケージ
+
+- **class-variance-authority**: バリアント管理
+- **clsx**: クラス名の条件付き結合
+- **tailwind-merge**: Tailwind クラスの競合解決
+- **@radix-ui/react-***: shadcn/ui の基盤となるアクセシブルなコンポーネント
+
+### 既存パッケージとの関係
+
+- **Tailwind CSS 4**: 既に導入済み、shadcn/ui はこれを活用
+- **Next.js 15**: App Router、Server Components に対応
+- **React 19**: shadcn/ui は React 19 に対応
+
+## リスクと対応
+
+### リスク1: 既存コンポーネントとの衝突
+
+**影響**: ファイル名が重複する可能性（Button.tsx vs button.tsx）
+
+**対応**:
+- shadcn/ui は小文字ファイル名、既存は大文字ファイル名で共存可能
+- 段階的に既存コンポーネントを削除
+
+### リスク2: スタイルの崩れ
+
+**影響**: shadcn/ui のデフォルトスタイルが既存デザインと合わない
+
+**対応**:
+- CSS 変数で既存カラーパレットをマッピング
+- 必要に応じて Tailwind クラスで微調整
+- 各ページ移行時に動作確認を徹底
+
+### リスク3: 移行コストの増大
+
+**影響**: 全ページを移行するのに時間がかかる
+
+**対応**:
+- 新規実装から shadcn/ui を使用（取引先管理画面等）
+- 既存ページは優先度の低いものから徐々に移行
+- 独自実装と shadcn/ui の共存期間を許容
+
+### リスク4: アクセシビリティの学習コスト
+
+**影響**: Radix UI のアクセシビリティ機能を理解する必要がある
+
+**対応**:
+- shadcn/ui のドキュメントを参照
+- 必要に応じて Radix UI のドキュメントも確認
+- 段階的に学習しながら進める
+
+## テストシナリオ
+
+### 第1段階（ベース導入）
+
+- [ ] shadcn/ui CLI で初期化が完了する
+- [ ] lib/utils.ts の cn() 関数が動作する
+- [ ] テストページで shadcn/ui コンポーネントが表示される
+- [ ] 既存のカラーテーマが適用される
+- [ ] 既存の独自実装コンポーネントも引き続き動作する
+
+### 第2段階（移行）
+
+各ページ移行時：
+
+- [ ] UI が正しく表示される
+- [ ] フォーム送信・バリデーションが動作する
+- [ ] アクセシビリティ（キーボードナビゲーション、スクリーンリーダー）が機能する
+- [ ] `npm run typecheck:admin` が成功する
+- [ ] `npm run lint:admin` が成功する
+
+すべての移行完了後：
+
+- [ ] 独自実装コンポーネントが削除されている
+- [ ] すべてのページで shadcn/ui コンポーネントが使用されている
+- [ ] ビルドが成功する
+- [ ] 本番環境で動作確認
+
+## 実装順序の利点
+
+1. **段階的なリスク低減**: 一度にすべてを変更しないため、問題の早期発見が可能
+2. **学習しながら進められる**: shadcn/ui に慣れながら移行できる
+3. **後戻り可能**: 問題があれば一部を元に戻すことも容易
+4. **新規機能で即利用可能**: 取引先管理画面など新規実装から shadcn/ui を使える
+
+## 参考リンク
+
+- [shadcn/ui 公式ドキュメント](https://ui.shadcn.com/)
+- [Radix UI ドキュメント](https://www.radix-ui.com/)
+- [Tailwind CSS 4 ドキュメント](https://tailwindcss.com/)
+- [Next.js 15 App Router ガイド](https://nextjs.org/docs)


### PR DESCRIPTION
## Summary

admin 管理画面のUIコンポーネントを shadcn/ui に段階的に移行するための設計ドキュメントを追加

## 設計内容

- **第1段階**: shadcn/ui のベース導入（既存コードに影響なし）
  - パッケージインストール
  - CLI 初期化
  - 既存カラーテーマのマッピング
  - 基本コンポーネントのインストール
  
- **第2段階**: ページ・コンポーネントごとの段階的移行
  - 新規実装（取引先管理画面等）から shadcn/ui を使用
  - 既存ページは優先度順に移行
  - 独自実装と共存しながら段階的に置き換え

## 背景

- 現在の独自実装UIコンポーネントは統一感の維持が難しい
- アクセシビリティ対応が不十分
- shadcn/ui でデザインシステムを確立し、開発効率とUX品質を向上

## 詳細

設計ドキュメント: `docs/20251216_1448_shadcn_ui導入設計.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)