### PR TITLE
fix(admin): 種別バッジのスタイルをカテゴリと統一

### DIFF
--- a/admin/src/client/components/transactions/TransactionRow.tsx
+++ b/admin/src/client/components/transactions/TransactionRow.tsx
@@ -147,11 +147,11 @@ export function TransactionRow({ transaction }: TransactionRowProps) {
         ¥{transaction.credit_amount.toLocaleString()}
       </td>
       <td className="px-2 py-3 text-sm text-white">
-        <span
-          className={`px-2 py-1 rounded text-white text-xs font-medium ${getTypeBadgeClass(transaction.transaction_type)}`}
+        <div
+          className={`inline-block px-2 py-1 rounded text-white text-xs font-medium ${getTypeBadgeClass(transaction.transaction_type)}`}
         >
           {getTypeLabel(transaction.transaction_type)}
-        </span>
+        </div>
       </td>
       <td className="px-2 py-3 text-sm text-white">
         {(() => {


### PR DESCRIPTION
## Summary
- 取引一覧テーブルの「種別」列のバッジがセル幅が狭い時に改行で崩れる問題を修正
- `<span>`から`<div class="inline-block">`に変更し、カテゴリバッジと同じ表示形式に統一

## Test plan
- [x] `npm run typecheck` パス
- [x] `npm run lint` パス
- [x] `npm test` パス
- [ ] `/transactions` ページで種別バッジが改行時に領域が崩れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル改善**
  * トランザクション画面の各取引行に表示されるバッジ要素のレイアウトを改善し、表示の一貫性が向上しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->