### PR TITLE
docs: admin UIガイドラインをDark Blueテーマ方針に更新

### DIFF
--- a/docs/admin-ui-guidelines.md
+++ b/docs/admin-ui-guidelines.md
@@ -95,25 +95,37 @@ function MyModal() {
 
 ## スタイリング
 
+### テーマ
+
+shadcn/ui 公式の **Dark Blue テーマ** を採用しています。
+テーマ定義は `admin/src/app/globals.css` の `@theme` ブロックにあります。
+
 ### カラー変数
 
 shadcn UI 標準の CSS 変数を使用してください。
 
 ```css
 /* 推奨: shadcn 標準変数 */
-bg-background      /* 背景色 */
-bg-card            /* カード背景 */
-text-foreground    /* テキスト色 */
-text-muted-foreground  /* 補助テキスト */
-border-border      /* ボーダー */
-bg-primary         /* プライマリ色 */
-bg-destructive     /* 危険色（赤） */
+bg-background         /* 背景色 */
+bg-card               /* カード背景 */
+text-foreground       /* テキスト色 */
+text-muted-foreground /* 補助テキスト */
+border-border         /* ボーダー */
+bg-input              /* 入力フィールド背景 */
+bg-primary            /* プライマリ色 */
+bg-secondary          /* セカンダリ色（ホバー等） */
+bg-destructive        /* 危険色（赤） */
+ring-ring             /* フォーカスリング */
 
-/* 非推奨: カスタム変数（段階的に移行予定） */
-bg-primary-bg
-bg-primary-panel
-text-primary-muted
-border-primary-border
+/* 非推奨: カスタム変数 → 以下に移行 */
+bg-primary-bg       → bg-background
+bg-primary-panel    → bg-card
+text-primary-muted  → text-muted-foreground
+border-primary-border → border-border
+bg-primary-input    → bg-input
+bg-primary-hover    → bg-secondary
+text-primary-accent → text-primary
+ring-primary-accent → ring-ring
 ```
 
 ### クラス名の合成


### PR DESCRIPTION
## Summary
- admin UIガイドラインを新しいDark Blueテーマ方針に合わせて更新

## Changes
- テーマセクションを追加（Dark Blue採用、globals.css参照）
- カラー変数の推奨リストを拡充
- 非推奨カスタム変数から推奨変数への移行対応表を追加

## Related
- #726 (admin CSS整理の設計ドキュメント)

## Test plan
- [x] ドキュメントのみの変更のためテスト不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)