### PR TITLE
feat(counterpart): 取引先の住所を任意項目に変更

### DIFF
--- a/admin/src/client/components/counterpart-assignment/BulkAssignModal.tsx
+++ b/admin/src/client/components/counterpart-assignment/BulkAssignModal.tsx
@@ -43,7 +43,9 @@ export function BulkAssignModal({
   const filteredCounterparts = allCounterparts.filter((cp) => {
     if (!searchQuery.trim()) return true;
     const query = searchQuery.toLowerCase();
-    return cp.name.toLowerCase().includes(query) || cp.address.toLowerCase().includes(query);
+    return (
+      cp.name.toLowerCase().includes(query) || (cp.address?.toLowerCase().includes(query) ?? false)
+    );
   });
 
   const handleSubmit = async () => {

--- a/admin/src/client/components/counterpart-assignment/CounterpartCombobox.tsx
+++ b/admin/src/client/components/counterpart-assignment/CounterpartCombobox.tsx
@@ -20,7 +20,7 @@ interface CounterpartComboboxProps {
   currentCounterpart: {
     id: string;
     name: string;
-    address: string;
+    address: string | null;
   } | null;
   allCounterparts: Counterpart[];
   onAssigned?: () => void;
@@ -48,14 +48,16 @@ export function CounterpartCombobox({
 
   const [optimisticCounterpart, setOptimisticCounterpart] = useOptimistic(
     currentCounterpart,
-    (_state, newCounterpart: { id: string; name: string; address: string } | null) =>
+    (_state, newCounterpart: { id: string; name: string; address: string | null } | null) =>
       newCounterpart,
   );
 
   const filteredCounterparts = allCounterparts.filter((cp) => {
     if (!searchQuery.trim()) return true;
     const query = searchQuery.toLowerCase();
-    return cp.name.toLowerCase().includes(query) || cp.address.toLowerCase().includes(query);
+    return (
+      cp.name.toLowerCase().includes(query) || (cp.address?.toLowerCase().includes(query) ?? false)
+    );
   });
 
   const suggestedIds = new Set(suggestions.map((s) => s.counterpart.id));

--- a/admin/src/client/components/counterparts/CreateCounterpartDialog.tsx
+++ b/admin/src/client/components/counterparts/CreateCounterpartDialog.tsx
@@ -20,7 +20,7 @@ export function CreateCounterpartDialog({ onClose, onCreate }: CreateCounterpart
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const isFormValid = name.trim() !== "" && address.trim() !== "";
+  const isFormValid = name.trim() !== "";
 
   const handleClose = useCallback(() => {
     if (!isLoading) {
@@ -48,7 +48,7 @@ export function CreateCounterpartDialog({ onClose, onCreate }: CreateCounterpart
 
       const result = await createCounterpartAction({
         name: name.trim(),
-        address: address.trim(),
+        address: address.trim() || null,
       });
 
       if (result.success) {
@@ -92,18 +92,15 @@ export function CreateCounterpartDialog({ onClose, onCreate }: CreateCounterpart
           </div>
 
           <div>
-            <Label htmlFor="create-address">
-              住所 <span className="text-red-500">*</span>
-            </Label>
+            <Label htmlFor="create-address">住所</Label>
             <Input
               type="text"
               id="create-address"
               value={address}
               onChange={(e) => setAddress(e.target.value)}
               maxLength={MAX_ADDRESS_LENGTH}
-              placeholder="住所を入力"
+              placeholder="住所を入力（任意）"
               disabled={isLoading}
-              required
             />
           </div>
 

--- a/admin/src/client/components/counterparts/EditCounterpartDialog.tsx
+++ b/admin/src/client/components/counterparts/EditCounterpartDialog.tsx
@@ -22,13 +22,13 @@ export function EditCounterpartDialog({
   onUpdate,
 }: EditCounterpartDialogProps) {
   const [name, setName] = useState(counterpart.name);
-  const [address, setAddress] = useState(counterpart.address);
+  const [address, setAddress] = useState(counterpart.address ?? "");
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!name.trim() || !address.trim()) return;
+    if (!name.trim()) return;
 
     try {
       setIsLoading(true);
@@ -36,7 +36,7 @@ export function EditCounterpartDialog({
 
       const result = await updateCounterpartAction(counterpart.id, {
         name: name.trim(),
-        address: address.trim(),
+        address: address.trim() || null,
       });
 
       if (result.success) {
@@ -80,18 +80,15 @@ export function EditCounterpartDialog({
           </div>
 
           <div>
-            <Label htmlFor="edit-address">
-              住所 <span className="text-red-500">*</span>
-            </Label>
+            <Label htmlFor="edit-address">住所</Label>
             <Input
               type="text"
               id="edit-address"
               value={address}
               onChange={(e) => setAddress(e.target.value)}
               maxLength={MAX_ADDRESS_LENGTH}
-              placeholder="住所を入力"
+              placeholder="住所を入力（任意）"
               disabled={isLoading}
-              required
             />
           </div>
 
@@ -103,7 +100,7 @@ export function EditCounterpartDialog({
             <Button type="button" variant="secondary" onClick={onClose} disabled={isLoading}>
               キャンセル
             </Button>
-            <Button type="submit" disabled={isLoading || !name.trim() || !address.trim()}>
+            <Button type="submit" disabled={isLoading || !name.trim()}>
               {isLoading ? "保存中..." : "保存"}
             </Button>
           </div>

--- a/admin/src/server/contexts/report/application/usecases/manage-counterpart-usecase.ts
+++ b/admin/src/server/contexts/report/application/usecases/manage-counterpart-usecase.ts
@@ -60,9 +60,10 @@ export class CreateCounterpartUsecase {
   constructor(private repository: ICounterpartRepository) {}
 
   async execute(input: CreateCounterpartInput): Promise<CreateCounterpartResult> {
+    const trimmedAddress = input.address?.trim() || null;
     const normalizedInput = {
       name: input.name.trim(),
-      address: input.address.trim(),
+      address: trimmedAddress,
     };
 
     const validationErrors = validateCounterpartInput(normalizedInput);
@@ -102,7 +103,9 @@ export class UpdateCounterpartUsecase {
     }
 
     const newName = input.name?.trim() ?? existing.name;
-    const newAddress = input.address?.trim() ?? existing.address;
+    // undefinedなら既存値を維持、それ以外（nullや文字列）はtrim後に空文字ならnullに正規化
+    const newAddress =
+      input.address === undefined ? existing.address : input.address?.trim() || null;
 
     const validationErrors = validateCounterpartInput({
       name: newName,

--- a/admin/src/server/contexts/report/domain/models/counterpart.ts
+++ b/admin/src/server/contexts/report/domain/models/counterpart.ts
@@ -1,7 +1,7 @@
 export interface Counterpart {
   id: string;
   name: string;
-  address: string;
+  address: string | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -12,12 +12,12 @@ export interface CounterpartWithUsage extends Counterpart {
 
 export interface CreateCounterpartInput {
   name: string;
-  address: string;
+  address: string | null;
 }
 
 export interface UpdateCounterpartInput {
   name?: string;
-  address?: string;
+  address?: string | null;
 }
 
 export const MAX_NAME_LENGTH = 120;
@@ -34,9 +34,7 @@ export function validateCounterpartInput(input: CreateCounterpartInput): string[
     errors.push(`名前は${MAX_NAME_LENGTH}文字以内で入力してください`);
   }
 
-  if (trimmedAddress.length === 0) {
-    errors.push("住所は必須です");
-  } else if (trimmedAddress.length > MAX_ADDRESS_LENGTH) {
+  if (trimmedAddress.length > MAX_ADDRESS_LENGTH) {
     errors.push(`住所は${MAX_ADDRESS_LENGTH}文字以内で入力してください`);
   }
 

--- a/admin/src/server/contexts/report/domain/models/transaction-with-counterpart.ts
+++ b/admin/src/server/contexts/report/domain/models/transaction-with-counterpart.ts
@@ -16,7 +16,7 @@ export interface TransactionWithCounterpart {
   counterpart: {
     id: string;
     name: string;
-    address: string;
+    address: string | null;
   } | null;
   /** 取引先情報の記載が必要（閾値以上かつ対象カテゴリ）かどうか。閾値は経常経費10万円、政治活動費5万円 */
   requiresCounterpart: boolean;

--- a/admin/src/server/contexts/report/domain/repositories/counterpart-repository.interface.ts
+++ b/admin/src/server/contexts/report/domain/repositories/counterpart-repository.interface.ts
@@ -17,7 +17,7 @@ export interface CounterpartWithUsageAndLastUsed extends CounterpartWithUsage {
 
 export interface ICounterpartRepository {
   findById(id: string): Promise<Counterpart | null>;
-  findByNameAndAddress(name: string, address: string): Promise<Counterpart | null>;
+  findByNameAndAddress(name: string, address: string | null): Promise<Counterpart | null>;
   findAll(filters?: CounterpartFilters): Promise<Counterpart[]>;
   findAllWithUsage(filters?: CounterpartFilters): Promise<CounterpartWithUsage[]>;
   create(data: CreateCounterpartInput): Promise<Counterpart>;

--- a/admin/src/server/contexts/report/infrastructure/repositories/prisma-counterpart.repository.ts
+++ b/admin/src/server/contexts/report/infrastructure/repositories/prisma-counterpart.repository.ts
@@ -54,13 +54,11 @@ export class PrismaCounterpartRepository implements ICounterpartRepository {
     return this.mapToCounterpart(counterpart);
   }
 
-  async findByNameAndAddress(name: string, address: string): Promise<Counterpart | null> {
-    const counterpart = await this.prisma.counterpart.findUnique({
+  async findByNameAndAddress(name: string, address: string | null): Promise<Counterpart | null> {
+    const counterpart = await this.prisma.counterpart.findFirst({
       where: {
-        name_address: {
-          name,
-          address,
-        },
+        name,
+        address,
       },
     });
 
@@ -111,7 +109,7 @@ export class PrismaCounterpartRepository implements ICounterpartRepository {
     const counterpart = await this.prisma.counterpart.create({
       data: {
         name: data.name.trim(),
-        address: data.address.trim(),
+        address: data.address?.trim() || null,
       },
     });
 
@@ -124,13 +122,13 @@ export class PrismaCounterpartRepository implements ICounterpartRepository {
       throw new Error(`無効なID形式です: ${id}`);
     }
 
-    const updateData: { name?: string; address?: string } = {};
+    const updateData: { name?: string; address?: string | null } = {};
 
     if (data.name !== undefined) {
       updateData.name = data.name.trim();
     }
     if (data.address !== undefined) {
-      updateData.address = data.address.trim();
+      updateData.address = data.address?.trim() || null;
     }
 
     const counterpart = await this.prisma.counterpart.update({

--- a/prisma/migrations/20251222130125_make_counterpart_address_nullable/migration.sql
+++ b/prisma/migrations/20251222130125_make_counterpart_address_nullable/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."counterparts" ALTER COLUMN "address" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -72,7 +72,7 @@ model Transaction {
 model Counterpart {
   id        BigInt   @id @default(autoincrement())
   name      String   @db.VarChar(120)
-  address   String   @db.VarChar(120)
+  address   String?  @db.VarChar(120)
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 


### PR DESCRIPTION
## Summary

- 取引先マスタで住所を後から入力できるようにするため、addressフィールドをnullableに変更
- Prismaスキーマ、ドメインモデル、バリデーション、UIを一貫して更新
- DBマイグレーション（make_counterpart_address_nullable）を含む

## Changes

- **Prismaスキーマ**: `address String` → `address String?`
- **ドメインモデル**: `address: string` → `address: string | null`
- **バリデーション**: 住所の必須チェックを削除、文字数上限チェックは維持
- **ユースケース**: 空文字をnullに正規化する処理を追加
- **UI**: 住所の必須マーク削除、プレースホルダーに「（任意）」追記

## Test plan

- [ ] 取引先の新規作成で住所を空欄のまま登録できること
- [ ] 取引先の編集で住所を空欄に変更して保存できること
- [ ] 住所を入力した場合は正常に保存されること
- [ ] 住所が120文字を超える場合はバリデーションエラーになること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 相手先の作成・編集画面で住所フィールドがオプショナルになりました
  * 住所情報なしで相手先を登録できるようになりました
  * 相手先検索・フィルタ機能でnull値の処理を安全化しました

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->