### PR TITLE
fix(admin): counterpart-assignment-rulesのカテゴリキーをPL_CATEGORIESと一致させる

### DIFF
--- a/admin/src/server/contexts/report/domain/models/counterpart-assignment-rules.ts
+++ b/admin/src/server/contexts/report/domain/models/counterpart-assignment-rules.ts
@@ -5,35 +5,55 @@
  * どのトランザクションがCounterpart情報を必要とするかを定義します。
  */
 
+import { PL_CATEGORIES } from "@/shared/utils/category-mapping";
+
 /**
  * Counterpart紐づけが必要な収入カテゴリ
- * - income_loan: 借入金（SYUUSHI07_04）
- * - income_grant_from_hq: 本部・支部交付金（SYUUSHI07_05）
+ * - loans: 借入金（SYUUSHI07_04）
+ * - grants: 本部・支部交付金（SYUUSHI07_05）
+ *
+ * ※ キーは shared/utils/category-mapping.ts の PL_CATEGORIES.key と一致させる
  */
 export const COUNTERPART_REQUIRED_INCOME_CATEGORIES = [
-  "income_loan",
-  "income_grant_from_hq",
+  // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+  PL_CATEGORIES["借入金"].key,
+  // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+  PL_CATEGORIES["本部又は支部から供与された交付金に係る収入"].key,
 ] as const;
 
 /**
  * Counterpart紐づけが必要な支出カテゴリ
  * 経常経費（SYUUSHI07_14）と政治活動費（SYUUSHI07_15）のすべて
+ *
+ * ※ キーは shared/utils/category-mapping.ts の PL_CATEGORIES.key と一致させる
  */
 export const COUNTERPART_REQUIRED_EXPENSE_CATEGORIES = [
   // 経常経費 (SYUUSHI07_14)
-  "expense_utility_costs",
-  "expense_office_supplies",
-  "expense_office_expenses",
+  // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+  PL_CATEGORIES["光熱水費"].key,
+  // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+  PL_CATEGORIES["備品・消耗品費"].key,
+  // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+  PL_CATEGORIES["事務所費"].key,
   // 政治活動費 (SYUUSHI07_15)
-  "expense_organizational_activity",
-  "expense_election_related",
-  "expense_publication",
-  "expense_publicity",
-  "expense_party_event",
-  "expense_other_projects",
-  "expense_research",
-  "expense_donation_grant",
-  "expense_other",
+  // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+  PL_CATEGORIES["組織活動費"].key,
+  // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+  PL_CATEGORIES["選挙関係費"].key,
+  // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+  PL_CATEGORIES["機関紙誌の発行事業費"].key,
+  // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+  PL_CATEGORIES["宣伝事業費"].key,
+  // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+  PL_CATEGORIES["政治資金パーティー開催事業費"].key,
+  // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+  PL_CATEGORIES["その他の事業費"].key,
+  // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+  PL_CATEGORIES["調査研究費"].key,
+  // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+  PL_CATEGORIES["寄附・交付金"].key,
+  // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+  PL_CATEGORIES["その他の経費"].key,
 ] as const;
 
 export type CounterpartRequiredIncomeCategory =

--- a/admin/tests/server/contexts/report/domain/models/counterpart-assignment-rules.test.ts
+++ b/admin/tests/server/contexts/report/domain/models/counterpart-assignment-rules.test.ts
@@ -6,33 +6,48 @@ import {
   COUNTERPART_REQUIRED_INCOME_CATEGORIES,
   COUNTERPART_REQUIRED_EXPENSE_CATEGORIES,
 } from "@/server/contexts/report/domain/models/counterpart-assignment-rules";
