### PR TITLE
docs: 報告書データプレビュー機能の設計

### DIFF
--- a/docs/20251222_2314_報告書データプレビュー機能設計.md
+++ b/docs/20251222_2314_報告書データプレビュー機能設計.md
@@ -1,0 +1,340 @@
+# 報告書データプレビュー機能設計
+
+## 概要
+
+XMLエクスポート画面に、ReportDataを表形式でシートごとにプレビューできる機能を追加する。タブでXMLプレビューと表形式プレビューを切り替え、縦に長い1ページで全シートを表示する。
+
+## 背景と目的
+
+- 現状: XMLが表示されるだけでPDCAが困難
+- 目的: 政治資金報告書の各シートを視覚的に確認できるようにし、データの検証を容易にする
+
+## 画面構成
+
+### タブ構成
+
+```
+[XMLプレビュー] [表形式プレビュー]
+```
+
+- タブ切り替えで表示を切り替え
+- デフォルトは「表形式プレビュー」
+
+### 表形式プレビューの構成
+
+縦に長い1ページで、以下のセクションを順に表示:
+
+1. **団体基本情報 (SYUUSHI07_01)**
+2. **収入の部**
+   - 寄附 (SYUUSHI07_07)
+     - 個人からの寄附
+   - 事業による収入 (SYUUSHI07_03)
+   - 借入金 (SYUUSHI07_04)
+   - 交付金 (SYUUSHI07_05)
+   - その他の収入 (SYUUSHI07_06)
+3. **支出の部**
+   - 経常経費 (SYUUSHI07_14)
+     - 光熱水費
+     - 備品・消耗品費
+     - 事務所費
+   - 政治活動費 (SYUUSHI07_15)
+     - 組織活動費
+     - 選挙関係費
+     - 機関紙誌の発行事業費
+     - 宣伝事業費
+     - 政治資金パーティー開催事業費
+     - その他の事業費
+     - 調査研究費
+     - 寄附・交付金
+     - その他の経費
+
+### 各セクションの表示形式
+
+#### セクションヘッダー
+```
+┌─────────────────────────────────────────┐
+│ [シート名] (SYUUSHI07_XX)               │
+│ 合計: ¥X,XXX,XXX                        │
+│ (10万円/5万円未満の合計: ¥XXX,XXX)      │  ← 該当するセクションのみ
+└─────────────────────────────────────────┘
+```
+
+#### テーブル形式
+
+各シートタイプに応じたカラム構成でTable表示:
+
+**収入系共通カラム例:**
+| No. | 項目名/摘要 | 金額 | 備考 |
+
+**支出系共通カラム例 (10万円以上):**
+| No. | 目的 | 金額 | 年月日 | 氏名 | 住所 | 備考 |
+
+**寄附明細:**
+| No. | 寄附者氏名 | 金額 | 年月日 | 住所 | 職業 | 備考 |
+
+### データがない場合の表示
+
+セクションにデータがない場合:
+- 薄いグレー背景で「データなし」と表示
+- または折りたたんだ状態で表示
+
+## アーキテクチャ
+
+### データフロー
+
+```
+exportXml action
+    ↓
+XmlExportUsecase.execute()
+    ↓
+returns { xml, buffer, filename, reportData }  ← reportData を活用
+    ↓
+ExportReportClient (クライアント)
+    ↓
+ReportDataPreview コンポーネント
+```
+
+### 必要なサーバーアクション変更
+
+`exportXml` は既に `reportData` を返却している（現在は使用していない）ため、サーバー側の変更は不要。
+
+### 必要なコンポーネント
+
+```
+admin/src/client/components/export-report/
+├── ExportReportClient.tsx        # 既存（変更）
+├── ReportDataPreview.tsx         # 新規: 表形式プレビューのルートコンポーネント
+├── sections/
+│   ├── ProfileSection.tsx        # 団体基本情報
+│   ├── DonationSection.tsx       # 寄附明細
+│   ├── IncomeSection.tsx         # 収入セクション
+│   └── ExpenseSection.tsx        # 支出セクション
+└── common/
+    ├── SectionHeader.tsx         # セクションヘッダー
+    └── DataTable.tsx             # 汎用テーブル表示
+```
+
+## 詳細設計
+
+### UIコンポーネント追加
+
+shadcn/ui の `Tabs` コンポーネントを追加する必要あり:
+
+```bash
+cd admin && npx shadcn@latest add tabs
+```
+
+### ExportReportClient の変更
+
+```typescript
+// 変更前: previewXml のみ管理
+const [previewXml, setPreviewXml] = useState("");
+
+// 変更後: reportData も管理
+const [previewData, setPreviewData] = useState<{
+  xml: string;
+  reportData: ReportData | null;
+}>({ xml: "", reportData: null });
+```
+
+### ReportDataPreview コンポーネント
+
+Props:
+```typescript
+interface ReportDataPreviewProps {
+  reportData: ReportData;
+}
+```
+
+責務:
+- 全セクションを縦に並べて表示
+- 各セクションの表示/非表示判定（`shouldOutputSheet` を利用）
+
+### セクションコンポーネント共通パターン
+
+```typescript
+interface SectionProps<T> {
+  title: string;
+  formId: string;         // e.g., "SYUUSHI07_06"
+  data: T;
+  columns: ColumnDef[];   // テーブルカラム定義
+}
+```
+
+### 金額フォーマット
+
+`toLocaleString('ja-JP')` で3桁カンマ区切り表示。
+
+### 日付フォーマット
+
+和暦表示（`formatWarekiDate` を流用可能かクライアント用にユーティリティ作成）。
+
+## テーブルカラム定義
+
+### 個人寄附 (PersonalDonationRow)
+
+| カラム名 | フィールド | 幅 |
+|---------|-----------|-----|
+| No. | ichirenNo | 50px |
+| 寄附者氏名 | kifusyaNm | 150px |
+| 金額 | kingaku | 100px (右寄せ) |
+| 年月日 | dt | 100px |
+| 住所 | adr | 200px |
+| 職業 | syokugyo | 100px |
+| 備考 | bikou | 150px |
+
+### 事業収入 (BusinessIncomeRow)
+
+| カラム名 | フィールド | 幅 |
+|---------|-----------|-----|
+| No. | ichirenNo | 50px |
+| 事業の種類 | gigyouSyurui | 250px |
+| 金額 | kingaku | 100px (右寄せ) |
+| 備考 | bikou | 200px |
+
+### 借入金 (LoanIncomeRow)
+
+| カラム名 | フィールド | 幅 |
+|---------|-----------|-----|
+| No. | ichirenNo | 50px |
+| 借入先 | kariiresaki | 250px |
+| 金額 | kingaku | 100px (右寄せ) |
+| 備考 | bikou | 200px |
+
+### 交付金 (GrantIncomeRow)
+
+| カラム名 | フィールド | 幅 |
+|---------|-----------|-----|
+| No. | ichirenNo | 50px |
+| 本支部名称 | honsibuNm | 200px |
+| 金額 | kingaku | 100px (右寄せ) |
+| 年月日 | dt | 100px |
+| 事務所所在地 | jimuAdr | 200px |
+| 備考 | bikou | 150px |
+
+### その他の収入 (OtherIncomeRow)
+
+| カラム名 | フィールド | 幅 |
+|---------|-----------|-----|
+| No. | ichirenNo | 50px |
+| 摘要 | tekiyou | 250px |
+| 金額 | kingaku | 100px (右寄せ) |
+| 備考 | bikou | 200px |
+
+### 経常経費・政治活動費 (ExpenseRow / PoliticalActivityExpenseRow)
+
+| カラム名 | フィールド | 幅 |
+|---------|-----------|-----|
+| No. | ichirenNo | 50px |
+| 目的 | mokuteki | 200px |
+| 金額 | kingaku | 100px (右寄せ) |
+| 年月日 | dt | 100px |
+| 氏名 | nm | 150px |
+| 住所 | adr | 200px |
+| 備考 | bikou | 150px |
+
+### 団体基本情報 (OrganizationReportProfile)
+
+キーバリュー形式で表示:
+
+| 項目 | 値 |
+|------|-----|
+| 団体名称 | officialName |
+| 団体名称（カナ） | officialNameKana |
+| 事務所所在地 | officeAddress + officeAddressBuilding |
+| 代表者 | details.representative.lastName + firstName |
+| 会計責任者 | details.accountant.lastName + firstName |
+| 事務担当者 | details.contactPersons (リスト) |
+
+## 型定義の配置
+
+ReportData 関連の型は既にサーバー側に存在するが、クライアントでも使用するため:
+
+1. 型定義を `admin/src/types/report-data.ts` に移動またはコピー
+2. または `import type` でサーバー側の型を参照（Next.js 15 では可能）
+
+推奨: `import type` でサーバー型を直接参照し、重複を避ける。
+
+## ファイル構成（最終）
+
+```
+admin/src/
+├── client/components/
+│   ├── export-report/
+│   │   ├── ExportReportClient.tsx         # 変更: タブ切り替え追加
+│   │   ├── ReportDataPreview.tsx          # 新規: 表形式プレビュー
+│   │   ├── XmlPreview.tsx                 # 新規: XMLプレビュー（分離）
+│   │   └── sections/
+│   │       ├── ProfileSection.tsx         # 団体基本情報
+│   │       ├── DonationSection.tsx        # 寄附
+│   │       ├── IncomeSection.tsx          # 収入
+│   │       ├── ExpenseSection.tsx         # 支出
+│   │       └── SectionWrapper.tsx         # セクション共通ラッパー
+│   └── ui/
+│       └── tabs.tsx                       # 新規: shadcn tabs
+└── types/
+    └── (既存の型を流用)
+```
+
+## スタイリング方針
+
+- shadcn/ui の Table コンポーネントを使用
+- セクション間は `mb-8` で余白
+- **表形式プレビューのセクションは白背景 (`bg-white`) + 黒ボーダー (`border-black`) で描画**
+  - 印刷イメージに近づけるため
+  - ただしPDFレイアウトへの厳密な寄せは行わない
+- テーブル内のテキストは黒 (`text-black`)
+- 閾値未満金額は合計のみ表示（個別レコードは非表示）、薄めのグレー (`text-gray-500`) で表示
+- 空セクションは `opacity-50` で薄く表示
+
+---
+
+## フェーズ分け
+
+全セクション実装は膨大なため、フェーズに分けて段階的に実装する。
+
+### フェーズ1: ベース実装 + 経常経費（光熱水費・備品消耗品費・事務所費）
+
+**スコープ:**
+- タブ切り替えUI（XMLプレビュー / 表形式プレビュー）
+- `ReportDataPreview` コンポーネントの骨格
+- `SectionWrapper` 共通コンポーネント
+- 経常経費 (SYUUSHI07_14) の3区分:
+  - 光熱水費 (utilityExpenses)
+  - 備品・消耗品費 (suppliesExpenses)
+  - 事務所費 (officeExpenses)
+
+**実装タスク:**
+
+1. shadcn/ui `Tabs` コンポーネント追加
+2. `ExportReportClient.tsx` 変更
+   - `reportData` をstateに追加
+   - タブ切り替えUI実装
+3. `XmlPreview.tsx` 新規作成（既存XMLプレビュー部分を分離）
+4. `ReportDataPreview.tsx` 新規作成
+5. `sections/SectionWrapper.tsx` 新規作成（セクションヘッダー + テーブル）
+6. `sections/RegularExpenseSection.tsx` 新規作成
+   - 光熱水費・備品消耗品費・事務所費の3テーブル表示
+   - 10万円未満合計の表示
+
+**ファイル構成（フェーズ1）:**
+
+```
+admin/src/client/components/
+├── export-report/
+│   ├── ExportReportClient.tsx      # 変更
+│   ├── XmlPreview.tsx              # 新規
+│   ├── ReportDataPreview.tsx       # 新規
+│   └── sections/
+│       ├── SectionWrapper.tsx      # 新規
+│       └── RegularExpenseSection.tsx  # 新規
+└── ui/
+    └── tabs.tsx                    # 新規 (shadcn)
+```
+
+### フェーズ2以降（未定）
+
+- 団体基本情報 (SYUUSHI07_01)
+- 寄附 (SYUUSHI07_07)
+- 収入 (SYUUSHI07_03〜06)
+- 政治活動費 (SYUUSHI07_15)


### PR DESCRIPTION
## Summary

- XMLエクスポート画面にReportDataを表形式でプレビューする機能の設計ドキュメントを追加
- フェーズ1として経常経費（光熱水費・備品消耗品費・事務所費）の表示を対象

## 設計概要

- タブ切り替えUI（XMLプレビュー / 表形式プレビュー）
- 白背景 + 黒ボーダーで印刷イメージに近づける
- 10万円未満の取引は合計のみ表示

## Test plan

- [ ] 設計レビュー

🤖 Generated with [Claude Code](https://claude.com/claude-code)