### PR TITLE
docs: 取引先住所検索機能の設計ドキュメント追加

### DIFF
--- a/docs/20251222_2217_取引先住所検索機能設計.md
+++ b/docs/20251222_2217_取引先住所検索機能設計.md
@@ -171,6 +171,24 @@ admin/src/
 | candidates | AddressCandidate[] | 自信度順、最大5件 |
 | searchQuery | string | 検索に使用したクエリ |
 
+### エラーハンドリング
+
+**SearchResult（Action の戻り値）**
+
+| 型 | 説明 |
+|-----|------|
+| { success: true; data: CounterpartAddressSearchResult } | 成功時 |
+| { success: false; error: SearchError } | 失敗時 |
+
+**SearchError（エラー種別）**
+
+| type | フィールド | 説明 |
+|------|-----------|------|
+| API_ERROR | message, retryable | API呼び出し失敗（retryable=trueならリトライ可） |
+| TIMEOUT | message | タイムアウト |
+| RATE_LIMIT | retryAfter | レート制限（retryAfter秒後にリトライ可） |
+| NO_RESULTS | message | 候補が見つからなかった |
+
 ### 技術選定
 
 | コンポーネント | 技術 | 理由 |


### PR DESCRIPTION
## Summary

- 取引先（Counterpart）の住所をLLMで検索する機能の設計ドキュメントを追加
- Vercel AI SDK + Claude API（WebSearch Tool）を使用した構成
- 将来のLangfuse移行を考慮した抽象化設計

## 設計概要

- ユースケース: 取引先名から住所候補を検索、ユーザーが選択して保存
- 技術構成: Server Action → UseCase → LLMGateway → Vercel AI SDK
- 住所保存は既存の `updateCounterpartAction` を利用

## Test plan

- [ ] 設計ドキュメントの内容を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)