### PR TITLE
fix(admin): 取引先紐付けダイアログの住所を任意に変更

### DIFF
--- a/admin/src/client/components/counterpart-assignment/CounterpartCombobox.tsx
+++ b/admin/src/client/components/counterpart-assignment/CounterpartCombobox.tsx
@@ -139,13 +139,13 @@ export function CounterpartCombobox({
 
   const handleCreateAndAssign = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!newName.trim() || !newAddress.trim()) return;
+    if (!newName.trim()) return;
 
     setError(null);
     startTransition(async () => {
       const createResult = await createCounterpartAction({
         name: newName.trim(),
-        address: newAddress.trim(),
+        address: newAddress.trim() || null,
       });
 
       if (!createResult.success) {
@@ -157,7 +157,7 @@ export function CounterpartCombobox({
         setOptimisticCounterpart({
           id: createResult.counterpartId,
           name: newName.trim(),
-          address: newAddress.trim(),
+          address: newAddress.trim() || null,
         });
         setIsOpen(false);
         setIsCreateMode(false);
@@ -253,7 +253,7 @@ export function CounterpartCombobox({
                   htmlFor={`create-address-${transactionId}`}
                   className="block mb-1 text-sm text-muted-foreground"
                 >
-                  住所 <span className="text-red-500">*</span>
+                  住所
                 </label>
                 <input
                   type="text"
@@ -262,9 +262,8 @@ export function CounterpartCombobox({
                   onChange={(e) => setNewAddress(e.target.value)}
                   maxLength={MAX_ADDRESS_LENGTH}
                   className="bg-input text-white border border-border rounded-lg px-3 py-2 w-full text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                  placeholder="住所"
+                  placeholder="住所（任意）"
                   disabled={isPending}
-                  required
                 />
               </div>
 
@@ -283,9 +282,9 @@ export function CounterpartCombobox({
                 </button>
                 <button
                   type="submit"
-                  disabled={isPending || !newName.trim() || !newAddress.trim()}
+                  disabled={isPending || !newName.trim()}
                   className={`bg-primary text-white rounded-lg px-3 py-1.5 text-sm transition-colors ${
-                    isPending || !newName.trim() || !newAddress.trim()
+                    isPending || !newName.trim()
                       ? "opacity-60 cursor-not-allowed"
                       : "hover:bg-blue-600 cursor-pointer"
                   }`}

--- a/admin/src/client/components/counterparts/CounterpartTable.tsx
+++ b/admin/src/client/components/counterparts/CounterpartTable.tsx
@@ -3,6 +3,7 @@ import "client-only";
 
 import { useState } from "react";
 import type { CounterpartWithUsage } from "@/server/contexts/report/domain/models/counterpart";
+import { Button } from "@/client/components/ui";
 import { EditCounterpartDialog } from "./EditCounterpartDialog";
 import { DeleteCounterpartButton } from "./DeleteCounterpartButton";
 
@@ -45,13 +46,14 @@ export function CounterpartTable({ counterparts, onUpdate }: CounterpartTablePro
                 <td className="py-3 px-4 text-white text-right">{counterpart.usageCount}件</td>
                 <td className="py-3 px-4 text-right">
                   <div className="flex gap-2 justify-end">
-                    <button
+                    <Button
                       type="button"
+                      variant="secondary"
+                      size="sm"
                       onClick={() => setEditingCounterpart(counterpart)}
-                      className="bg-secondary text-white border-0 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors duration-200 hover:bg-secondary cursor-pointer"
                     >
                       編集
-                    </button>
+                    </Button>
                     <DeleteCounterpartButton
                       counterpartId={counterpart.id}
                       counterpartName={counterpart.name}


### PR DESCRIPTION
## Summary
- 取引先紐付けページの新規作成ダイアログで、住所を任意項目に変更
- CounterpartTableの編集ボタンをshadcn/ui Buttonコンポーネントに統一

## Test plan
- [ ] http://localhost:3001/assign/counterparts で「新規取引先作成」ダイアログを開く
- [ ] 住所に `*` マークがなく、「住所（任意）」というプレースホルダーが表示されることを確認
- [ ] 名前のみ入力して「作成して紐付け」ボタンが有効になることを確認
- [ ] http://localhost:3001/counterparts で編集ボタンのスタイルを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)