### PR TITLE
feat(admin): 取引先割当画面のUI改善

### DIFF
--- a/admin/src/client/components/counterpart-assignment/CounterpartCombobox.tsx
+++ b/admin/src/client/components/counterpart-assignment/CounterpartCombobox.tsx
@@ -208,7 +208,7 @@ export function CounterpartCombobox({
       )}
 
       {isOpen && (
-        <div className="absolute top-full left-0 mt-1 w-80 bg-card border border-border rounded-lg shadow-lg z-50 max-h-96 overflow-hidden">
+        <div className="absolute top-full right-0 mt-1 w-80 bg-card border border-border rounded-lg shadow-lg z-50 max-h-96 overflow-hidden">
           {isCreateMode ? (
             <form onSubmit={handleCreateAndAssign} className="p-3 space-y-3">
               <div className="flex justify-between items-center">


### PR DESCRIPTION
## Summary
- フィルターUIをToggleコンポーネントに変更し、取引先必須フィルターにツールチップを追加
- テーブルUIの改善（カテゴリに色付けバッジ、詳細区分列追加、レイアウト調整）
- フィルターのデフォルト値をON（true）に変更

## Changes
- `CounterpartAssignmentFilters`: チェックボックスからToggleコンポーネントに変更、取引先必須フィルターに説明用ツールチップを追加
- `TransactionWithCounterpartTable`: カテゴリ列に背景色バッジ追加、詳細区分列追加、セルの横パディング拡大
- `CounterpartCombobox`: ドロップダウンを右寄せに変更
- shadcn UIコンポーネント追加（Toggle, Tooltip）

## Test plan
- [x] `npm run typecheck` パス
- [x] `npm run lint` パス
- [x] `npm test` パス
- [ ] 取引先割当画面でフィルターが正常に動作することを確認
- [ ] ツールチップが表示されることを確認
- [ ] テーブルのレイアウトが正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)