### PR TITLE
fix: 取引一覧のSelectでデフォルトで最初の政治団体を選択

### DIFF
--- a/admin/src/client/components/transactions/TransactionsClient.tsx
+++ b/admin/src/client/components/transactions/TransactionsClient.tsx
@@ -28,22 +28,19 @@ export function TransactionsClient({ organizations }: TransactionsClientProps) {
   const [loading, setLoading] = useState(true);
   const [fetching, setFetching] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [selectedOrgId, setSelectedOrgId] = useState<string>("");
+  const [selectedOrgId, setSelectedOrgId] = useState<string>(organizations[0]?.id ?? "");
   const isInitialLoad = useRef(true);
 
   const currentPage = parseInt(searchParams.get("page") || "1", 10);
   const perPage = 50;
 
-  const organizationOptions = [
-    { value: "", label: "全件" },
-    ...organizations.map((org) => ({
-      value: org.id,
-      label: org.displayName,
-    })),
-  ];
+  const organizationOptions = organizations.map((org) => ({
+    value: org.id,
+    label: org.displayName,
+  }));
 
   useEffect(() => {
-    const fetchTransactions = async (orgId: string = "") => {
+    const fetchTransactions = async (orgId: string) => {
       try {
         // 初回ロードはloading、以降はfetching
         if (isInitialLoad.current) {


### PR DESCRIPTION
## Summary
- Radix UIのSelectItemに空文字列のvalueが渡されていた問題を修正
- 「全件」オプションを削除し、最初の政治団体をデフォルト選択に変更

## Changes
- `TransactionsClient.tsx`: デフォルトで`organizations[0]?.id`を選択するよう変更
- 「全件」オプションの削除

## Test plan
- [x] `npm run typecheck` パス
- [x] `npm run lint` パス
- [x] `npm test` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* 取引画面の組織フィルターを改善し、常に有効な組織が自動的に選択されるようになりました。
* 組織フィルターのドロップダウンから空のオプションを削除し、実際の組織のみを表示するようにしました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->