### PR TITLE
docs: 取引先作成UI統合設計書を追加

### DIFF
--- a/docs/20251223_1017_取引先作成UI統合設計.md
+++ b/docs/20251223_1017_取引先作成UI統合設計.md
@@ -1,0 +1,548 @@
+# 取引先作成UI統合設計
+
+## 背景と課題
+
+### 現状の問題
+
+取引先（Counterpart）の作成には4つの経路が存在し、実装が分散している：
+
+1. マスター画面からの新規作成 - [CounterpartFormDialog](../admin/src/client/components/counterparts/CounterpartFormDialog.tsx)
+2. マスター画面からの既存データ編集 - [CounterpartFormDialog](../admin/src/client/components/counterparts/CounterpartFormDialog.tsx)
+3. 個別取引の紐付け - [CounterpartCombobox](../admin/src/client/components/counterpart-assignment/CounterpartCombobox.tsx)
+4. 一括取引の紐付け - [BulkAssignModal](../admin/src/client/components/counterpart-assignment/BulkAssignModal.tsx)
+
+#### 具体的な問題点
+
+1. **Dialog入れ子のアンチパターン**
+   - `CounterpartFormDialog` (Dialog) の中で `CounterpartForm` を使用
+   - `CounterpartForm` 内で `AddressSearchDialog` (Dialog) を開く
+   - Dialog→Dialogの入れ子構造となり、UXとメンテナンス性が悪化
+
+2. **重複実装**
+   - 取引先作成フォームが3箇所に散在
+   - 住所検索機能の有無が経路によって異なる
+   - バグ修正や機能追加時に複数箇所の修正が必要
+
+3. **単一/一括の重複**
+   - 個別紐付け（CounterpartCombobox）と一括紐付け（BulkAssignModal）が別実装
+   - 単一は一括のサブセットとして扱えるが、現状は重複コード
+
+## 設計方針
+
+### 関心の分離
+
+UIコンポーネントを以下のレイヤーに分離：
+
+1. **機能コンポーネント**: ビジネスロジックと入力制御を持つ
+2. **プレゼンテーションラッパー**: Dialogとして表示する責務のみ
+
+### 統合の原則
+
+- 単一紐付けを一括紐付けのサブセット（`transactions.length === 1`）として扱う
+- 住所検索をインライン化し、Dialog入れ子を排除
+- すべての経路で同じ機能コンポーネントを再利用
+
+### Dialogサイズ設計
+
+操作しやすさを優先し、以下のサイズポリシーを適用：
+
+- **マスター画面用Dialog（経路1,2）**: 標準サイズ（`max-w-md` 程度）
+  - シンプルなフォームのため、コンパクトなサイズで十分
+  - 住所検索結果がインライン展開されるため、縦方向には余裕を持たせる
+
+- **紐付け用Dialog（経路3,4）**: 大型サイズ（画面いっぱい）
+  - 2カラムレイアウトで情報量が多いため、広い作業スペースが必要
+  - サイズ指定: `max-w-[95vw] max-h-[95vh]`
+  - 理由:
+    - 左カラム: 取引情報・一覧を十分に表示
+    - 右カラム: 取引先一覧や住所検索結果を快適にスクロール・選択
+    - 住所検索時の候補を複数同時に比較しやすい
+
+## コンポーネント設計
+
+### 全体構造
+
+```
+CounterpartFormContent (機能コンポーネント)
+├─ 名前入力
+├─ 住所入力
+└─ 住所検索結果表示（インライン）
+
+CounterpartSelectorContent (機能コンポーネント)
+├─ 検索入力
+├─ 既存取引先一覧（選択可能）
+└─ AI提案機能（単一・一括共通）
+
+AssignWithCounterpartContent (機能コンポーネント)
+├─ 左カラム: Transaction情報・一覧
+│   └─ transactions: TransactionWithCounterpart[]
+└─ 右カラム:
+    ├─ モード切り替え（既存選択 / 新規作成）
+    ├─ CounterpartSelectorContent（既存選択モード時）
+    └─ CounterpartFormContent（新規作成モード時）
+
+CounterpartFormDialog (1,2用プレゼンテーションラッパー)
+└─ Dialog > CounterpartFormContent
+
+AssignCounterpartDialog (3,4用プレゼンテーションラッパー)
+└─ Dialog (wide) > AssignWithCounterpartContent
+```
+
+### 1. CounterpartFormContent
+
+取引先の作成・編集フォーム（機能コンポーネント）
+
+#### Props
+
+```tsx
+interface CounterpartFormContentProps {
+  mode: 'create' | 'edit';
+  initialData?: {
+    id: string;
+    name: string;
+    address: string | null;
+    usageCount?: number;
+  };
+  onSubmit: (data: { name: string; address: string | null }) => Promise<void>;
+  disabled?: boolean;
+}
+```
+
+#### 主な機能
+
+- 名前・住所の入力フォーム
+- 住所検索機能（インライン表示）
+  - 検索結果を折りたたみ可能な領域に表示
+  - 候補選択時に住所フィールドに自動入力
+  - ヒント入力・再検索機能
+  - Google確認リンク
+- バリデーション（名前必須、最大文字数）
+
+#### 住所検索のインライン化
+
+従来の `AddressSearchDialog` の機能を、フォーム内に展開：
+
+```
+┌─────────────────────────────┐
+│ 名前 *                      │
+│ ┌─────────────────────────┐ │
+│ │ 株式会社サンプル         │ │
+│ └─────────────────────────┘ │
+│                            │
+│ 住所  [住所を検索]          │
+│ ┌─────────────────────────┐ │
+│ │ 東京都...               │ │
+│ └─────────────────────────┘ │
+│                            │
+│ ┌─ 検索結果 ──────────────┐ │
+│ │ ヒント: [印刷] [再検索] │ │
+│ │                         │ │
+│ │ ┌─────────────────────┐ │ │
+│ │ │ 候補1 (自信度: 高)   │ │ │
+│ │ │ 東京都千代田区...    │ │ │
+│ │ │ 根拠: 国税庁        │ │ │
+│ │ │ [選択] [Google確認] │ │ │
+│ │ └─────────────────────┘ │ │
+│ │ ┌─────────────────────┐ │ │
+│ │ │ 候補2 (自信度: 中)   │ │ │
+│ │ │ ...                 │ │ │
+│ │ └─────────────────────┘ │ │
+│ └─────────────────────────┘ │
+└─────────────────────────────┘
+```
+
+#### 配置場所
+
+`admin/src/client/components/counterparts/CounterpartFormContent.tsx`
+
+### 2. CounterpartSelectorContent
+
+既存取引先選択UI（機能コンポーネント）
+
+#### Props
+
+```tsx
+interface CounterpartSelectorContentProps {
+  allCounterparts: Counterpart[];
+  selectedCounterpartId: string | null;
+  onSelect: (counterpartId: string) => void;
+  transactions: TransactionWithCounterpart[]; // AI提案用（単一・一括共通）
+  politicalOrganizationId: string; // AI提案用
+}
+```
+
+#### 主な機能
+
+- 検索入力（名前・住所でフィルタリング）
+- 取引先一覧表示（ラジオボタン選択）
+- AI提案機能（単一・一括共通）
+  - **単一時**: 取引内容（摘要、金額、カテゴリ）に基づく提案
+  - **一括時**: 複数取引の共通パターンに基づく提案
+    - 同一摘要・類似金額の取引が多い場合に共通の取引先を推測
+    - 同一カテゴリの過去実績から頻出取引先を提案
+  - 提案理由の表示（「摘要に『印刷』が含まれるため」「過去の広告費で最も多く使用」等）
+
+#### 配置場所
+
+`admin/src/client/components/counterparts/CounterpartSelectorContent.tsx`
+
+### 3. AssignWithCounterpartContent
+
+取引紐付けUI（機能コンポーネント）
+
+#### Props
+
+```tsx
+interface AssignWithCounterpartContentProps {
+  transactions: TransactionWithCounterpart[]; // 単一でも配列
+  allCounterparts: Counterpart[];
+  politicalOrganizationId: string;
+  onSuccess: () => void;
+  onCancel: () => void;
+}
+```
+
+#### 主な機能
+
+- 2カラムレイアウト
+  - 左: Transaction情報
+    - 単一時: 詳細表示
+    - 一括時: 件数と一覧（10件まで表示 + 残件数）
+  - 右: 取引先選択/作成
+- モード切り替え（タブ形式）
+  - 既存選択モード: `CounterpartSelectorContent` を表示
+  - 新規作成モード: `CounterpartFormContent` を表示
+- ボタンラベルの動的変更
+  - 既存選択時:
+    - 単一: "この取引先を紐付け"
+    - 一括: "すべてに紐付け (5件)"
+  - 新規作成時:
+    - 単一: "作成して紐付け"
+    - 一括: "作成してすべてに紐付け"
+
+#### 単一/一括の判定
+
+```tsx
+const isBulk = transactions.length > 1;
+```
+
+#### 配置場所
+
+`admin/src/client/components/counterpart-assignment/AssignWithCounterpartContent.tsx`
+
+### 4. CounterpartFormDialog
+
+マスター画面用プレゼンテーションラッパー
+
+#### Props
+
+```tsx
+type CounterpartFormDialogProps =
+  | {
+      mode: "create";
+      onClose: () => void;
+      onSuccess: () => void;
+    }
+  | {
+      mode: "edit";
+      counterpart: CounterpartWithUsage;
+      onClose: () => void;
+      onSuccess: () => void;
+    };
+```
+
+#### 責務
+
+- Dialogとして表示（shadcn Dialog使用）
+- タイトル表示（"新規取引先作成" / "取引先編集"）
+- `CounterpartFormContent` をラップ
+- submit時にactionを呼び出し（`createCounterpartAction` / `updateCounterpartAction`）
+- エラーハンドリング
+- 成功時に `onSuccess()` を実行して閉じる
+
+#### 配置場所
+
+`admin/src/client/components/counterparts/CounterpartFormDialog.tsx` (既存を書き換え)
+
+### 5. AssignCounterpartDialog
+
+紐付け画面用プレゼンテーションラッパー（単一/一括共通）
+
+#### Props
+
+```tsx
+interface AssignCounterpartDialogProps {
+  isOpen: boolean;
+  transactions: TransactionWithCounterpart[]; // 単一でも一括でも配列
+  allCounterparts: Counterpart[];
+  politicalOrganizationId: string;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+```
+
+#### 責務
+
+- Dialogとして表示（大型サイズ: `max-w-[95vw] max-h-[95vh]`）
+  - 画面いっぱいに広がることで操作性を確保
+  - 2カラムレイアウトと住所検索結果表示のために広い作業スペースが必要
+- タイトル表示
+  - 単一: "取引先を紐付け"
+  - 一括: "一括紐付け"
+- `AssignWithCounterpartContent` をラップ
+
+#### 配置場所
+
+`admin/src/client/components/counterpart-assignment/AssignCounterpartDialog.tsx` (新規作成)
+
+## 画面仕様
+
+### 経路1,2: マスター画面からの作成/編集
+
+現状維持。`CounterpartFormDialog` を使用。
+
+```
+┌─────────────────────────────┐
+│  新規取引先作成       [×]    │
+├─────────────────────────────┤
+│ CounterpartFormContent      │
+│ ├─ 名前入力                 │
+│ ├─ 住所入力                 │
+│ └─ 住所検索結果（インライン）│
+│                            │
+│        [キャンセル] [作成]  │
+└─────────────────────────────┘
+```
+
+### 経路3: 個別取引からの紐付け
+
+`AssignCounterpartDialog` を使用（`transactions.length === 1`）
+
+#### 既存選択モード
+
+```
+┌──────────────────────────────────────────────────────┐
+│  取引先を紐付け                               [×]    │
+├──────────────────────┬───────────────────────────────┤
+│ Transaction情報      │ ┌─────────────────────────┐   │
+│                      │ │ [既存から選択] 新規作成  │   │
+│ 日付: 2024/01/15     │ └─────────────────────────┘   │
+│ 金額: ¥100,000       │                               │
+│ 摘要: 印刷費         │ CounterpartSelectorContent    │
+│                      │ ├─ 検索入力                   │
+│                      │ ├─ AI提案                     │
+│                      │ └─ 取引先一覧                 │
+│                      │                               │
+│              [キャンセル] [この取引先を紐付け]       │
+└──────────────────────┴───────────────────────────────┘
+```
+
+#### 新規作成モード
+
+```
+┌──────────────────────────────────────────────────────┐
+│  取引先を紐付け                               [×]    │
+├──────────────────────┬───────────────────────────────┤
+│ Transaction情報      │ ┌─────────────────────────┐   │
+│                      │ │ 既存から選択 [新規作成]  │   │
+│ 日付: 2024/01/15     │ └─────────────────────────┘   │
+│ 金額: ¥100,000       │                               │
+│ 摘要: 印刷費         │ CounterpartFormContent        │
+│                      │ ├─ 名前入力                   │
+│                      │ ├─ 住所入力                   │
+│                      │ └─ 住所検索結果（インライン）  │
+│                      │                               │
+│        [キャンセル] [作成して紐付け]                 │
+└──────────────────────┴───────────────────────────────┘
+```
+
+### 経路4: 一括取引からの紐付け
+
+`AssignCounterpartDialog` を使用（`transactions.length > 1`）
+
+#### 既存選択モード
+
+```
+┌──────────────────────────────────────────────────────┐
+│  一括紐付け                                   [×]    │
+├──────────────────────┬───────────────────────────────┤
+│ 選択中の取引 (5件)   │ ┌─────────────────────────┐   │
+│                      │ │ [既存から選択] 新規作成  │   │
+│ ┌──────────────────┐ │ └─────────────────────────┘   │
+│ │ 2024/01/15       │ │                               │
+│ │ ¥100,000 印刷費  │ │ CounterpartSelectorContent    │
+│ │                  │ │ ├─ 検索入力                   │
+│ │ 2024/01/20       │ │ ├─ AI提案（一括用）           │
+│ │ ¥50,000 配送料   │ │ └─ 取引先一覧                 │
+│ │ ...              │ │                               │
+│ └──────────────────┘ │                               │
+│                      │                               │
+│      [キャンセル] [すべてに紐付け (5件)]             │
+└──────────────────────┴───────────────────────────────┘
+```
+
+#### 新規作成モード
+
+```
+┌──────────────────────────────────────────────────────┐
+│  一括紐付け                                   [×]    │
+├──────────────────────┬───────────────────────────────┤
+│ 選択中の取引 (5件)   │ ┌─────────────────────────┐   │
+│                      │ │ 既存から選択 [新規作成]  │   │
+│ ┌──────────────────┐ │ └─────────────────────────┘   │
+│ │ 2024/01/15       │ │                               │
+│ │ ¥100,000 印刷費  │ │ CounterpartFormContent        │
+│ │ ...              │ │ ├─ 名前入力                   │
+│ └──────────────────┘ │ ├─ 住所入力                   │
+│                      │ └─ 住所検索結果（インライン）  │
+│                      │                               │
+│      [キャンセル] [作成してすべてに紐付け]           │
+└──────────────────────┴───────────────────────────────┘
+```
+
+## データフロー
+
+### 経路1: マスター画面からの新規作成
+
+```
+CounterpartMasterClient
+  └─ CounterpartFormDialog (mode: create)
+      └─ CounterpartFormContent
+          └─ onSubmit
+              └─ createCounterpartAction()
+                  └─ revalidatePath('/counterparts')
+                      └─ onSuccess()
+                          └─ Dialog close
+```
+
+### 経路2: マスター画面からの編集
+
+```
+CounterpartMasterClient
+  └─ CounterpartFormDialog (mode: edit)
+      └─ CounterpartFormContent (initialData)
+          └─ onSubmit
+              └─ updateCounterpartAction(id)
+                  └─ revalidatePath('/counterparts')
+                      └─ onSuccess()
+                          └─ Dialog close
+```
+
+### 経路3: 個別取引からの紐付け（既存選択）
+
+```
+CounterpartAssignmentClient
+  └─ TransactionWithCounterpartTable
+      └─ [紐付けボタン] click
+          └─ AssignCounterpartDialog
+              └─ AssignWithCounterpartContent (transactions: [1件])
+                  └─ CounterpartSelectorContent
+                      └─ onSelect
+                          └─ assignCounterpartAction(transactionId, counterpartId)
+                              └─ revalidatePath('/assign/counterparts')
+                                  └─ onSuccess()
+                                      └─ Dialog close
+```
+
+### 経路3: 個別取引からの紐付け（新規作成）
+
+```
+CounterpartAssignmentClient
+  └─ TransactionWithCounterpartTable
+      └─ [紐付けボタン] click
+          └─ AssignCounterpartDialog
+              └─ AssignWithCounterpartContent (transactions: [1件])
+                  └─ CounterpartFormContent
+                      └─ onSubmit
+                          └─ createCounterpartAction()
+                              └─ assignCounterpartAction(transactionId, newCounterpartId)
+                                  └─ revalidatePath('/assign/counterparts')
+                                      └─ onSuccess()
+                                          └─ Dialog close
+```
+
+### 経路4: 一括取引からの紐付け（既存選択）
+
+```
+CounterpartAssignmentClient
+  └─ [一括紐付けボタン] click
+      └─ AssignCounterpartDialog
+          └─ AssignWithCounterpartContent (transactions: [複数件])
+              └─ CounterpartSelectorContent
+                  └─ onSelect
+                      └─ bulkAssignCounterpartAction(transactionIds, counterpartId)
+                          └─ revalidatePath('/assign/counterparts')
+                              └─ onSuccess()
+                                  └─ Dialog close
+```
+
+### 経路4: 一括取引からの紐付け（新規作成）
+
+```
+CounterpartAssignmentClient
+  └─ [一括紐付けボタン] click
+      └─ AssignCounterpartDialog
+          └─ AssignWithCounterpartContent (transactions: [複数件])
+              └─ CounterpartFormContent
+                  └─ onSubmit
+                      └─ createCounterpartAction()
+                          └─ bulkAssignCounterpartAction(transactionIds, newCounterpartId)
+                              └─ revalidatePath('/assign/counterparts')
+                                  └─ onSuccess()
+                                      └─ Dialog close
+```
+
+## 廃止するコンポーネント
+
+以下のコンポーネントは新しい設計で置き換えられるため廃止：
+
+1. `AddressSearchDialog.tsx` - 機能は `CounterpartFormContent` 内にインライン化
+2. `CounterpartCombobox.tsx` - `AssignCounterpartDialog` + `AssignWithCounterpartContent` に置き換え
+3. `BulkAssignModal.tsx` - `AssignCounterpartDialog` に統合
+
+## マイグレーション計画
+
+### フェーズ1: 新コンポーネント実装
+
+1. `CounterpartFormContent.tsx` 実装（住所検索インライン化）
+2. `CounterpartSelectorContent.tsx` 実装
+3. `AssignWithCounterpartContent.tsx` 実装
+
+### フェーズ2: ラッパー実装と既存書き換え
+
+4. `CounterpartFormDialog.tsx` を新実装に書き換え（経路1,2）
+5. `AssignCounterpartDialog.tsx` 新規作成
+
+### フェーズ3: 呼び出し元更新
+
+6. `CounterpartAssignmentClient.tsx` 更新
+   - `CounterpartCombobox` → `AssignCounterpartDialog` に差し替え
+   - 一括紐付けボタン → `AssignCounterpartDialog` に差し替え
+7. `TransactionWithCounterpartTable.tsx` 更新
+
+### フェーズ4: 旧コンポーネント削除
+
+8. `AddressSearchDialog.tsx` 削除
+9. `CounterpartCombobox.tsx` 削除
+10. `BulkAssignModal.tsx` 削除
+11. `CounterpartForm.tsx` 削除（機能は `CounterpartFormContent` に統合済み）
+
+## 期待される効果
+
+### コード品質
+
+- Dialog入れ子のアンチパターン解消
+- 重複コードの削減（3箇所 → 1箇所）
+- 単一/一括の統合によるロジック一元化
+
+### 保守性
+
+- 機能追加・修正が1箇所で済む
+- テストケース削減（重複ロジックがないため）
+- バグ発生箇所の特定が容易
+
+### UX
+
+- すべての経路で一貫した操作体験
+- 住所検索がインライン化され、ダイアログ切り替えの煩雑さ解消
+- 単一/一括で同じUIのため学習コスト低減


