### PR TITLE
refactor(admin): フィルターUIを別コンポーネントに切り出し、取引先必須フィルターを追加

### DIFF
--- a/admin/src/app/(auth)/counterparts/assignment/page.tsx
+++ b/admin/src/app/(auth)/counterparts/assignment/page.tsx
@@ -32,6 +32,7 @@ interface CounterpartAssignmentPageProps {
     orgId?: string;
     year?: string;
     unassigned?: string;
+    counterpartRequired?: string;
     category?: string;
     search?: string;
     sort?: string;
@@ -62,6 +63,7 @@ export default async function CounterpartAssignmentPage({
           politicalOrganizationId: "",
           financialYear: new Date().getFullYear(),
           unassignedOnly: false,
+          counterpartRequiredOnly: false,
           categoryKey: "",
           searchQuery: "",
           sortField: "transactionDate",
@@ -76,6 +78,7 @@ export default async function CounterpartAssignmentPage({
   const politicalOrganizationId = params.orgId || organizations[0].id;
   const financialYear = params.year ? Number.parseInt(params.year, 10) : new Date().getFullYear();
   const unassignedOnly = params.unassigned === "true";
+  const counterpartRequiredOnly = params.counterpartRequired === "true";
   const categoryKey = params.category || "";
   const searchQuery = params.search || "";
   const sortField =
@@ -89,6 +92,7 @@ export default async function CounterpartAssignmentPage({
     politicalOrganizationId,
     financialYear,
     unassignedOnly,
+    requiresCounterpartOnly: counterpartRequiredOnly,
     categoryKey: categoryKey || undefined,
     searchQuery: searchQuery || undefined,
     page,
@@ -108,6 +112,7 @@ export default async function CounterpartAssignmentPage({
         politicalOrganizationId,
         financialYear,
         unassignedOnly,
+        counterpartRequiredOnly,
         categoryKey,
         searchQuery,
         sortField,

--- a/admin/src/client/components/counterpart-assignment/CounterpartAssignmentFilters.tsx
+++ b/admin/src/client/components/counterpart-assignment/CounterpartAssignmentFilters.tsx
@@ -1,0 +1,101 @@
+"use client";
+import "client-only";
+
+import { useState } from "react";
+import {
+  Card,
+  Input,
+  Button,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/client/components/ui";
+
+export interface CounterpartAssignmentFilterValues {
+  categoryKey: string;
+  searchQuery: string;
+  unassignedOnly: boolean;
+  counterpartRequiredOnly: boolean;
+}
+
+interface CounterpartAssignmentFiltersProps {
+  values: CounterpartAssignmentFilterValues;
+  categoryOptions: { value: string; label: string }[];
+  onChange: (values: Partial<CounterpartAssignmentFilterValues>) => void;
+}
+
+export function CounterpartAssignmentFilters({
+  values,
+  categoryOptions,
+  onChange,
+}: CounterpartAssignmentFiltersProps) {
+  const [localSearchQuery, setLocalSearchQuery] = useState(values.searchQuery);
+
+  const handleSearchSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onChange({ searchQuery: localSearchQuery });
+  };
+
+  return (
+    <Card className="p-4 gap-2">
+      <h2 className="text-lg font-semibold text-white">絞り込み</h2>
+      <div className="flex flex-col md:flex-row md:items-end gap-4">
+        <div className="w-fit space-y-2">
+          <Label>カテゴリ</Label>
+          <Select
+            value={values.categoryKey}
+            onValueChange={(value) => onChange({ categoryKey: value })}
+          >
+            <SelectTrigger className="w-40">
+              <SelectValue placeholder="選択してください" />
+            </SelectTrigger>
+            <SelectContent>
+              {categoryOptions.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <form onSubmit={handleSearchSubmit} className="w-fit space-y-2">
+          <Label htmlFor="search-query">検索</Label>
+          <div className="flex gap-2">
+            <Input
+              id="search-query"
+              type="text"
+              value={localSearchQuery}
+              onChange={(e) => setLocalSearchQuery(e.target.value)}
+              placeholder="摘要、メモで検索..."
+              className="w-48"
+            />
+            <Button type="submit" variant="secondary">
+              検索
+            </Button>
+          </div>
+        </form>
+        <label className="flex items-center gap-2 cursor-pointer h-10">
+          <input
+            type="checkbox"
+            checked={values.unassignedOnly}
+            onChange={(e) => onChange({ unassignedOnly: e.target.checked })}
+            className="w-4 h-4 rounded border-border bg-input text-primary focus:ring-ring focus:ring-offset-0"
+          />
+          <span className="text-white">未紐付けのみ表示</span>
+        </label>
+        <label className="flex items-center gap-2 cursor-pointer h-10">
+          <input
+            type="checkbox"
+            checked={values.counterpartRequiredOnly}
+            onChange={(e) => onChange({ counterpartRequiredOnly: e.target.checked })}
+            className="w-4 h-4 rounded border-border bg-input text-primary focus:ring-ring focus:ring-offset-0"
+          />
+          <span className="text-white">取引先必須のみ表示</span>
+        </label>
+      </div>
+    </Card>
+  );
+}

--- a/admin/src/client/components/counterpart-assignment/TransactionWithCounterpartTable.tsx
+++ b/admin/src/client/components/counterpart-assignment/TransactionWithCounterpartTable.tsx
@@ -112,7 +112,7 @@ export function TransactionWithCounterpartTable({
               <span>{formatAmount(info.getValue())}</span>
               {transaction.requiresCounterpart && (
                 <span className="text-xs bg-amber-500/20 text-amber-400 px-1.5 py-0.5 rounded">
-                  明細必須
+                  取引先必須
                 </span>
               )}
             </div>
@@ -186,14 +186,14 @@ export function TransactionWithCounterpartTable({
 
   return (
     <div className="overflow-x-auto">
-      <table className="w-full">
+      <table className="w-full text-sm">
         <thead>
           {table.getHeaderGroups().map((headerGroup) => (
             <tr key={headerGroup.id} className="border-b border-border">
               {headerGroup.headers.map((header) => (
                 <th
                   key={header.id}
-                  className="text-left py-3 px-4 text-muted-foreground font-medium"
+                  className="text-left py-2 px-3 text-muted-foreground font-medium"
                 >
                   {header.isPlaceholder
                     ? null
@@ -210,7 +210,7 @@ export function TransactionWithCounterpartTable({
               className="border-b border-border hover:bg-secondary/30 transition-colors"
             >
               {row.getVisibleCells().map((cell) => (
-                <td key={cell.id} className="py-3 px-4 text-white">
+                <td key={cell.id} className="py-2 px-3 text-white">
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}
                 </td>
               ))}


### PR DESCRIPTION
## Summary
- 取引先紐付け管理ページのフィルターUIを `CounterpartAssignmentFilters` コンポーネントに切り出し
- 複数のchangeハンドラーを統一した `onChange` に一本化してシンプル化
- 「取引先必須のみ表示」フィルターを新規追加
- テーブル行のフォントサイズとpaddingを縮小してコンパクト化
- 「明細必須」ラベルを「取引先必須」に変更

## Test plan
- [x] `npm run typecheck` パス
- [x] `npm run lint` パス
- [x] `npm test` パス
- [ ] 取引先紐付けページでフィルター機能が正常に動作すること
- [ ] 「取引先必須のみ表示」チェックボックスでフィルタリングできること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 取引先必須フィルター機能を追加しました。

* **UI改善**
  * フィルター機能のUIを整理し、より直感的に使用できるようにしました。
  * テーブルのテキスト表記を更新し、スペーシングを最適化しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->