### PR TITLE
docs: カウンターパート個別ページの設計ドキュメントを追加

### DIFF
--- a/docs/20251224_1735_カウンターパート個別ページ設計.md
+++ b/docs/20251224_1735_カウンターパート個別ページ設計.md
@@ -1,0 +1,693 @@
+# カウンターパート個別ページ設計
+
+## 概要
+
+取引先（Counterpart）マスタ管理の一覧ページ（[admin/src/app/(auth)/counterparts/page.tsx](admin/src/app/(auth)/counterparts/page.tsx)）の配下に、個別のカウンターパートの詳細情報を表示・編集するページを追加する。
+
+## 背景と目的
+
+### 現状
+
+- カウンターパート一覧ページ（`/counterparts`）では、取引先の一覧表示・新規作成・編集・削除が可能
+- 各カウンターパートがどの取引（Transaction）で使用されているかを確認する機能がない
+- カウンターパートの編集はダイアログ内でのみ可能で、詳細を確認する専用ページがない
+
+### 目的
+
+1. 個別カウンターパートの情報を専用ページで表示・編集できるようにする
+2. そのカウンターパートが紐づいている取引を一覧で表示し、操作できるようにする
+3. カウンターパートの利用状況を可視化し、管理しやすくする
+
+## スコープ
+
+### 対象機能
+
+1. カウンターパート情報の表示・編集（一覧ページのダイアログを流用）
+2. 紐づいている取引の一覧表示（`TransactionWithCounterpartTable` を流用）
+3. 取引の紐付け解除
+4. 取引への別カウンターパートの紐付け変更
+
+### 対象外
+
+- カウンターパートのマージ機能
+- 取引の一括編集機能（既存の `/assign/counterparts` ページで実施）
+- カウンターパートの削除（一覧ページから可能）
+
+## URL設計
+
+```
+/counterparts           # 一覧ページ（既存）
+/counterparts/[id]      # 個別詳細ページ（新規）
+```
+
+例:
+- `/counterparts/123` - ID=123のカウンターパート詳細ページ
+
+## ページレイアウト
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ ← 一覧に戻る                                                          │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                       │
+│ ┌─ カウンターパート情報 ───────────────────────────────────────┐   │
+│ │                                                                 │   │
+│ │ 名前:   ○○商店                                      [編集]    │   │
+│ │ 住所:   東京都渋谷区〇〇1-2-3                                  │   │
+│ │                                                                 │   │
+│ │ 作成日: 2024-12-15                                              │   │
+│ │ 更新日: 2024-12-20                                              │   │
+│ │ 使用回数: 12件                                                  │   │
+│ │                                                                 │   │
+│ └─────────────────────────────────────────────────────────────┘   │
+│                                                                       │
+│ ┌─ 紐づいている取引 ───────────────────────────────────────────┐ │
+│ │                                                                   │ │
+│ │ ┌─ フィルタ ─────────────────────────────────────────────┐   │ │
+│ │ │ [政治団体 ▼]  [報告年 ▼]                                  │   │ │
+│ │ └───────────────────────────────────────────────────────┘   │ │
+│ │                                                                   │ │
+│ │ 12件の取引                                                        │ │
+│ │                                                                   │ │
+│ │ ┌─ Transaction一覧テーブル ──────────────────────────────┐  │ │
+│ │ │ [☑] │ 日付       │ 金額      │ カテゴリ    │ 取引先     │  │ │
+│ │ │─────┼───────────┼──────────┼────────────┼───────────│  │ │
+│ │ │ [☑] │ 2024-06-01 │ ¥5,000   │ 事務所費    │ ○○商店▼  │  │ │
+│ │ │ [☑] │ 2024-06-15 │ ¥5,200   │ 事務所費    │ ○○商店▼  │  │ │
+│ │ │ [ ] │ 2024-07-01 │ ¥5,100   │ 事務所費    │ ○○商店▼  │  │ │
+│ │ │                                                             │  │ │
+│ │ │ [< 前へ]  1 / 1  [次へ >]                                  │  │ │
+│ │ └─────────────────────────────────────────────────────┘  │ │
+│ │                                                                   │ │
+│ │ 選択中: 2件  [一括紐付け変更]  [一括紐付け解除]                 │ │
+│ │                                                                   │ │
+│ └───────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### セクション詳細
+
+#### 1. カウンターパート情報セクション
+
+- **表示項目**:
+  - 名前（必須）
+  - 住所（任意）
+  - 作成日
+  - 更新日
+  - 使用回数（このカウンターパートが紐づいている取引の総数）
+
+- **編集ボタン**:
+  - クリックすると既存の `CounterpartFormDialog` がモーダルで開く
+  - 編集・保存後はページをリフレッシュ
+
+#### 2. 紐づいている取引セクション
+
+- **フィルタ機能**:
+  - 政治団体選択（ドロップダウン）
+  - 報告年選択（ドロップダウン）
+
+- **取引一覧テーブル**:
+  - `TransactionWithCounterpartTable` コンポーネントを流用
+  - ソート機能（日付・金額・カテゴリ）
+  - ページネーション（50件/ページ）
+  - 行選択機能（チェックボックス）
+
+- **一括操作**:
+  - 選択した取引に対して別のカウンターパートを一括紐付け変更
+  - 選択した取引の紐付けを一括解除
+
+## アーキテクチャ設計
+
+### ディレクトリ構成
+
+```
+admin/src/
+├── app/(auth)/counterparts/
+│   ├── page.tsx                 # 一覧ページ（既存）
+│   └── [id]/
+│       └── page.tsx             # 個別詳細ページ（新規）
+│
+├── client/components/counterparts/
+│   ├── CounterpartMasterClient.tsx          # 一覧画面Client（既存）
+│   ├── CounterpartFormDialog.tsx            # 編集ダイアログ（既存、流用）
+│   ├── CounterpartDetailClient.tsx          # 詳細画面Client（新規）
+│   └── CounterpartTransactionTable.tsx      # 詳細画面用テーブルラッパー（新規）
+│
+├── server/contexts/report/
+│   ├── domain/
+│   │   └── models/
+│   │       └── counterpart.ts               # 既存
+│   │
+│   ├── infrastructure/repositories/
+│   │   └── prisma-transaction.repository.ts # 拡張
+│   │
+│   ├── application/usecases/
+│   │   └── get-counterpart-transactions-usecase.ts  # 新規
+│   │
+│   └── presentation/
+│       ├── loaders/
+│       │   └── counterpart-detail-loader.ts         # 新規
+│       └── actions/
+│           └── bulk-unassign-counterpart.ts         # 新規（一括解除）
+```
+
+### データフロー
+
+#### ページ表示
+
+```
+User → /counterparts/[id]
+  → CounterpartDetailPage (Server Component)
+    → loadCounterpartDetailData(id)
+      → GetCounterpartByIdUsecase.execute(id)
+        → PrismaCounterpartRepository.findById(id)
+      → loadCounterpartUsageData(id)
+    → loadTransactionsWithCounterpartsData({ counterpartId: id })
+      → GetCounterpartTransactionsUsecase.execute({ counterpartId })
+        → PrismaTransactionRepository.findByCounterpart(id)
+  → Render CounterpartDetailClient
+```
+
+#### カウンターパート編集
+
+```
+User → [編集] ボタンクリック
+  → CounterpartFormDialog モーダル表示
+    → 既存の updateCounterpartAction を利用
+      → UpdateCounterpartUsecase.execute()
+    → revalidatePath("/counterparts/[id]")
+  → ページリフレッシュ
+```
+
+#### 紐付け解除
+
+```
+User → 取引を選択（単一または複数） → [紐付け解除] ボタンクリック
+  → bulkUnassignCounterpartAction({ transactionIds })
+    → Prisma transaction
+      → TransactionCounterpart.deleteMany({ where: { transactionId: { in: ids } } })
+    → revalidatePath("/counterparts/[id]")
+  → ページリフレッシュ
+```
+
+※単一の場合も一括解除Actionを使用（transactionIds配列に1件のみ渡す）
+
+#### 一括紐付け変更
+
+```
+User → 複数取引を選択 → [一括紐付け変更] ボタンクリック
+  → AssignCounterpartDialog モーダル表示
+    → 既存の bulkAssignCounterpartAction を利用
+      → BulkAssignCounterpartUsecase.execute()
+    → revalidatePath("/counterparts/[id]")
+```
+
+## 実装内容
+
+### 1. Server Component: Page
+
+**ファイル**: `admin/src/app/(auth)/counterparts/[id]/page.tsx`
+
+```typescript
+import "server-only";
+
+import { notFound } from "next/navigation";
+import { loadCounterpartByIdData, loadCounterpartUsageData } from "@/server/contexts/report/presentation/loaders/counterparts-loader";
+import { loadCounterpartTransactionsData } from "@/server/contexts/report/presentation/loaders/counterpart-detail-loader";
+import { loadPoliticalOrganizationsData } from "@/server/contexts/shared/presentation/loaders/load-political-organizations-data";
+import { loadAllCounterpartsData } from "@/server/contexts/report/presentation/loaders/counterparts-loader";
+import { CounterpartDetailClient } from "@/client/components/counterparts/CounterpartDetailClient";
+
+interface CounterpartDetailPageProps {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{
+    orgId?: string;
+    year?: string;
+    sort?: string;
+    order?: string;
+    page?: string;
+  }>;
+}
+
+export default async function CounterpartDetailPage({
+  params,
+  searchParams,
+}: CounterpartDetailPageProps) {
+  const { id } = await params;
+  const searchParamsResolved = await searchParams;
+
+  // カウンターパート情報を取得
+  const counterpart = await loadCounterpartByIdData(id);
+  if (!counterpart) {
+    notFound();
+  }
+
+  const usageCount = await loadCounterpartUsageData(id);
+
+  // 政治団体一覧を取得
+  const organizations = await loadPoliticalOrganizationsData();
+
+  // 全カウンターパート一覧を取得（紐付け変更用）
+  const allCounterparts = await loadAllCounterpartsData();
+
+  // フィルタパラメータの解析
+  const politicalOrganizationId = searchParamsResolved.orgId || organizations[0]?.id || "";
+  const financialYear = searchParamsResolved.year
+    ? Number.parseInt(searchParamsResolved.year, 10)
+    : new Date().getFullYear();
+  const sortField =
+    (searchParamsResolved.sort as "transactionDate" | "debitAmount" | "categoryKey") ||
+    "transactionDate";
+  const sortOrder = (searchParamsResolved.order as "asc" | "desc") || "desc";
+  const parsedPage = searchParamsResolved.page ? Number.parseInt(searchParamsResolved.page, 10) : 1;
+  const page = Number.isNaN(parsedPage) || parsedPage < 1 ? 1 : parsedPage;
+  const perPage = 50;
+
+  // 紐づいている取引を取得
+  const transactionsData = await loadCounterpartTransactionsData({
+    counterpartId: id,
+    politicalOrganizationId: politicalOrganizationId || undefined,
+    financialYear,
+    page,
+    perPage,
+    sortField,
+    sortOrder,
+  });
+
+  return (
+    <CounterpartDetailClient
+      counterpart={{ ...counterpart, usageCount }}
+      transactions={transactionsData.transactions}
+      total={transactionsData.total}
+      page={transactionsData.page}
+      perPage={transactionsData.perPage}
+      organizations={organizations}
+      allCounterparts={allCounterparts}
+      initialFilters={{
+        politicalOrganizationId,
+        financialYear,
+        sortField,
+        sortOrder,
+      }}
+    />
+  );
+}
+```
+
+### 2. Client Component: CounterpartDetailClient
+
+**ファイル**: `admin/src/client/components/counterparts/CounterpartDetailClient.tsx`
+
+主な責務:
+- カウンターパート情報の表示と編集ダイアログの管理
+- フィルタ状態の管理とURL更新（政治団体・年度のみ）
+- 取引一覧の表示（`TransactionWithCounterpartTable` を流用）
+- 行選択状態の管理
+- 一括操作モーダルの管理
+
+### 3. Loader: counterpart-detail-loader
+
+**ファイル**: `admin/src/server/contexts/report/presentation/loaders/counterpart-detail-loader.ts`
+
+```typescript
+import "server-only";
+
+import { unstable_cache } from "next/cache";
+import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
+import { PrismaTransactionRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-transaction.repository";
+import { GetCounterpartTransactionsUsecase } from "@/server/contexts/report/application/usecases/get-counterpart-transactions-usecase";
+import type { TransactionWithCounterpart } from "@/server/contexts/report/domain/models/transaction-with-counterpart";
+
+export interface LoadCounterpartTransactionsInput {
+  counterpartId: string;
+  politicalOrganizationId?: string;
+  financialYear?: number;
+  page: number;
+  perPage: number;
+  sortField?: "transactionDate" | "debitAmount" | "categoryKey";
+  sortOrder?: "asc" | "desc";
+}
+
+export interface LoadCounterpartTransactionsResult {
+  transactions: TransactionWithCounterpart[];
+  total: number;
+  page: number;
+  perPage: number;
+}
+
+export async function loadCounterpartTransactionsData(
+  input: LoadCounterpartTransactionsInput,
+): Promise<LoadCounterpartTransactionsResult> {
+  const offset = (input.page - 1) * input.perPage;
+
+  const cachedLoader = unstable_cache(
+    async (): Promise<LoadCounterpartTransactionsResult> => {
+      const repository = new PrismaTransactionRepository(prisma);
+      const usecase = new GetCounterpartTransactionsUsecase(repository);
+
+      const result = await usecase.execute({
+        counterpartId: input.counterpartId,
+        politicalOrganizationId: input.politicalOrganizationId,
+        financialYear: input.financialYear,
+        limit: input.perPage,
+        offset,
+        sortField: input.sortField,
+        sortOrder: input.sortOrder,
+      });
+
+      return {
+        transactions: result.transactions,
+        total: result.total,
+        page: input.page,
+        perPage: input.perPage,
+      };
+    },
+    [
+      "counterpart-transactions",
+      input.counterpartId,
+      input.politicalOrganizationId || "",
+      String(input.financialYear || ""),
+      String(input.page),
+      String(input.perPage),
+      input.sortField || "",
+      input.sortOrder || "",
+    ],
+    { revalidate: 60 },
+  );
+
+  return cachedLoader();
+}
+```
+
+### 4. Usecase: get-counterpart-transactions-usecase
+
+**ファイル**: `admin/src/server/contexts/report/application/usecases/get-counterpart-transactions-usecase.ts`
+
+```typescript
+import type { ITransactionRepository } from "@/server/contexts/report/domain/repositories/transaction-repository.interface";
+import type {
+  TransactionWithCounterpart,
+  TransactionWithCounterpartResult,
+} from "@/server/contexts/report/domain/models/transaction-with-counterpart";
+
+export interface GetCounterpartTransactionsInput {
+  counterpartId: string;
+  politicalOrganizationId?: string;
+  financialYear?: number;
+  limit?: number;
+  offset?: number;
+  sortField?: "transactionDate" | "debitAmount" | "categoryKey";
+  sortOrder?: "asc" | "desc";
+}
+
+export class GetCounterpartTransactionsUsecase {
+  constructor(private transactionRepository: ITransactionRepository) {}
+
+  async execute(input: GetCounterpartTransactionsInput): Promise<TransactionWithCounterpartResult> {
+    return this.transactionRepository.findByCounterpart({
+      counterpartId: input.counterpartId,
+      politicalOrganizationId: input.politicalOrganizationId,
+      financialYear: input.financialYear,
+      limit: input.limit,
+      offset: input.offset,
+      sortField: input.sortField,
+      sortOrder: input.sortOrder,
+    });
+  }
+}
+```
+
+### 5. Repository拡張: findByCounterpart
+
+**ファイル**: `admin/src/server/contexts/report/infrastructure/repositories/prisma-transaction.repository.ts`
+
+既存のRepositoryに以下のメソッドを追加:
+
+```typescript
+async findByCounterpart(
+  filters: {
+    counterpartId: string;
+    politicalOrganizationId?: string;
+    financialYear?: number;
+    limit?: number;
+    offset?: number;
+    sortField?: "transactionDate" | "debitAmount" | "categoryKey";
+    sortOrder?: "asc" | "desc";
+  }
+): Promise<TransactionWithCounterpartResult> {
+  const where = this.buildCounterpartFilterWhere(filters);
+
+  const [transactions, total] = await Promise.all([
+    this.prisma.transaction.findMany({
+      where,
+      include: {
+        transactionCounterparts: {
+          include: {
+            counterpart: true,
+          },
+        },
+      },
+      orderBy: this.buildOrderBy(filters.sortField, filters.sortOrder),
+      take: filters.limit,
+      skip: filters.offset,
+    }),
+    this.prisma.transaction.count({ where }),
+  ]);
+
+  return {
+    transactions: transactions.map((tx) => this.mapToTransactionWithCounterpart(tx)),
+    total,
+  };
+}
+
+private buildCounterpartFilterWhere(filters: {
+  counterpartId: string;
+  politicalOrganizationId?: string;
+  financialYear?: number;
+}) {
+  const counterpartBigIntId = this.parseBigIntId(filters.counterpartId);
+  if (counterpartBigIntId === null) {
+    throw new Error(`無効なカウンターパートID: ${filters.counterpartId}`);
+  }
+
+  const where: any = {
+    transactionCounterparts: {
+      some: {
+        counterpartId: counterpartBigIntId,
+      },
+    },
+  };
+
+  if (filters.politicalOrganizationId) {
+    const orgBigIntId = this.parseBigIntId(filters.politicalOrganizationId);
+    if (orgBigIntId !== null) {
+      where.politicalOrganizationId = orgBigIntId;
+    }
+  }
+
+  if (filters.financialYear) {
+    where.financialYear = filters.financialYear;
+  }
+
+  return where;
+}
+```
+
+### 6. Action: bulk-unassign-counterpart
+
+**ファイル**: `admin/src/server/contexts/report/presentation/actions/bulk-unassign-counterpart.ts`
+
+```typescript
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
+
+interface BulkUnassignCounterpartInput {
+  transactionIds: string[];
+}
+
+interface BulkUnassignCounterpartResult {
+  success: boolean;
+  errors?: string[];
+}
+
+export async function bulkUnassignCounterpartAction(
+  input: BulkUnassignCounterpartInput,
+): Promise<BulkUnassignCounterpartResult> {
+  try {
+    const transactionBigIntIds = input.transactionIds.map((id) => BigInt(id));
+
+    await prisma.transactionCounterpart.deleteMany({
+      where: {
+        transactionId: { in: transactionBigIntIds },
+      },
+    });
+
+    revalidatePath("/counterparts/[id]", "page");
+
+    return { success: true };
+  } catch (error) {
+    console.error("Failed to bulk unassign counterparts:", error);
+    return {
+      success: false,
+      errors: ["一括紐付け解除に失敗しました"],
+    };
+  }
+}
+```
+
+## 既存コンポーネントの流用
+
+### 1. CounterpartFormDialog
+
+既存の [admin/src/client/components/counterparts/CounterpartFormDialog.tsx](admin/src/client/components/counterparts/CounterpartFormDialog.tsx) をそのまま利用。
+
+編集成功後に `onSuccess` コールバックで `router.refresh()` を実行してページをリフレッシュ。
+
+### 2. TransactionWithCounterpartTable
+
+既存の [admin/src/client/components/counterpart-assignment/TransactionWithCounterpartTable.tsx](admin/src/client/components/counterpart-assignment/TransactionWithCounterpartTable.tsx) をそのまま利用。
+
+個別の紐付け解除は行選択で対応し、単一解除も一括解除Action（`bulkUnassignCounterpartAction`）を使用。
+
+### 3. AssignCounterpartDialog
+
+既存の [admin/src/client/components/counterpart-assignment/AssignCounterpartDialog.tsx](admin/src/client/components/counterpart-assignment/AssignCounterpartDialog.tsx) をそのまま利用。
+
+一括紐付け変更時に使用。
+
+## UI/UX
+
+### ナビゲーション
+
+- 一覧ページ（`/counterparts`）から個別詳細ページ（`/counterparts/[id]`）へリンク
+- 個別詳細ページから「← 一覧に戻る」リンク
+
+### フィルタ機能
+
+- 政治団体・報告年でフィルタ可能
+- フィルタ変更時はURLクエリパラメータを更新してサーバー側で再フェッチ
+
+### ソート機能
+
+- 日付・金額・カテゴリでソート可能
+- クリックでASC/DESC切り替え
+
+### 一括操作
+
+- チェックボックスで複数行選択
+- 選択中の件数を表示
+- 「一括紐付け変更」ボタン: `AssignCounterpartDialog` を開く
+- 「一括紐付け解除」ボタン: 確認ダイアログ表示後に `bulkUnassignCounterpartAction` を実行
+
+### 楽観的UI更新
+
+- 紐付け解除・変更時は楽観的UI更新を行い、即座にUIを更新
+- エラー時はロールバック
+
+## エラーハンドリング
+
+### 1. カウンターパートが存在しない場合
+
+- `notFound()` を呼び出して404ページを表示
+
+### 2. 紐付け解除・変更失敗
+
+- Server Actionからエラーメッセージを返す
+- クライアント側でToast通知を表示
+- 楽観的UI更新をロールバック
+
+## セキュリティ
+
+### 認可
+
+- カウンターパート情報の取得・編集は認証済みユーザーのみ
+- 取引データは所属する政治団体のデータのみアクセス可能
+
+### バリデーション
+
+- カウンターパートID・取引IDの形式チェック（BigInt変換可能か）
+- 存在チェック
+
+## テストシナリオ
+
+### 1. ページ表示
+
+- [ ] カウンターパート情報が正しく表示される
+- [ ] 使用回数が正しく表示される
+- [ ] 紐づいている取引が一覧表示される
+- [ ] 存在しないIDでアクセスすると404ページが表示される
+
+### 2. カウンターパート編集
+
+- [ ] 編集ボタンをクリックするとダイアログが開く
+- [ ] 編集・保存後にページがリフレッシュされる
+
+### 3. 取引フィルタ
+
+- [ ] 政治団体でフィルタできる
+- [ ] 報告年でフィルタできる
+- [ ] ソート機能が動作する
+- [ ] ページネーション機能が動作する
+
+### 4. 紐付け解除
+
+- [ ] 取引を選択して紐付けを解除できる（単一・複数どちらも）
+- [ ] 解除後にページがリフレッシュされる
+
+### 5. 紐付け変更
+
+- [ ] 単一取引のカウンターパートを変更できる
+- [ ] 複数取引を選択して一括変更できる
+- [ ] 変更後にページがリフレッシュされる
+
+## 実装順序
+
+### フェーズ1: 基本表示
+
+1. Server Component: `CounterpartDetailPage`
+2. Loader: `loadCounterpartTransactionsData`
+3. Usecase: `GetCounterpartTransactionsUsecase`
+4. Repository拡張: `findByCounterpart`
+5. Client Component: `CounterpartDetailClient`（編集・一括操作なし）
+
+**動作確認**:
+- [ ] カウンターパート情報が表示される
+- [ ] 紐づいている取引が一覧表示される
+- [ ] フィルタ・ソート・ページネーションが動作する
+
+### フェーズ2: 編集機能
+
+1. `CounterpartFormDialog` の統合
+2. 編集成功後のリフレッシュ処理
+
+**動作確認**:
+- [ ] 編集ボタンでダイアログが開く
+- [ ] 編集・保存ができる
+- [ ] 保存後にページがリフレッシュされる
+
+### フェーズ3: 紐付け解除・変更
+
+1. Action: `bulkUnassignCounterpartAction`（単一・複数どちらも対応）
+2. 行選択機能の実装
+3. 一括操作ボタンの実装
+4. `AssignCounterpartDialog` の統合
+
+**動作確認**:
+- [ ] 紐付け解除ができる（単一・複数どちらも）
+- [ ] 一括紐付け変更ができる
+
+## 制限事項
+
+- カウンターパートのマージ機能は含まない
+- 取引の新規作成・削除は対象外（既存の `/assign/counterparts` ページで実施）
+- 取引の詳細編集は対象外
+- フィルタは政治団体と年度のみで、カテゴリや検索キーワードでのフィルタは含まない
+
+## 参考資料
+
+- [取引先情報管理機能設計](docs/20251216_1430_取引先情報管理機能設計.md)
+- [admin/src/app/(auth)/counterparts/page.tsx](admin/src/app/(auth)/counterparts/page.tsx)
+- [admin/src/client/components/counterpart-assignment/TransactionWithCounterpartTable.tsx](admin/src/client/components/counterpart-assignment/TransactionWithCounterpartTable.tsx)
+- [admin/src/client/components/counterparts/CounterpartFormDialog.tsx](admin/src/client/components/counterparts/CounterpartFormDialog.tsx)


### PR DESCRIPTION
## 概要

カウンターパートマスタ管理の個別詳細ページ（`/counterparts/[id]`）に関する設計ドキュメントを作成しました。

## 主な内容

### 機能概要
- カウンターパート情報の表示・編集機能
- そのカウンターパートに紐づいている取引の一覧表示
- 取引の紐付け解除・変更機能（単一・一括どちらも対応）

### フィルタ機能
- 政治団体
- 報告年

### 実装計画
- **新規実装**: 5ファイル
  - Server Component（ページ）
  - Client Component（詳細画面）
  - Loader（取引データ取得）
  - Usecase（ビジネスロジック）
  - Action（一括紐付け解除）
- **変更**: 1ファイル
  - Repository（findByCounterpartメソッド追加）
- **流用**: 3ファイル（既存コンポーネントをそのまま利用）

### 実装順序
1. フェーズ1: 基本表示
2. フェーズ2: 編集機能
3. フェーズ3: 紐付け解除・変更

## 関連資料

設計ドキュメント: `docs/20251224_1735_カウンターパート個別ページ設計.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)