### PR TITLE
docs: SYUUSHI07_02（収支総括表）実装設計書を追加

### DIFF
--- a/docs/20251227_1604_SYUUSHI07_02収支総括表実装設計.md
+++ b/docs/20251227_1604_SYUUSHI07_02収支総括表実装設計.md
@@ -1,0 +1,152 @@
+# SYUUSHI07_02（第14号様式 その2）実装設計書
+
+## 概要
+
+SYUUSHI07_02は「収支の総括表」を格納する様式であり、政治資金報告書の全体的な収支状況を俯瞰的に把握するための集計データを出力する。
+
+## XMLフォーマット仕様
+
+```xml
+<SYUUSHI07_02>
+  <SHEET>
+    <SYUNYU_SGK>収入総額</SYUNYU_SGK>
+    <ZENNEN_KKS_GK>前年繰越額</ZENNEN_KKS_GK>
+    <HONNEN_SYUNYU_GK>本年収入額</HONNEN_SYUNYU_GK>
+    <SISYUTU_SGK>支出総額</SISYUTU_SGK>
+    <YOKUNEN_KKS_GK>翌年繰越額</YOKUNEN_KKS_GK>
+    <KOJIN_FUTAN_KGK>個人負担党費金額</KOJIN_FUTAN_KGK>
+    <KOJIN_FUTAN_SU>個人負担党費員数</KOJIN_FUTAN_SU>
+    <KOJIN_KIFU_GK>個人寄附</KOJIN_KIFU_GK>
+    <KOJIN_KIFU_BIKOU>個人寄附の備考</KOJIN_KIFU_BIKOU>
+    <TOKUTEI_KIFU_GK>特定寄附</TOKUTEI_KIFU_GK>
+    <TOKUTEI_KIFU_BIKOU>特定寄附の備考</TOKUTEI_KIFU_BIKOU>
+    <HOJIN_KIFU_GK>法人寄附</HOJIN_KIFU_GK>
+    <HOJIN_KIFU_BIKOU>法人寄附の備考</HOJIN_KIFU_BIKOU>
+    <SEIJI_KIFU_GK>政治団体寄附</SEIJI_KIFU_GK>
+    <SEIJI_KIFU_BIKOU>政治団体寄附の備考</SEIJI_KIFU_BIKOU>
+    <KIFU_SKEI_GK>寄附小計</KIFU_SKEI_GK>
+    <KIFU_SKEI_BIKOU>寄附小計の備考</KIFU_SKEI_BIKOU>
+    <ATUSEN_GK>あっせんによるもの</ATUSEN_GK>
+    <ATUSEN_BIKOU>あっせんによるものの備考</ATUSEN_BIKOU>
+    <TOKUMEI_KIFU_GK>政党匿名寄附</TOKUMEI_KIFU_GK>
+    <TOKUMEI_KIFU_BIKOU>政党匿名寄附の備考</TOKUMEI_KIFU_BIKOU>
+    <KIFU_GKEI_GK>寄附合計</KIFU_GKEI_GK>
+    <KIFU_GKEI_BIKOU>寄附合計の備考</KIFU_GKEI_BIKOU>
+  </SHEET>
+</SYUUSHI07_02>
+```
+
+## 項目定義
+
+| 項番 | 項目名 | タグ名 | 項目属性 | 最大長 | 備考 |
+|------|--------|--------|----------|--------|------|
+| 1 | 収入総額 | SYUNYU_SGK | NUMBER | 12 | 前年繰越額 + 本年収入額 |
+| 2 | 前年繰越額 | ZENNEN_KKS_GK | NUMBER | 12 | 初期値ゼロ（NULL不可） |
+| 3 | 本年収入額 | HONNEN_SYUNYU_GK | NUMBER | 12 | 寄附合計 + 事業収入 + 借入金 + 交付金 + その他収入 |
+| 4 | 支出総額 | SISYUTU_SGK | NUMBER | 12 | 経常経費 + 政治活動費 |
+| 5 | 翌年繰越額 | YOKUNEN_KKS_GK | NUMBER | 12 | 収入総額 - 支出総額 |
+| 6 | 個人負担党費金額 | KOJIN_FUTAN_KGK | NUMBER | 12 | 初期値NULL（スコープ外） |
+| 7 | 個人負担党費員数 | KOJIN_FUTAN_SU | NUMBER | 12 | 初期値NULL（スコープ外） |
+| 8 | 個人寄附 | KOJIN_KIFU_GK | NUMBER | 12 | SYUUSHI07_07 KUBUN1 の合計 |
+| 9 | 個人寄附の備考 | KOJIN_KIFU_BIKOU | VARCHAR | 100 | 初期値NULL |
+| 10 | 特定寄附 | TOKUTEI_KIFU_GK | NUMBER | 12 | 初期値NULL（スコープ外） |
+| 11 | 特定寄附の備考 | TOKUTEI_KIFU_BIKOU | VARCHAR | 100 | 初期値NULL |
+| 12 | 法人寄附 | HOJIN_KIFU_GK | NUMBER | 12 | SYUUSHI07_07 KUBUN2 の合計 |
+| 13 | 法人寄附の備考 | HOJIN_KIFU_BIKOU | VARCHAR | 100 | 初期値NULL |
+| 14 | 政治団体寄附 | SEIJI_KIFU_GK | NUMBER | 12 | SYUUSHI07_07 KUBUN3 の合計 |
+| 15 | 政治団体寄附の備考 | SEIJI_KIFU_BIKOU | VARCHAR | 100 | 初期値NULL |
+| 16 | 寄附小計 | KIFU_SKEI_GK | NUMBER | 12 | 個人 + 特定 + 法人 + 政治団体 |
+| 17 | 寄附小計の備考 | KIFU_SKEI_BIKOU | VARCHAR | 100 | 初期値NULL |
+| 18 | あっせんによるもの | ATUSEN_GK | NUMBER | 12 | SYUUSHI07_08 の合計（スコープ外） |
+| 19 | あっせんによるものの備考 | ATUSEN_BIKOU | VARCHAR | 100 | 初期値NULL |
+| 20 | 政党匿名寄附 | TOKUMEI_KIFU_GK | NUMBER | 12 | SYUUSHI07_09 の合計（スコープ外） |
+| 21 | 政党匿名寄附の備考 | TOKUMEI_KIFU_BIKOU | VARCHAR | 100 | 初期値NULL |
+| 22 | 寄附合計 | KIFU_GKEI_GK | NUMBER | 12 | 寄附小計 + あっせん + 政党匿名 |
+| 23 | 寄附合計の備考 | KIFU_GKEI_BIKOU | VARCHAR | 100 | 初期値NULL |
+
+## 現在の実装状況
+
+### 実装済み（集計可能なデータソース）
+
+| 様式 | データ | 対応セクション |
+|------|--------|----------------|
+| SYUUSHI07_03 | 事業による収入 | `BusinessIncomeSection.totalAmount` |
+| SYUUSHI07_04 | 借入金 | `LoanIncomeSection.totalAmount` |
+| SYUUSHI07_05 | 交付金収入 | `GrantIncomeSection.totalAmount` |
+| SYUUSHI07_06 | その他の収入 | `OtherIncomeSection.totalAmount` |
+| SYUUSHI07_07 | 個人からの寄附 | `PersonalDonationSection.totalAmount` |
+| SYUUSHI07_14 | 経常経費（光熱水費・備品・事務所費） | 各セクションの `totalAmount` の合計 |
+| SYUUSHI07_15 | 政治活動費（9種類） | 各セクションの `totalAmount` の合計 |
+
+### 未実装（スコープ外）
+
+| 項目 | 理由 |
+|------|------|
+| 個人負担党費 | チームみらいでは該当なし |
+| 特定寄附 | チームみらいでは該当なし |
+| 法人寄附・政治団体寄附 | SYUUSHI07_07 KUBUN2/KUBUN3 未実装 |
+| あっせんによるもの | SYUUSHI07_08 未実装 |
+| 政党匿名寄附 | SYUUSHI07_09 未実装 |
+
+### 外部入力が必要な項目
+
+| 項目 | 対応方針 |
+|------|----------|
+| 前年繰越額 | `OrganizationReportProfile` に `previousYearCarryover` を追加して入力 |
+
+## 実装方針
+
+### ドメインモデル
+
+`admin/src/server/contexts/report/domain/models/summary-data.ts` を新規作成し、`SummaryData` インターフェースを定義する。
+
+主要フィールド:
+- 収支総括: `syunyuSgk`, `zennenKksGk`, `honnenSyunyuGk`, `sisyutuSgk`, `yokunenKksGk`
+- 党費: `kojinFutanKgk`, `kojinFutanSu`（オプショナル）
+- 寄附内訳: `kojinKifuGk`, `hojinKifuGk`, `seijiKifuGk`, `kifuSkeiGk`, `kifuGkeiGk` および各備考
+
+### 集計ロジック
+
+`ReportData.getSummary()` メソッドで `SummaryData` を計算して返す。フィールドとしては持たず、ドメインロジックとして `ReportData` 内に閉じ込める。シリアライザーは `ReportData.getSummary(reportData)` を呼び出すだけとする。
+
+計算式:
+- 本年収入額 = 寄附合計 + 事業収入 + 借入金 + 交付金 + その他収入
+- 収入総額 = 前年繰越額 + 本年収入額
+- 支出総額 = 経常経費 + 政治活動費
+- 翌年繰越額 = 収入総額 - 支出総額
+- 寄附小計 = 個人 + 特定 + 法人 + 政治団体
+- 寄附合計 = 寄附小計 + あっせん + 政党匿名
+
+### シリアライザー
+
+`admin/src/server/contexts/report/domain/services/summary-serializer.ts` を新規作成。
+
+### SYUUSHI_UMU_FLG
+
+`report-data.ts` の `buildSyuushiUmuFlg` で2桁目（その2: 収支の総括表）を `true` に変更。
+
+## 追加で必要なフィールド
+
+### 前年繰越額の入力
+
+前年繰越額は取引データからは算出できないため、`OrganizationReportProfile` に `previousYearCarryover: number` を追加する。
+
+### 法人寄附・政治団体寄附
+
+SYUUSHI07_07 の KUBUN2/KUBUN3 を実装する際に、`DonationData` に `corporateDonations`, `politicalDonations` を追加する。
+
+## 実装対象ファイル
+
+| ファイル | 操作 |
+|---------|------|
+| `admin/src/server/contexts/report/domain/models/summary-data.ts` | 新規作成 |
+| `admin/src/server/contexts/report/domain/services/summary-serializer.ts` | 新規作成 |
+| `admin/src/server/contexts/report/domain/models/organization-report-profile.ts` | 修正（`previousYearCarryover` 追加） |
+| `admin/src/server/contexts/report/domain/models/report-data.ts` | 修正（`getSummary()` 追加、`buildSyuushiUmuFlg` の2桁目を有効化） |
+| `admin/src/server/contexts/report/domain/services/report-serializer.ts` | 修正（SYUUSHI07_02 セクション出力追加） |
+| `admin/prisma/seed.ts` または関連シードファイル | 修正（profile に `previousYearCarryover` 追加） |
+
+## 参考資料
+
+- [docs/report-format.md](report-format.md) - XMLフォーマット仕様
+- [docs/scope-by-2026Jan.md](scope-by-2026Jan.md) - 開発スコープ


### PR DESCRIPTION
## Summary

- SYUUSHI07_02（第14号様式 その2）収支総括表の実装設計書を追加
- XMLフォーマット仕様、項目定義、実装方針を記載
- DDD設計に基づき `ReportData.getSummary()` で集計ロジックをドメインに閉じ込める方針

## Test plan

- [ ] ドキュメントの内容を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)