### PR TITLE
docs: 取引先フォームDRY化設計書を追加

### DIFF
--- a/docs/20251223_0108_取引先フォームDRY化設計.md
+++ b/docs/20251223_0108_取引先フォームDRY化設計.md
@@ -1,0 +1,315 @@
+# 取引先フォームDRY化設計
+
+## 背景・目的
+
+取引先マスタ管理画面（`/counterparts`）の新規登録・編集ダイアログにおいて、以下の課題がある：
+
+1. **新規登録に住所検索機能がない** - `CreateCounterpartDialog`は手動入力のみで、LLM住所検索（`VercelAIGateway`）を使えない
+2. **フォーム部分の重複** - 両ダイアログで名前・住所入力フォームが重複している
+3. **ダイアログ構造の重複** - モーダルのラッパー、エラー表示、ボタン配置が類似
+4. **shadcn Dialog未使用** - 自前実装のモーダル（`<div className="fixed inset-0...">`）を使用しており、Escapeキー対応やフォーカストラップを手動実装している
+
+本設計では、これらを統一し、DRY原則に基づいたコンポーネント構成に変更する。また、shadcn Dialogへの移行も行う。
+
+## 現状のコンポーネント構成
+
+```
+admin/src/client/components/counterparts/
+├── CounterpartMasterClient.tsx  # 一覧画面のクライアントコンポーネント
+├── CounterpartTable.tsx         # テーブル表示
+├── CreateCounterpartDialog.tsx  # 新規登録ダイアログ（住所検索なし）
+├── EditCounterpartDialog.tsx    # 編集ダイアログ（住所検索あり）
+├── AddressSearchDialog.tsx      # LLM住所検索ダイアログ
+└── DeleteCounterpartButton.tsx  # 削除ボタン
+```
+
+### 現状の問題点
+
+| ファイル | 問題 |
+|---------|------|
+| `CreateCounterpartDialog.tsx` | 住所検索機能がない、フォーム部分がEditと重複、shadcn Dialog未使用 |
+| `EditCounterpartDialog.tsx` | フォーム部分がCreateと重複、shadcn Dialog未使用 |
+| `AddressSearchDialog.tsx` | shadcn Dialog未使用 |
+
+## 変更後のコンポーネント構成
+
+```
+admin/src/client/components/counterparts/
+├── CounterpartMasterClient.tsx  # import変更のみ
+├── CounterpartTable.tsx         # import変更のみ
+├── CounterpartFormDialog.tsx    # 新規: 統合ダイアログ（新規/編集共通、shadcn Dialog使用）
+├── CounterpartForm.tsx          # 新規: フォーム部分（住所検索含む）
+├── AddressSearchDialog.tsx      # 変更: shadcn Dialogへ移行
+└── DeleteCounterpartButton.tsx  # 変更なし
+```
+
+削除対象:
+- `CreateCounterpartDialog.tsx`
+- `EditCounterpartDialog.tsx`
+
+## 各コンポーネントの設計
+
+### CounterpartForm
+
+フォーム入力部分を切り出したコンポーネント。
+
+**責務:**
+- 名前・住所の入力フィールド管理
+- バリデーション（名前必須）
+- 住所検索ダイアログの呼び出し
+
+**Props:**
+
+| Prop | 型 | 説明 |
+|------|-----|------|
+| `name` | `string` | 名前の値 |
+| `onNameChange` | `(value: string) => void` | 名前変更ハンドラ |
+| `address` | `string` | 住所の値 |
+| `onAddressChange` | `(value: string) => void` | 住所変更ハンドラ |
+| `disabled` | `boolean` | フォーム無効化フラグ |
+
+**特徴:**
+- `AddressSearchDialog`を内部で管理
+- 住所検索ボタンは名前が入力されている場合のみ有効化
+- input要素のidは内部で `useId()` を使用して自動生成
+
+### CounterpartFormDialog
+
+新規登録・編集を統一したダイアログコンポーネント。
+
+**責務:**
+- shadcn Dialogを使用したモーダルのレンダリング
+- 新規/編集モードに応じたタイトル・ボタンラベルの切り替え
+- サーバーアクションの呼び出し
+- エラー表示
+
+**Props（Discriminated Union）:**
+
+```typescript
+type CounterpartFormDialogProps =
+  | {
+      mode: "create";
+      onClose: () => void;
+      onSuccess: () => void;
+    }
+  | {
+      mode: "edit";
+      counterpart: CounterpartWithUsage;
+      onClose: () => void;
+      onSuccess: () => void;
+    };
+```
+
+| Prop | 型 | 説明 |
+|------|-----|------|
+| `mode` | `"create" \| "edit"` | モード |
+| `counterpart` | `CounterpartWithUsage` | 編集対象（editモード時のみ必須） |
+| `onClose` | `() => void` | 閉じるハンドラ |
+| `onSuccess` | `() => void` | 成功時ハンドラ |
+
+**shadcn Dialog使用による標準機能:**
+- Escapeキーでダイアログを閉じる（shadcn Dialogの標準機能）
+- フォーカストラップ（ダイアログ内にフォーカスを閉じ込める）
+- オーバーレイクリックでダイアログを閉じる
+- スクリーンリーダー対応（アクセシビリティ）
+
+**モード別の挙動:**
+
+| 項目 | create | edit |
+|------|--------|------|
+| タイトル | 新規取引先作成 | 取引先編集 |
+| 送信ボタン | 作成 | 保存 |
+| 送信中ラベル | 作成中... | 保存中... |
+| サーバーアクション | `createCounterpartAction` | `updateCounterpartAction` |
+| 使用状況表示 | なし | あり |
+| 注意書き | 同名・同住所は登録不可 | なし |
+
+## 呼び出し側の変更
+
+### CounterpartMasterClient
+
+```diff
+- import { CreateCounterpartDialog } from "@/client/components/counterparts/CreateCounterpartDialog";
++ import { CounterpartFormDialog } from "@/client/components/counterparts/CounterpartFormDialog";
+
+// ダイアログ呼び出し部分
+- {isCreateDialogOpen && (
+-   <CreateCounterpartDialog
+-     onClose={() => setIsCreateDialogOpen(false)}
+-     onCreate={() => {
+-       setIsCreateDialogOpen(false);
+-       handleUpdate();
+-     }}
+-   />
+- )}
++ {isCreateDialogOpen && (
++   <CounterpartFormDialog
++     mode="create"
++     onClose={() => setIsCreateDialogOpen(false)}
++     onSuccess={() => {
++       setIsCreateDialogOpen(false);
++       handleUpdate();
++     }}
++   />
++ )}
+```
+
+### CounterpartTable
+
+```diff
+- import { EditCounterpartDialog } from "./EditCounterpartDialog";
++ import { CounterpartFormDialog } from "./CounterpartFormDialog";
+
+// ダイアログ呼び出し部分
+- {editingCounterpart && (
+-   <EditCounterpartDialog
+-     counterpart={editingCounterpart}
+-     onClose={() => setEditingCounterpart(null)}
+-     onUpdate={() => {
+-       setEditingCounterpart(null);
+-       onUpdate();
+-     }}
+-   />
+- )}
++ {editingCounterpart && (
++   <CounterpartFormDialog
++     mode="edit"
++     counterpart={editingCounterpart}
++     onClose={() => setEditingCounterpart(null)}
++     onSuccess={() => {
++       setEditingCounterpart(null);
++       onUpdate();
++     }}
++   />
++ )}
+```
+
+## LLM住所検索の利用フロー（統一後）
+
+```
+ユーザー操作
+    │
+    ├─ 新規作成ボタン ─┐
+    │                  │
+    └─ 編集ボタン ────┴─→ CounterpartFormDialog
+                              │
+                              └─→ CounterpartForm
+                                      │
+                                      └─→ 住所検索ボタン
+                                              │
+                                              └─→ AddressSearchDialog
+                                                      │
+                                                      └─→ searchCounterpartAddressAction
+                                                              │
+                                                              └─→ VercelAIGateway.searchAddress()
+```
+
+## 影響範囲
+
+### 変更が必要なファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `CounterpartMasterClient.tsx` | import変更、ダイアログ呼び出し変更 |
+| `CounterpartTable.tsx` | import変更、ダイアログ呼び出し変更 |
+
+### 新規作成するファイル
+
+| ファイル | 内容 |
+|---------|------|
+| `CounterpartFormDialog.tsx` | 統合ダイアログ |
+| `CounterpartForm.tsx` | フォーム部分 |
+
+### 削除するファイル
+
+| ファイル | 理由 |
+|---------|------|
+| `CreateCounterpartDialog.tsx` | CounterpartFormDialogに統合 |
+| `EditCounterpartDialog.tsx` | CounterpartFormDialogに統合 |
+
+### shadcn Dialogへ移行するファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `AddressSearchDialog.tsx` | 自前モーダル → shadcn Dialog |
+
+### 変更不要なファイル
+
+- `DeleteCounterpartButton.tsx` - 変更なし
+- サーバーアクション類 - 変更なし
+
+## shadcn Dialog 使用方針
+
+### 使用するコンポーネント
+
+`@/client/components/ui` から以下をインポート:
+
+```typescript
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/client/components/ui";
+```
+
+### CounterpartFormDialog の構造
+
+```tsx
+<Dialog open={true} onOpenChange={(open) => !open && onClose()}>
+  <DialogContent>
+    <DialogHeader>
+      <DialogTitle>{mode === "create" ? "新規取引先作成" : "取引先編集"}</DialogTitle>
+    </DialogHeader>
+
+    {/* エラー表示 */}
+    {error && <div className="...">{error}</div>}
+
+    {/* フォーム */}
+    <form onSubmit={handleSubmit}>
+      <CounterpartForm ... />
+
+      {/* 使用状況（editモードのみ） */}
+      {mode === "edit" && <div>使用状況: {counterpart.usageCount}件</div>}
+
+      {/* 注意書き（createモードのみ） */}
+      {mode === "create" && <p>※ 同じ名前・住所の組み合わせは登録できません</p>}
+
+      <DialogFooter>
+        <Button variant="secondary" onClick={onClose}>キャンセル</Button>
+        <Button type="submit">{mode === "create" ? "作成" : "保存"}</Button>
+      </DialogFooter>
+    </form>
+  </DialogContent>
+</Dialog>
+```
+
+### AddressSearchDialog の構造
+
+```tsx
+<Dialog open={true} onOpenChange={(open) => !open && onClose()}>
+  <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+    <DialogHeader>
+      <DialogTitle>住所検索: {companyName}</DialogTitle>
+    </DialogHeader>
+
+    {/* 検索フォーム・結果表示 */}
+    ...
+
+    <DialogFooter>
+      <Button variant="secondary" onClick={onClose}>キャンセル</Button>
+      <Button onClick={handleSave}>この住所を保存</Button>
+    </DialogFooter>
+  </DialogContent>
+</Dialog>
+```
+
+### 削除できるコード
+
+shadcn Dialog移行により、以下の自前実装コードが不要になる:
+
+- `useEffect` によるEscapeキーハンドリング
+- `handleClose` の `useCallback` ラッパー
+- `<div className="fixed inset-0 bg-black/50 ...">` によるオーバーレイ
+- 手動のz-index管理


### PR DESCRIPTION
## Summary

- 取引先マスタ管理画面の新規登録/編集ダイアログをDRY化する設計書
- `CreateCounterpartDialog`と`EditCounterpartDialog`を`CounterpartFormDialog`に統合
- shadcn Dialogへの移行方針を追加
- 新規登録でもLLM住所検索（VercelAIGateway）が使えるようにする設計

## 主な設計内容

- **CounterpartForm**: フォーム部分を切り出した共通コンポーネント
- **CounterpartFormDialog**: 新規/編集を統合したダイアログ（Discriminated Unionで型安全に）
- **AddressSearchDialog**: shadcn Dialogへの移行

## Test plan

- [ ] 設計書の内容レビュー

🤖 Generated with [Claude Code](https://claude.com/claude-code)