### PR TITLE
feat(admin): フィルターUIをToggleコンポーネントに変更し、取引先必須フィルターにツールチップを追加

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -20,6 +20,8 @@
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-toggle": "^1.1.10",
+    "@radix-ui/react-tooltip": "^1.2.8",
     "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.55.0",
     "@tanstack/react-table": "^8.21.3",

--- a/admin/src/app/(auth)/counterparts/assignment/page.tsx
+++ b/admin/src/app/(auth)/counterparts/assignment/page.tsx
@@ -77,8 +77,8 @@ export default async function CounterpartAssignmentPage({
 
   const politicalOrganizationId = params.orgId || organizations[0].id;
   const financialYear = params.year ? Number.parseInt(params.year, 10) : new Date().getFullYear();
-  const unassignedOnly = params.unassigned === "true";
-  const counterpartRequiredOnly = params.counterpartRequired === "true";
+  const unassignedOnly = params.unassigned !== "false";
+  const counterpartRequiredOnly = params.counterpartRequired !== "false";
   const categoryKey = params.category || "";
   const searchQuery = params.search || "";
   const sortField =

--- a/admin/src/client/components/counterpart-assignment/CounterpartAssignmentClient.tsx
+++ b/admin/src/client/components/counterpart-assignment/CounterpartAssignmentClient.tsx
@@ -101,12 +101,11 @@ export function CounterpartAssignmentClient({
     const searchParams = new URLSearchParams();
     searchParams.set("orgId", params.orgId ?? selectedOrganizationId);
     searchParams.set("year", String(params.year ?? financialYear));
-    if (params.unassigned ?? unassignedOnly) {
-      searchParams.set("unassigned", "true");
-    }
-    if (params.counterpartRequired ?? counterpartRequiredOnly) {
-      searchParams.set("counterpartRequired", "true");
-    }
+    searchParams.set("unassigned", String(params.unassigned ?? unassignedOnly));
+    searchParams.set(
+      "counterpartRequired",
+      String(params.counterpartRequired ?? counterpartRequiredOnly),
+    );
     if (params.category ?? categoryKey) {
       searchParams.set("category", params.category ?? categoryKey);
     }

--- a/admin/src/client/components/counterpart-assignment/CounterpartAssignmentFilters.tsx
+++ b/admin/src/client/components/counterpart-assignment/CounterpartAssignmentFilters.tsx
@@ -2,6 +2,7 @@
 import "client-only";
 
 import { useState } from "react";
+import { CircleHelp, Square, SquareCheck } from "lucide-react";
 import {
   Card,
   Input,
@@ -12,6 +13,10 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  Toggle,
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
 } from "@/client/components/ui";
 
 export interface CounterpartAssignmentFilterValues {
@@ -40,7 +45,7 @@ export function CounterpartAssignmentFilters({
   };
 
   return (
-    <Card className="p-4 gap-2">
+    <Card className="p-4 flex flex-col gap-3">
       <h2 className="text-lg font-semibold text-white">絞り込み</h2>
       <div className="flex flex-col md:flex-row md:items-end gap-4">
         <div className="w-fit space-y-2">
@@ -77,24 +82,66 @@ export function CounterpartAssignmentFilters({
             </Button>
           </div>
         </form>
-        <label className="flex items-center gap-2 cursor-pointer h-10">
-          <input
-            type="checkbox"
-            checked={values.unassignedOnly}
-            onChange={(e) => onChange({ unassignedOnly: e.target.checked })}
-            className="w-4 h-4 rounded border-border bg-input text-primary focus:ring-ring focus:ring-offset-0"
-          />
-          <span className="text-white">未紐付けのみ表示</span>
-        </label>
-        <label className="flex items-center gap-2 cursor-pointer h-10">
-          <input
-            type="checkbox"
-            checked={values.counterpartRequiredOnly}
-            onChange={(e) => onChange({ counterpartRequiredOnly: e.target.checked })}
-            className="w-4 h-4 rounded border-border bg-input text-primary focus:ring-ring focus:ring-offset-0"
-          />
-          <span className="text-white">取引先必須のみ表示</span>
-        </label>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <Toggle
+          variant="outline"
+          pressed={values.unassignedOnly}
+          onPressedChange={(pressed) => onChange({ unassignedOnly: pressed })}
+        >
+          {values.unassignedOnly ? (
+            <SquareCheck className="size-4" />
+          ) : (
+            <Square className="size-4" />
+          )}
+          未紐付けのみ表示
+        </Toggle>
+        <Toggle
+          variant="outline"
+          pressed={values.counterpartRequiredOnly}
+          onPressedChange={(pressed) => onChange({ counterpartRequiredOnly: pressed })}
+        >
+          {values.counterpartRequiredOnly ? (
+            <SquareCheck className="size-4" />
+          ) : (
+            <Square className="size-4" />
+          )}
+          取引先必須のみ表示
+          <Tooltip>
+            <TooltipTrigger asChild onClick={(e) => e.stopPropagation()}>
+              <CircleHelp className="size-4 hover:text-foreground cursor-help" />
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="max-w-sm">
+              <div className="space-y-2 text-left">
+                <p className="font-semibold">取引先必須のカテゴリ</p>
+                <p>
+                  政治資金規正法により、以下のカテゴリでは一定金額以上の取引について支払先の氏名・住所を明細に記載する必要があります。
+                </p>
+                <div className="space-y-1">
+                  <p className="font-medium">【収入】全額記載必須</p>
+                  <ul className="list-disc list-inside text-xs">
+                    <li>借入金</li>
+                    <li>本部・支部交付金</li>
+                  </ul>
+                </div>
+                <div className="space-y-1">
+                  <p className="font-medium">【経常経費】10万円以上</p>
+                  <ul className="list-disc list-inside text-xs">
+                    <li>光熱水費</li>
+                    <li>備品・消耗品費</li>
+                    <li>事務所費</li>
+                  </ul>
+                </div>
+                <div className="space-y-1">
+                  <p className="font-medium">【政治活動費】5万円以上</p>
+                  <ul className="list-disc list-inside text-xs">
+                    <li>組織活動費、選挙関係費、機関紙誌の発行事業費 等</li>
+                  </ul>
+                </div>
+              </div>
+            </TooltipContent>
+          </Tooltip>
+        </Toggle>
       </div>
     </Card>
   );

--- a/admin/src/client/components/ui/index.ts
+++ b/admin/src/client/components/ui/index.ts
@@ -56,3 +56,10 @@ export {
 } from "@/client/components/ui/form";
 export { Textarea } from "@/client/components/ui/textarea";
 export { Checkbox } from "@/client/components/ui/checkbox";
+export {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipProvider,
+} from "@/client/components/ui/tooltip";
+export { Toggle, toggleVariants } from "@/client/components/ui/toggle";

--- a/admin/src/client/components/ui/toggle.tsx
+++ b/admin/src/client/components/ui/toggle.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import type * as React from "react";
+import * as TogglePrimitive from "@radix-ui/react-toggle";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/client/lib/index";
+
+const toggleVariants = cva(
+  "inline-flex w-fit shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium cursor-pointer hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline:
+          "border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground",
+      },
+      size: {
+        default: "h-9 px-2 min-w-9",
+        sm: "h-8 px-1.5 min-w-8",
+        lg: "h-10 px-2.5 min-w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+function Toggle({
+  className,
+  variant,
+  size,
+  ...props
+}: React.ComponentProps<typeof TogglePrimitive.Root> & VariantProps<typeof toggleVariants>) {
+  return (
+    <TogglePrimitive.Root
+      data-slot="toggle"
+      className={cn(toggleVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+export { Toggle, toggleVariants };

--- a/admin/src/client/components/ui/tooltip.tsx
+++ b/admin/src/client/components/ui/tooltip.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import type * as React from "react";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+
+import { cn } from "@/client/lib/index";
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  );
+}
+
+function Tooltip({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return (
+    <TooltipProvider>
+      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+    </TooltipProvider>
+  );
+}
+
+function TooltipTrigger({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  );
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,12 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.1.13)(react@19.1.2)
+      '@radix-ui/react-toggle':
+        specifier: ^1.1.10
+        version: 1.1.10(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.2.8
+        version: 1.2.8(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
       '@supabase/ssr':
         specifier: ^0.6.1
         version: 0.6.1(@supabase/supabase-js@2.58.0)
@@ -1091,6 +1097,32 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-toggle@1.1.10':
+    resolution: {integrity: sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tooltip@1.2.8':
+    resolution: {integrity: sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-use-callback-ref@1.1.1':
@@ -4125,6 +4157,37 @@ snapshots:
       react: 19.1.2
     optionalDependencies:
       '@types/react': 19.1.13
+
+  '@radix-ui/react-toggle@1.1.10(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.13)(react@19.1.2)
+      react: 19.1.2
+      react-dom: 19.1.2(react@19.1.2)
+    optionalDependencies:
+      '@types/react': 19.1.13
+      '@types/react-dom': 19.1.9(@types/react@19.1.13)
+
+  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.13)(react@19.1.2)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.13)(react@19.1.2)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.13)(react@19.1.2)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.13)(react@19.1.2)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.13)(react@19.1.2)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
+      react: 19.1.2
+      react-dom: 19.1.2(react@19.1.2)
+    optionalDependencies:
+      '@types/react': 19.1.13
+      '@types/react-dom': 19.1.9(@types/react@19.1.13)
 
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.1.13)(react@19.1.2)':
     dependencies:


### PR DESCRIPTION
## Summary
- チェックボックスをshadcn Toggleコンポーネントに変更してUIを改善
- 取引先必須フィルターに政治資金規正法の説明ツールチップを追加
- Toggle, Tooltipコンポーネントをshadcnパターンで追加
- フィルターのデフォルト値を「有効」に変更（URLパラメータ未指定時）

## Test plan
- [x] `npm run typecheck` がパス
- [x] `npm run lint` がパス  
- [x] `npm test` がパス
- [ ] 取引先紐付け画面でToggleフィルターが正常に動作することを確認
- [ ] 取引先必須フィルターのツールチップが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * カウンターパート割り当てフィルターのUIをトグルコンポーネントに更新
  * フィルター項目にツールチップでの説明情報を追加

* **変更**
  * フィルター条件のデフォルト動作を変更（パラメータ省略時の処理を改善）

* **Chores**
  * UIコンポーネント用ライブラリを依存関係に追加

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->