### PR TITLE
refactor(admin): サイドバーを3セクション構造に変更

### DIFF
--- a/admin/src/client/components/layout/Sidebar.tsx
+++ b/admin/src/client/components/layout/Sidebar.tsx
@@ -6,6 +6,17 @@ import { usePathname } from "next/navigation";
 import type { UserRole } from "@prisma/client";
 import { Button } from "@/client/components/ui";
 
+type NavItem = {
+  href: string;
+  label: string;
+  adminOnly?: boolean;
+};
+
+type NavSection = {
+  title: string;
+  items: NavItem[];
+};
+
 export default function Sidebar({
   logoutAction,
   userRole,
@@ -22,34 +33,63 @@ export default function Sidebar({
     return pathname.startsWith(path);
   };
 
-  const navItems = [
-    { href: "/user-info", label: "ユーザー情報" },
-    { href: "/political-organizations", label: "政治団体" },
-    { href: "/transactions", label: "取引一覧" },
-    { href: "/balance-snapshots", label: "残高登録" },
-    { href: "/upload-csv", label: "CSVアップロード" },
-    { href: "/export-report", label: "報告書エクスポート" },
-    { href: "/users", label: "ユーザー管理", adminOnly: true },
+  const navSections: NavSection[] = [
+    {
+      title: "基本情報",
+      items: [
+        { href: "/user-info", label: "ユーザー情報" },
+        { href: "/political-organizations", label: "政治団体" },
+        { href: "/users", label: "ユーザー管理", adminOnly: true },
+      ],
+    },
+    {
+      title: "データ取り込み",
+      items: [
+        { href: "/transactions", label: "取引一覧" },
+        { href: "/upload-csv", label: "CSVアップロード" },
+        { href: "/balance-snapshots", label: "残高登録" },
+      ],
+    },
+    {
+      title: "報告書",
+      items: [
+        { href: "/counterparts/master", label: "取引先マスタ" },
+        { href: "/counterparts/assignment", label: "取引先紐付け" },
+        { href: "/export-report", label: "報告書エクスポート" },
+      ],
+    },
   ];
 
   return (
     <aside className="bg-card p-4 flex flex-col h-full">
-      <h2 className="text-muted-foreground text-lg font-medium mb-3 mt-0">管理画面</h2>
-      <nav className="flex flex-col gap-2">
-        {navItems.map(
-          (item) =>
-            (!item.adminOnly || userRole === "admin") && (
-              <Link
-                key={item.href}
-                href={item.href}
-                className={`text-foreground no-underline px-2.5 py-2 rounded-lg transition-colors duration-200 ${
-                  isActive(item.href) ? "bg-secondary" : "hover:bg-secondary"
-                }`}
-              >
-                {item.label}
-              </Link>
-            ),
-        )}
+      <nav className="flex flex-col gap-6">
+        {navSections.map((section) => {
+          const visibleItems = section.items.filter(
+            (item) => !item.adminOnly || userRole === "admin",
+          );
+          if (visibleItems.length === 0) return null;
+
+          return (
+            <div key={section.title}>
+              <h3 className="text-muted-foreground text-xs font-medium uppercase tracking-wider mb-1 px-2.5">
+                {section.title}
+              </h3>
+              <div className="flex flex-col gap-0.5">
+                {visibleItems.map((item) => (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    className={`text-foreground no-underline px-2.5 py-2 rounded-lg transition-colors duration-200 ${
+                      isActive(item.href) ? "bg-secondary" : "hover:bg-secondary"
+                    }`}
+                  >
+                    {item.label}
+                  </Link>
+                ))}
+              </div>
+            </div>
+          );
+        })}
       </nav>
       <div className="mt-auto pt-4">
         <form action={logoutAction}>


### PR DESCRIPTION
## Summary
- サイドバーを「基本情報」「データ取り込み」「報告書」の3セクション構造に変更
- 取引先マスタ・取引先紐付けページをサイドバーに追加
- 近接の原則に基づきセクション間・アイテム間のマージンを調整
- 不要な「管理画面」見出しを削除

## Test plan
- [x] `npm run typecheck` パス
- [x] `npm run lint` パス
- [x] `npm test` パス
- [ ] 管理画面でサイドバーの表示確認
- [ ] 各リンクが正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)