### PR DESCRIPTION
## 概要

取引先作成・編集の4つの経路を統合し、Dialog入れ子のアンチパターンを解消する設計書を作成しました。

## 背景

現状、取引先の作成には以下の4つの経路が存在し、実装が分散している：
1. マスター画面からの新規作成
2. マスター画面からの既存データ編集
3. 個別取引の紐付け
4. 一括取引の紐付け

### 主な問題点
- Dialog→Dialogの入れ子構造によるUX・メンテナンス性の悪化
- 取引先作成フォームが3箇所に散在（重複実装）
- 個別紐付けと一括紐付けが別実装

## 設計内容

### 1. 関心の分離
- **機能コンポーネント**: ビジネスロジックと入力制御
- **プレゼンテーションラッパー**: Dialogとして表示する責務のみ

### 2. 統合の原則
- 単一紐付けを一括紐付けのサブセット（`transactions.length === 1`）として統合
- 住所検索をインライン化し、Dialog入れ子を排除
- すべての経路で同じ機能コンポーネントを再利用

### 3. 主要コンポーネント
- `CounterpartFormContent`: 取引先作成・編集フォーム（住所検索インライン）
- `CounterpartSelectorContent`: 既存取引先選択UI（AI提案機能付き）
- `AssignWithCounterpartContent`: 2カラム紐付けUI（単一/一括共通）
- `CounterpartFormDialog`: マスター画面用ラッパー
- `AssignCounterpartDialog`: 紐付け画面用ラッパー（大型サイズ: 95vw）

### 4. 特徴
- AI提案機能を単一・一括の両方で動作させる
- 紐付けDialogは画面いっぱい（max-w-[95vw]）で操作性を確保
- マイグレーション計画により段階的な移行が可能

## 期待される効果

### コード品質
- Dialog入れ子のアンチパターン解消
- 重複コードの削減（3箇所 → 1箇所）
- 単一/一括の統合によるロジック一元化

### 保守性
- 機能追加・修正が1箇所で済む
- バグ発生箇所の特定が容易

### UX
- すべての経路で一貫した操作体験
- 住所検索がインライン化され、ダイアログ切り替えの煩雑さ解消
- 単一/一括で同じUIのため学習コスト低減

## 関連ファイル

- `docs/20251223_1017_取引先作成UI統合設計.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)