### PR TITLE
docs: admin CSS整理の設計ドキュメントを追加

### DIFF
--- a/docs/20251222_1046_admin_CSS整理設計.md
+++ b/docs/20251222_1046_admin_CSS整理設計.md
@@ -1,0 +1,191 @@
+# admin CSS 整理設計
+
+## 背景
+
+admin アプリケーションに後から shadcn/ui を導入したため、CSS 変数やコンポーネントクラスに重複定義が存在している。これを整理し、shadcn/ui のベストプラクティスに沿った構成に統一する。
+
+## 方針
+
+- shadcn/ui 公式の **Dark Blue テーマ** を採用
+- ファイル名を `globals.css` に変更
+- 独自定義を削除し、shadcn 標準に統一
+
+## 現状分析
+
+### 1. ファイル構成
+
+現在: `admin/src/app/styles.css`
+→ shadcn/ui 標準: `admin/src/app/globals.css`
+
+### 2. CSS 変数の重複
+
+#### 2.1 `:root` 変数（独自定義）
+
+```css
+:root {
+  --bg: #0b1020;
+  --panel: #141a2d;
+  --muted: #9aa4bf;
+  --accent: #5b8cff;
+  --hover: #1d2745;
+  --input: #0f1527;
+  --border: #263258;
+}
+```
+
+**使用箇所**: `styles.css` 内のみ（6箇所）→ **削除可能**
+
+#### 2.2 `--color-primary-*` プレフィックス付き変数（独自定義）
+
+| 独自変数 | 対応する shadcn 変数 |
+|---------|---------------------|
+| `--color-primary-bg` | `--color-background` |
+| `--color-primary-panel` | `--color-card` |
+| `--color-primary-muted` | `--color-muted-foreground` |
+| `--color-primary-accent` | `--color-primary` |
+| `--color-primary-hover` | `--color-secondary` |
+| `--color-primary-input` | `--color-input` |
+| `--color-primary-border` | `--color-border` |
+
+**使用箇所**: 多数のコンポーネントで Tailwind クラスとして使用（例: `text-primary-muted`, `bg-primary-input`）
+
+### 3. コンポーネントクラスの重複
+
+| 独自クラス | shadcn 対応 | 使用箇所 |
+|-----------|-------------|---------|
+| `.card` | `<Card>` / `bg-card` | 3箇所 |
+| `.input` | `<Input>` / `bg-input` | 未使用 |
+| `.button` | `<Button>` | 未使用 |
+| `.muted` | `text-muted-foreground` | 1箇所 |
+
+### 4. その他の独自レイアウトクラス
+
+| クラス | 用途 | 対応方針 |
+|--------|------|---------|
+| `.container` | 2カラムグリッドレイアウト | 維持 |
+| `.sidebar` | サイドバースタイル | 削除（Sidebar.tsx で Tailwind 使用中） |
+| `.nav`, `.nav a` | ナビゲーションリンク | 使用状況確認後に判断 |
+| `.content` | メインコンテンツエリア | 維持 |
+| `.row` | グリッドレイアウト | 削除（未使用） |
+
+## 採用するテーマ
+
+shadcn/ui 公式 Dark Blue テーマ（oklch カラースペース）:
+
+```css
+@theme {
+  --color-background: oklch(0.141 0.005 286.375);
+  --color-foreground: oklch(0.985 0 0);
+
+  --color-card: oklch(0.141 0.005 286.375);
+  --color-card-foreground: oklch(0.985 0 0);
+
+  --color-popover: oklch(0.141 0.005 286.375);
+  --color-popover-foreground: oklch(0.985 0 0);
+
+  --color-primary: oklch(0.546 0.245 262.881);
+  --color-primary-foreground: oklch(0.379 0.146 265.522);
+
+  --color-secondary: oklch(0.268 0.007 286.033);
+  --color-secondary-foreground: oklch(0.985 0 0);
+
+  --color-muted: oklch(0.268 0.007 286.033);
+  --color-muted-foreground: oklch(0.705 0.015 286.067);
+
+  --color-accent: oklch(0.268 0.007 286.033);
+  --color-accent-foreground: oklch(0.985 0 0);
+
+  --color-destructive: oklch(0.396 0.141 25.723);
+  --color-destructive-foreground: oklch(0.637 0.237 25.331);
+
+  --color-border: oklch(0.268 0.007 286.033);
+  --color-input: oklch(0.268 0.007 286.033);
+  --color-ring: oklch(0.546 0.245 262.881);
+
+  --radius: 0.5rem;
+}
+```
+
+## 実装順序
+
+### Phase 1: テーマ変更とファイル整理
+
+1. `@theme` を Dark Blue テーマに変更
+2. `:root` 変数を削除し、`styles.css` 内の参照を `@theme` 変数に変更
+3. 互換性のため `--color-primary-*` 変数を Dark Blue の値で維持
+4. 未使用の `.input`, `.button`, `.row` クラスを削除
+5. `.sidebar` クラスを削除（Sidebar.tsx で Tailwind 使用中）
+6. `styles.css` → `globals.css` にリネーム
+7. `layout.tsx` の import 更新
+
+### Phase 2: 独自クラスの置換
+
+1. `.card` クラスの使用箇所を Tailwind クラスに置換
+   - `admin/src/app/(public)/login/processor.tsx`
+   - `admin/src/app/(auth)/page.tsx`
+   - `admin/src/app/(auth)/user-info/page.tsx`
+2. `.muted` クラスの使用箇所を `text-muted-foreground` に置換
+   - `admin/src/app/(auth)/page.tsx`
+3. `.card`, `.muted` クラス定義を削除
+
+### Phase 3: 独自カラークラスの段階的移行（オプション）
+
+新規コードでは shadcn 標準クラスを使用し、既存コードは段階的に移行:
+
+| 移行元 | 移行先 |
+|-------|-------|
+| `text-primary-muted` | `text-muted-foreground` |
+| `bg-primary-input` | `bg-input` |
+| `border-primary-border` | `border-border` |
+| `bg-primary-panel` | `bg-card` |
+| `bg-primary-hover` | `bg-secondary` |
+| `text-primary-accent` | `text-primary` |
+| `ring-primary-accent` | `ring-ring` |
+
+## 移行対象ファイル一覧
+
+### Phase 2 対象
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `admin/src/app/(public)/login/processor.tsx` | `.card` → `bg-card rounded-xl p-4` |
+| `admin/src/app/(auth)/page.tsx` | `.card` → `bg-card rounded-xl p-4`, `.muted` → `text-muted-foreground` |
+| `admin/src/app/(auth)/user-info/page.tsx` | `.card` → `bg-card rounded-xl p-4` |
+
+### Phase 3 対象（段階的移行）
+
+`text-primary-muted` 使用ファイル:
+- `BulkAssignModal.tsx`
+- `TransactionWithCounterpartTable.tsx`
+- `CounterpartAssignmentClient.tsx`
+- `CounterpartCombobox.tsx`
+- `UserManagement.tsx`
+- `CurrentBalance.tsx`
+- `BalanceSnapshotsClient.tsx`
+- `BalanceSnapshotList.tsx`
+- `TransactionRow.tsx` (transactions, csv-import)
+- `TransactionsClient.tsx`
+- `CsvPreview.tsx`
+- `XmlExportClient.tsx`
+- `CreateCounterpartDialog.tsx`
+- `EditCounterpartDialog.tsx`
+- `CounterpartMasterClient.tsx`
+- `CounterpartTable.tsx`
+- `ClientPagination.tsx`
+- `StaticPagination.tsx`
+- `political-organizations/page.tsx`
+- `report-profile/page.tsx`
+
+`bg-primary-input` 使用ファイル:
+- `CounterpartCombobox.tsx`
+- `UserManagement.tsx`
+- `StatisticsTable.tsx`
+- `CounterpartMasterClient.tsx`
+- `political-organizations/page.tsx`
+
+`border-primary-border` 使用ファイル:
+- `TransactionWithCounterpartTable.tsx`
+- `CounterpartAssignmentClient.tsx`
+- `CounterpartCombobox.tsx`
+- `UserManagement.tsx`
+- `CounterpartMasterClient.tsx`


### PR DESCRIPTION
## Summary
- shadcn/ui Dark Blue テーマへの移行と独自CSS定義の整理方針をまとめた設計ドキュメントを追加

## 内容
- 現状分析: CSS変数・コンポーネントクラスの重複を整理
- 採用テーマ: shadcn/ui 公式 Dark Blue テーマ
- 実装フェーズ: Phase 1〜3に分けた段階的移行計画
- 移行対象ファイル一覧

## Test plan
- [x] ドキュメントのみの追加のためテスト不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)