### PR TITLE
fix: SYUUSHI07_01にSHEETタグを追加し、SYUUSHI_FLGの余分なネストを削除

### DIFF
--- a/admin/src/server/contexts/report/domain/services/profile-serializer.ts
+++ b/admin/src/server/contexts/report/domain/services/profile-serializer.ts
@@ -17,7 +17,8 @@ import type {
  */
 export function serializeProfileSection(profile: OrganizationReportProfile): XMLBuilder {
   const frag = fragment();
-  const root = frag.ele("SYUUSHI07_01");
+  const syuushi0701 = frag.ele("SYUUSHI07_01");
+  const root = syuushi0701.ele("SHEET");
   const details = profile.details;
 
   root.ele("HOUKOKU_NEN").txt(profile.financialYear.toString());

--- a/admin/src/server/contexts/report/domain/services/report-serializer.ts
+++ b/admin/src/server/contexts/report/domain/services/report-serializer.ts
@@ -213,8 +213,8 @@ function buildSyuushiFlgSection(availableFormIds: string[]): XMLBuilder {
     .padEnd(FLAG_STRING_LENGTH, "0")
     .slice(0, FLAG_STRING_LENGTH);
 
-  const frag = create().ele("SYUUSHI_FLG");
-  frag.ele("SYUUSHI_UMU_FLG").ele("SYUUSHI_UMU").txt(flagString);
+  const frag = create().ele("SYUUSHI_UMU_FLG");
+  frag.ele("SYUUSHI_UMU").txt(flagString);
 
   return frag;
 }

--- a/admin/tests/server/contexts/report/application/usecases/xml-export-usecase.test.ts
+++ b/admin/tests/server/contexts/report/application/usecases/xml-export-usecase.test.ts
@@ -223,8 +223,6 @@ describe("XmlExportUsecase", () => {
         financialYear: 2024,
       });
 
-      // SYUUSHI_FLG should be present
-      expect(result.xml).toContain("<SYUUSHI_FLG>");
       expect(result.xml).toContain("<SYUUSHI_UMU_FLG>");
       expect(result.xml).toContain("<SYUUSHI_UMU>");
 

--- a/admin/tests/server/contexts/report/domain/services/report-serializer.test.ts
+++ b/admin/tests/server/contexts/report/domain/services/report-serializer.test.ts
@@ -103,16 +103,27 @@ describe("serializeReportData", () => {
     expect(xml).toContain("<APP>収支報告書作成ソフト (収支報告書作成ソフト)</APP>");
   });
 
-  it("generates SYUUSHI_FLG section with profile flag set", () => {
+  it("generates SYUUSHI_UMU_FLG section with profile flag set", () => {
     const reportData = createEmptyReportData();
 
     const xml = serializeReportData(reportData);
 
-    expect(xml).toContain("<SYUUSHI_FLG>");
+    // SYUUSHI_UMU_FLG should be direct child of BOOK (not wrapped in SYUUSHI_FLG)
     expect(xml).toContain("<SYUUSHI_UMU_FLG>");
+    expect(xml).not.toContain("<SYUUSHI_FLG>");
     // First flag is set for profile (SYUUSHI07_01)
     expect(xml).toContain("<SYUUSHI07_01>");
     expect(xml).toContain("<HOUKOKU_NEN>2024</HOUKOKU_NEN>");
+  });
+
+  it("wraps SYUUSHI07_01 content in SHEET tag", () => {
+    const reportData = createEmptyReportData();
+
+    const xml = serializeReportData(reportData);
+
+    // SYUUSHI07_01 should contain SHEET which contains HOUKOKU_NEN
+    expect(xml).toMatch(/<SYUUSHI07_01>\s*<SHEET>/);
+    expect(xml).toMatch(/<\/SHEET>\s*<\/SYUUSHI07_01>/);
   });
 
   it("sets correct flag when personalDonations has data", () => {


### PR DESCRIPTION
## Summary

- SYUUSHI07_01の内容を`<SHEET>`タグで囲むように修正
- SYUUSHI_UMU_FLGをBOOKの直接の子要素として出力するように修正（余分な`<SYUUSHI_FLG>`タグを削除）

関連: #799 (差分分析ドキュメント)

## Test plan

- [x] report-serializer.test.ts にSHEETタグの検証テストを追加
- [x] 既存テストがすべて通過することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * レポートXML生成時の内部データ構造を最適化しました。ネストされた要素の配置と階層構造が改善され、より正確なレポート出力が実現しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->