+import { PL_CATEGORIES } from "@/shared/utils/category-mapping";
 
 describe("counterpart-assignment-rules", () => {
   describe("COUNTERPART_REQUIRED_INCOME_CATEGORIES", () => {
     it("借入金と交付金のみを含む", () => {
-      expect(COUNTERPART_REQUIRED_INCOME_CATEGORIES).toContain("income_loan");
-      expect(COUNTERPART_REQUIRED_INCOME_CATEGORIES).toContain("income_grant_from_hq");
+      // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+      expect(COUNTERPART_REQUIRED_INCOME_CATEGORIES).toContain(PL_CATEGORIES["借入金"].key);
+      // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+      expect(COUNTERPART_REQUIRED_INCOME_CATEGORIES).toContain(PL_CATEGORIES["本部又は支部から供与された交付金に係る収入"].key);
       expect(COUNTERPART_REQUIRED_INCOME_CATEGORIES).toHaveLength(2);
     });
   });
 
   describe("COUNTERPART_REQUIRED_EXPENSE_CATEGORIES", () => {
     it("経常経費カテゴリを含む", () => {
-      expect(COUNTERPART_REQUIRED_EXPENSE_CATEGORIES).toContain("expense_utility_costs");
-      expect(COUNTERPART_REQUIRED_EXPENSE_CATEGORIES).toContain("expense_office_supplies");
-      expect(COUNTERPART_REQUIRED_EXPENSE_CATEGORIES).toContain("expense_office_expenses");
+      // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+      expect(COUNTERPART_REQUIRED_EXPENSE_CATEGORIES).toContain(PL_CATEGORIES["光熱水費"].key);
+      // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+      expect(COUNTERPART_REQUIRED_EXPENSE_CATEGORIES).toContain(PL_CATEGORIES["備品・消耗品費"].key);
+      // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+      expect(COUNTERPART_REQUIRED_EXPENSE_CATEGORIES).toContain(PL_CATEGORIES["事務所費"].key);
     });
 
     it("政治活動費カテゴリを含む", () => {
-      expect(COUNTERPART_REQUIRED_EXPENSE_CATEGORIES).toContain("expense_organizational_activity");
-      expect(COUNTERPART_REQUIRED_EXPENSE_CATEGORIES).toContain("expense_election_related");
-      expect(COUNTERPART_REQUIRED_EXPENSE_CATEGORIES).toContain("expense_publication");
-      expect(COUNTERPART_REQUIRED_EXPENSE_CATEGORIES).toContain("expense_publicity");
-      expect(COUNTERPART_REQUIRED_EXPENSE_CATEGORIES).toContain("expense_party_event");
-      expect(COUNTERPART_REQUIRED_EXPENSE_CATEGORIES).toContain("expense_other_projects");
-      expect(COUNTERPART_REQUIRED_EXPENSE_CATEGORIES).toContain("expense_research");
-      expect(COUNTERPART_REQUIRED_EXPENSE_CATEGORIES).toContain("expense_donation_grant");
-      expect(COUNTERPART_REQUIRED_EXPENSE_CATEGORIES).toContain("expense_other");
+      // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+      expect(COUNTERPART_REQUIRED_EXPENSE_CATEGORIES).toContain(PL_CATEGORIES["組織活動費"].key);
+      // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+      expect(COUNTERPART_REQUIRED_EXPENSE_CATEGORIES).toContain(PL_CATEGORIES["選挙関係費"].key);
+      // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+      expect(COUNTERPART_REQUIRED_EXPENSE_CATEGORIES).toContain(PL_CATEGORIES["機関紙誌の発行事業費"].key);
+      // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+      expect(COUNTERPART_REQUIRED_EXPENSE_CATEGORIES).toContain(PL_CATEGORIES["宣伝事業費"].key);
+      // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+      expect(COUNTERPART_REQUIRED_EXPENSE_CATEGORIES).toContain(PL_CATEGORIES["政治資金パーティー開催事業費"].key);
+      // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+      expect(COUNTERPART_REQUIRED_EXPENSE_CATEGORIES).toContain(PL_CATEGORIES["その他の事業費"].key);
+      // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+      expect(COUNTERPART_REQUIRED_EXPENSE_CATEGORIES).toContain(PL_CATEGORIES["調査研究費"].key);
+      // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+      expect(COUNTERPART_REQUIRED_EXPENSE_CATEGORIES).toContain(PL_CATEGORIES["寄附・交付金"].key);
+      // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+      expect(COUNTERPART_REQUIRED_EXPENSE_CATEGORIES).toContain(PL_CATEGORIES["その他の経費"].key);
     });
 
     it("12カテゴリを含む", () => {
@@ -49,21 +64,33 @@ describe("counterpart-assignment-rules", () => {
   describe("isCounterpartRequired", () => {
     describe("支出取引", () => {
       it("経常経費カテゴリでtrue", () => {
-        expect(isCounterpartRequired("expense", "expense_utility_costs")).toBe(true);
-        expect(isCounterpartRequired("expense", "expense_office_supplies")).toBe(true);
-        expect(isCounterpartRequired("expense", "expense_office_expenses")).toBe(true);
+        // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+        expect(isCounterpartRequired("expense", PL_CATEGORIES["光熱水費"].key)).toBe(true);
+        // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+        expect(isCounterpartRequired("expense", PL_CATEGORIES["備品・消耗品費"].key)).toBe(true);
+        // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+        expect(isCounterpartRequired("expense", PL_CATEGORIES["事務所費"].key)).toBe(true);
       });
 
       it("政治活動費カテゴリでtrue", () => {
-        expect(isCounterpartRequired("expense", "expense_organizational_activity")).toBe(true);
-        expect(isCounterpartRequired("expense", "expense_election_related")).toBe(true);
-        expect(isCounterpartRequired("expense", "expense_publication")).toBe(true);
-        expect(isCounterpartRequired("expense", "expense_publicity")).toBe(true);
-        expect(isCounterpartRequired("expense", "expense_party_event")).toBe(true);
-        expect(isCounterpartRequired("expense", "expense_other_projects")).toBe(true);
-        expect(isCounterpartRequired("expense", "expense_research")).toBe(true);
-        expect(isCounterpartRequired("expense", "expense_donation_grant")).toBe(true);
-        expect(isCounterpartRequired("expense", "expense_other")).toBe(true);
+        // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+        expect(isCounterpartRequired("expense", PL_CATEGORIES["組織活動費"].key)).toBe(true);
+        // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+        expect(isCounterpartRequired("expense", PL_CATEGORIES["選挙関係費"].key)).toBe(true);
+        // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+        expect(isCounterpartRequired("expense", PL_CATEGORIES["機関紙誌の発行事業費"].key)).toBe(true);
+        // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+        expect(isCounterpartRequired("expense", PL_CATEGORIES["宣伝事業費"].key)).toBe(true);
+        // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+        expect(isCounterpartRequired("expense", PL_CATEGORIES["政治資金パーティー開催事業費"].key)).toBe(true);
+        // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+        expect(isCounterpartRequired("expense", PL_CATEGORIES["その他の事業費"].key)).toBe(true);
+        // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+        expect(isCounterpartRequired("expense", PL_CATEGORIES["調査研究費"].key)).toBe(true);
+        // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+        expect(isCounterpartRequired("expense", PL_CATEGORIES["寄附・交付金"].key)).toBe(true);
+        // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+        expect(isCounterpartRequired("expense", PL_CATEGORIES["その他の経費"].key)).toBe(true);
       });
 
       it("未知のカテゴリでfalse", () => {
@@ -73,23 +100,28 @@ describe("counterpart-assignment-rules", () => {
 
     describe("収入取引", () => {
       it("借入金でtrue", () => {
-        expect(isCounterpartRequired("income", "income_loan")).toBe(true);
+        // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+        expect(isCounterpartRequired("income", PL_CATEGORIES["借入金"].key)).toBe(true);
       });
 
       it("交付金でtrue", () => {
-        expect(isCounterpartRequired("income", "income_grant_from_hq")).toBe(true);
+        // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+        expect(isCounterpartRequired("income", PL_CATEGORIES["本部又は支部から供与された交付金に係る収入"].key)).toBe(true);
       });
 
       it("個人からの寄附でfalse（寄附は対象外）", () => {
-        expect(isCounterpartRequired("income", "income_donation_individual")).toBe(false);
+        // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+        expect(isCounterpartRequired("income", PL_CATEGORIES["個人からの寄附"].key)).toBe(false);
       });
 
       it("その他の収入でfalse", () => {
-        expect(isCounterpartRequired("income", "income_other")).toBe(false);
+        // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+        expect(isCounterpartRequired("income", PL_CATEGORIES["その他の収入"].key)).toBe(false);
       });
 
       it("事業収入でfalse", () => {
-        expect(isCounterpartRequired("income", "income_business")).toBe(false);
+        // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+        expect(isCounterpartRequired("income", PL_CATEGORIES["機関紙誌の発行その他の事業による収入"].key)).toBe(false);
       });
     });
   });
@@ -114,32 +146,43 @@ describe("counterpart-assignment-rules", () => {
 
   describe("requiresCounterpartDetail", () => {
     it("対象カテゴリかつ閾値以上でtrue", () => {
-      expect(requiresCounterpartDetail("expense", "expense_office_expenses", 150_000)).toBe(true);
-      expect(requiresCounterpartDetail("expense", "expense_organizational_activity", 100_000)).toBe(
+      // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+      expect(requiresCounterpartDetail("expense", PL_CATEGORIES["事務所費"].key, 150_000)).toBe(true);
+      // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+      expect(requiresCounterpartDetail("expense", PL_CATEGORIES["組織活動費"].key, 100_000)).toBe(
         true,
       );
-      expect(requiresCounterpartDetail("income", "income_loan", 200_000)).toBe(true);
-      expect(requiresCounterpartDetail("income", "income_grant_from_hq", 100_000)).toBe(true);
+      // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+      expect(requiresCounterpartDetail("income", PL_CATEGORIES["借入金"].key, 200_000)).toBe(true);
+      // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+      expect(requiresCounterpartDetail("income", PL_CATEGORIES["本部又は支部から供与された交付金に係る収入"].key, 100_000)).toBe(true);
     });
 
     it("対象カテゴリでも閾値未満でfalse", () => {
-      expect(requiresCounterpartDetail("expense", "expense_office_expenses", 50_000)).toBe(false);
-      expect(requiresCounterpartDetail("expense", "expense_organizational_activity", 99_999)).toBe(
+      // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+      expect(requiresCounterpartDetail("expense", PL_CATEGORIES["事務所費"].key, 50_000)).toBe(false);
+      // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+      expect(requiresCounterpartDetail("expense", PL_CATEGORIES["組織活動費"].key, 99_999)).toBe(
         false,
       );
-      expect(requiresCounterpartDetail("income", "income_loan", 0)).toBe(false);
+      // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+      expect(requiresCounterpartDetail("income", PL_CATEGORIES["借入金"].key, 0)).toBe(false);
     });
 
     it("閾値以上でも非対象カテゴリでfalse", () => {
-      expect(requiresCounterpartDetail("income", "income_donation_individual", 150_000)).toBe(
+      // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+      expect(requiresCounterpartDetail("income", PL_CATEGORIES["個人からの寄附"].key, 150_000)).toBe(
         false,
       );
-      expect(requiresCounterpartDetail("income", "income_other", 200_000)).toBe(false);
-      expect(requiresCounterpartDetail("income", "income_business", 1_000_000)).toBe(false);
+      // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+      expect(requiresCounterpartDetail("income", PL_CATEGORIES["その他の収入"].key, 200_000)).toBe(false);
+      // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+      expect(requiresCounterpartDetail("income", PL_CATEGORIES["機関紙誌の発行その他の事業による収入"].key, 1_000_000)).toBe(false);
     });
 
     it("非対象カテゴリかつ閾値未満でfalse", () => {
-      expect(requiresCounterpartDetail("income", "income_donation_individual", 50_000)).toBe(false);
+      // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
+      expect(requiresCounterpartDetail("income", PL_CATEGORIES["個人からの寄附"].key, 50_000)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary
- 取引先紐付け管理画面（`/counterparts/assignment`）で結果が0件になる問題を修正
- `counterpart-assignment-rules.ts`で定義していたカテゴリキーがDBに保存されている`categoryKey`（`category-mapping.ts`由来）と一致していなかった
- Single Source of Truthを維持するため、`PL_CATEGORIES`を直接参照するように修正

## Changes
- `COUNTERPART_REQUIRED_INCOME_CATEGORIES`と`COUNTERPART_REQUIRED_EXPENSE_CATEGORIES`を`PL_CATEGORIES`経由で定義
- テストも同様に`PL_CATEGORIES`を参照するように更新

## Test plan
- [x] `npm run typecheck` パス
- [x] `npm run lint` パス
- [x] `npm test` パス（219テスト）
- [ ] `/counterparts/assignment`ページでトランザクションが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * カテゴリー定義の参照方式を統一し、コードの保守性を向上させました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->