### PR TITLE
fix: .env.exampleのDATABASE_URLを54332に修正

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Database Configuration
-DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:6543/postgres"
+DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:54332/postgres"
 DIRECT_URL="postgresql://postgres:postgres@127.0.0.1:54332/postgres"
 
 # Application Configuration

--- a/admin/.env.example
+++ b/admin/.env.example
@@ -12,8 +12,8 @@ SITE_URL="http://localhost:3001"
 # If set, enables basic auth for the entire application
 # Value should be SHA256 hash of "id:password" format
 # Example: echo -n "admin:password" | shasum -a 256
-BASIC_AUTH_SECRET="sha256_hash_of_id_password"
+# BASIC_AUTH_SECRET="sha256_hash_of_id_password"
 
 # Database Configuration
-DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:6543/postgres"
+DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:54332/postgres"
 DIRECT_URL="postgresql://postgres:postgres@127.0.0.1:54332/postgres"

--- a/webapp/.env.example
+++ b/webapp/.env.example
@@ -12,8 +12,8 @@ NEXT_PUBLIC_GA_TRACKING_ID="your-ga-tracking-id"
 # 設定すると、webアプリ全体にベーシック認証を適用
 # 値は "id:password" 形式の文字列をSHA256ハッシュ化したもの
 # 例: echo -n "admin:password" | shasum -a 256
-BASIC_AUTH_SECRET="sha256_hash_of_id_password"
+# BASIC_AUTH_SECRET="sha256_hash_of_id_password"
 
 # Database Configuration
-DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:6543/postgres"
+DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:54332/postgres"
 DIRECT_URL="postgresql://postgres:postgres@127.0.0.1:54332/postgres"


### PR DESCRIPTION
## Summary
- `.env.example`のDATABASE_URLをpooler(6543)から直接接続(54332)に変更
- `BASIC_AUTH_SECRET`をコメントアウトしてローカル開発時の認証を無効化

## Background
Supabaseローカル環境でpoolerサービスが停止していることがあり、6543ポートでの接続に失敗するケースがありました。直接接続ポート(54332)をデフォルトにすることで、ローカル開発環境のセットアップがスムーズになります。

## Test plan
- [x] ローカルでSupabase起動後、webapp/adminが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 環境設定ファイルを更新しました。データベース接続ポートを変更し、認証設定を調整しています。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->