### PR TITLE
fix(admin): Select.Itemに空文字列valueを渡さないよう修正

### DIFF
--- a/admin/src/client/components/counterpart-assignment/CounterpartAssignmentClient.tsx
+++ b/admin/src/client/components/counterpart-assignment/CounterpartAssignmentClient.tsx
@@ -25,6 +25,8 @@ import {
 import { PoliticalOrganizationSelect } from "@/client/components/political-organizations/PoliticalOrganizationSelect";
 import { PL_CATEGORIES } from "@/shared/utils/category-mapping";
 
+const ALL_CATEGORIES_VALUE = "__all__";
+
 interface CounterpartAssignmentClientProps {
   organizations: PoliticalOrganization[];
   initialTransactions: TransactionWithCounterpart[];
@@ -64,7 +66,9 @@ export function CounterpartAssignmentClient({
     initialFilters.financialYear || initialFinancialYear,
   );
   const [unassignedOnly, setUnassignedOnly] = useState(initialFilters.unassignedOnly);
-  const [categoryKey, setCategoryKey] = useState(initialFilters.categoryKey);
+  const [categoryKey, setCategoryKey] = useState(
+    initialFilters.categoryKey || ALL_CATEGORIES_VALUE,
+  );
   const [searchQuery, setSearchQuery] = useState(initialFilters.searchQuery);
   const [sortField, setSortField] = useState(initialFilters.sortField);
   const [sortOrder, setSortOrder] = useState(initialFilters.sortOrder);
@@ -76,7 +80,7 @@ export function CounterpartAssignmentClient({
   }, [initialTransactions, rowSelection]);
 
   const categoryOptions = useMemo(() => {
-    const options = [{ value: "", label: "すべてのカテゴリ" }];
+    const options = [{ value: ALL_CATEGORIES_VALUE, label: "すべてのカテゴリ" }];
     for (const [, value] of Object.entries(PL_CATEGORIES)) {
       if (value.type === "expense" || value.type === "income") {
         options.push({
@@ -151,8 +155,9 @@ export function CounterpartAssignmentClient({
 
   const handleCategoryChange = (value: string) => {
     setCategoryKey(value);
+    const categoryForUrl = value === ALL_CATEGORIES_VALUE ? "" : value;
     startTransition(() => {
-      router.push(buildUrl({ category: value, page: 1 }));
+      router.push(buildUrl({ category: categoryForUrl, page: 1 }));
     });
   };
 


### PR DESCRIPTION
## Summary
- Radix UIのSelect.Itemは空文字列のvalueを許可しないため、「すべてのカテゴリ」オプションのvalueを空文字列から`"__all__"`に変更
- URLパラメータへの変換時は空文字列に戻す処理を追加し、既存の動作を維持

## Changes
- `ALL_CATEGORIES_VALUE`定数を追加
- カテゴリ選択の初期値とオプションのvalueを`"__all__"`に変更
- `handleCategoryChange`でURLパラメータ用に空文字列に変換

## Test plan
- [x] `npm run typecheck` パス
- [x] `npm run lint` パス
- [x] `npm test` パス
- [ ] `/counterparts/assignment`ページでエラーが発生しないことを確認
- [ ] カテゴリフィルターが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **機能改善**
  * カウンターパート割り当て機能のカテゴリフィルタリングロジックを改善しました。全カテゴリ表示時のURL処理を最適化し、ナビゲーション動作の安定性が向上しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->