### PR TITLE
fix: TransactionからDBのcounterpart情報を取得するように修正

### DIFF
--- a/admin/src/server/contexts/report/infrastructure/repositories/prisma-report-transaction.repository.ts
+++ b/admin/src/server/contexts/report/infrastructure/repositories/prisma-report-transaction.repository.ts
@@ -237,6 +237,16 @@ export class PrismaReportTransactionRepository implements IReportTransactionRepo
         debitAmount: true,
         creditAmount: true,
         transactionDate: true,
+        transactionCounterparts: {
+          select: {
+            counterpart: {
+              select: {
+                name: true,
+                address: true,
+              },
+            },
+          },
+        },
       },
     });
 
@@ -249,9 +259,8 @@ export class PrismaReportTransactionRepository implements IReportTransactionRepo
       debitAmount: Number(t.debitAmount),
       creditAmount: Number(t.creditAmount),
       transactionDate: t.transactionDate,
-      // TODO: CounterPartテーブル実装後に実際の値を取得する
-      counterpartName: "（仮）取引先名称",
-      counterpartAddress: "（仮）東京都千代田区永田町1-1-1",
+      counterpartName: t.transactionCounterparts[0]?.counterpart.name ?? "",
+      counterpartAddress: t.transactionCounterparts[0]?.counterpart.address ?? "",
     }));
   }
 
@@ -278,6 +287,16 @@ export class PrismaReportTransactionRepository implements IReportTransactionRepo
         debitAmount: true,
         creditAmount: true,
         transactionDate: true,
+        transactionCounterparts: {
+          select: {
+            counterpart: {
+              select: {
+                name: true,
+                address: true,
+              },
+            },
+          },
+        },
       },
     });
 
@@ -290,9 +309,8 @@ export class PrismaReportTransactionRepository implements IReportTransactionRepo
       debitAmount: Number(t.debitAmount),
       creditAmount: Number(t.creditAmount),
       transactionDate: t.transactionDate,
-      // TODO: CounterPartテーブル実装後に実際の値を取得する
-      counterpartName: "（仮）本部名称",
-      counterpartAddress: "（仮）東京都千代田区永田町1-1-1",
+      counterpartName: t.transactionCounterparts[0]?.counterpart.name ?? "",
+      counterpartAddress: t.transactionCounterparts[0]?.counterpart.address ?? "",
     }));
   }
 
@@ -355,6 +373,16 @@ export class PrismaReportTransactionRepository implements IReportTransactionRepo
         debitAmount: true,
         creditAmount: true,
         transactionDate: true,
+        transactionCounterparts: {
+          select: {
+            counterpart: {
+              select: {
+                name: true,
+                address: true,
+              },
+            },
+          },
+        },
       },
     });
 
@@ -367,9 +395,8 @@ export class PrismaReportTransactionRepository implements IReportTransactionRepo
       debitAmount: Number(t.debitAmount),
       creditAmount: Number(t.creditAmount),
       transactionDate: t.transactionDate,
-      // TODO: CounterPartテーブル実装後に実際の値を取得する
-      counterpartName: "（仮）取引先名称",
-      counterpartAddress: "（仮）東京都千代田区永田町1-1-1",
+      counterpartName: t.transactionCounterparts[0]?.counterpart.name ?? "",
+      counterpartAddress: t.transactionCounterparts[0]?.counterpart.address ?? "",
     }));
   }
 
@@ -396,6 +423,16 @@ export class PrismaReportTransactionRepository implements IReportTransactionRepo
         debitAmount: true,
         creditAmount: true,
         transactionDate: true,
+        transactionCounterparts: {
+          select: {
+            counterpart: {
+              select: {
+                name: true,
+                address: true,
+              },
+            },
+          },
+        },
       },
     });
 
@@ -408,9 +445,8 @@ export class PrismaReportTransactionRepository implements IReportTransactionRepo
       debitAmount: Number(t.debitAmount),
       creditAmount: Number(t.creditAmount),
       transactionDate: t.transactionDate,
-      // TODO: CounterPartテーブル実装後に実際の値を取得する
-      counterpartName: "（仮）取引先名称",
-      counterpartAddress: "（仮）東京都千代田区永田町1-1-1",
+      counterpartName: t.transactionCounterparts[0]?.counterpart.name ?? "",
+      counterpartAddress: t.transactionCounterparts[0]?.counterpart.address ?? "",
     }));
   }
 
@@ -437,6 +473,16 @@ export class PrismaReportTransactionRepository implements IReportTransactionRepo
         debitAmount: true,
         creditAmount: true,
         transactionDate: true,
+        transactionCounterparts: {
+          select: {
+            counterpart: {
+              select: {
+                name: true,
+                address: true,
+              },
+            },
+          },
+        },
       },
     });
 
@@ -449,9 +495,8 @@ export class PrismaReportTransactionRepository implements IReportTransactionRepo
       debitAmount: Number(t.debitAmount),
       creditAmount: Number(t.creditAmount),
       transactionDate: t.transactionDate,
-      // TODO: CounterPartテーブル実装後に実際の値を取得する
-      counterpartName: "（仮）取引先名称",
-      counterpartAddress: "（仮）東京都千代田区永田町1-1-1",
+      counterpartName: t.transactionCounterparts[0]?.counterpart.name ?? "",
+      counterpartAddress: t.transactionCounterparts[0]?.counterpart.address ?? "",
     }));
   }
 
@@ -478,6 +523,16 @@ export class PrismaReportTransactionRepository implements IReportTransactionRepo
         debitAmount: true,
         creditAmount: true,
         transactionDate: true,
+        transactionCounterparts: {
+          select: {
+            counterpart: {
+              select: {
+                name: true,
+                address: true,
+              },
+            },
+          },
+        },
       },
     });
 
@@ -490,9 +545,8 @@ export class PrismaReportTransactionRepository implements IReportTransactionRepo
       debitAmount: Number(t.debitAmount),
       creditAmount: Number(t.creditAmount),
       transactionDate: t.transactionDate,
-      // TODO: CounterPartテーブル実装後に実際の値を取得する
-      counterpartName: "（仮）取引先名称",
-      counterpartAddress: "（仮）東京都千代田区永田町1-1-1",
+      counterpartName: t.transactionCounterparts[0]?.counterpart.name ?? "",
+      counterpartAddress: t.transactionCounterparts[0]?.counterpart.address ?? "",
     }));
   }
 


### PR DESCRIPTION
## Summary
- ReportTransactionRepositoryの各メソッドで、ハードコードされていたcounterpart情報をDBから取得するように修正
- TransactionCounterpartリレーションを使用してN+1を回避
- リレーションがない場合は空文字列にフォールバック

## 修正対象メソッド
- `findPoliticalActivityExpenseTransactions`（政治活動費共通ヘルパー）
- `findLoanIncomeTransactions`（借入金）
- `findGrantIncomeTransactions`（交付金）
- `findUtilityExpenseTransactions`（光熱水費）
- `findSuppliesExpenseTransactions`（備品・消耗品費）
- `findOfficeExpenseTransactions`（事務所費）
- `findOrganizationExpenseTransactions`（組織活動費）

## Test plan
- [ ] 型チェック通過確認済み
- [ ] 報告書プレビュー画面でcounterpartが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * トランザクション情報に相手方の名前と住所が正しく表示されるようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->