### PR TITLE
docs: Claude Codeコマンドと設定ファイルの整備

### DIFF
--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,6 +1,12 @@
-# 設計ドキュメント作成ルール
+---
+allowed-tools: Bash(TZ=Asia/Tokyo date:*), Write, Read, Glob, Grep
+argument-hint: <設計内容の説明>
+description: 設計ドキュメントを作成する (project)
+---
 
-設計作業を依頼された場合は、以下のルールに従ってファイルを作成すること：
+## タスク
+
+`$ARGUMENTS` の内容について設計ドキュメントを作成してください。
 
 ## ファイル命名規則
 
@@ -9,6 +15,13 @@
 - 保存場所: `docs/` 以下
 
 例: `docs/20250815_1430_ユーザー認証システム設計.md`
+
+## 政治資金収支報告書に関する設計
+
+政治資金収支報告書に関連する設計作業の場合は、必ず以下のドキュメントを参照すること：
+
+- [docs/report-format.md](docs/report-format.md): 政治資金収支報告書XMLの仕様
+- [docs/scope-by-2026Jan.md](docs/scope-by-2026Jan.md): 前提となる2026年1月までのスコープ
 
 ## 含めてはいけない内容
 

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash(git:*), Bash(gh:*), Bash(npm:*)
-argument-hint: [branch-name]
+argument-hint: [追加の指示]
 description: フィーチャーブランチを作成してPRを出す
 ---
 
@@ -8,15 +8,18 @@ description: フィーチャーブランチを作成してPRを出す
 
 - 現在のブランチ: !`git branch --show-current`
 - 変更ファイル: !`git status --short`
+- 追加の指示: $ARGUMENTS
 
 ## タスク
 
 以下の手順でPRを作成してください：
 
-1. **ブランチ作成**: 現在のブランチがdevelopやmainの場合、`$ARGUMENTS` という名前でフィーチャーブランチを作成してチェックアウトする。既にフィーチャーブランチにいる場合はそのまま使用する。
+1. **ブランチ決定**:
+   - 現在のブランチがdevelopやmainの場合: 変更内容に基づいて適切なブランチ名を自分で決定し、新しいブランチを作成してチェックアウトする（例: `feature/add-dark-mode`, `fix/login-error`, `refactor/auth-logic`）
+   - 既にフィーチャーブランチにいる場合: 変更内容がブランチ名と合致していればそのまま使用する。合致していない場合はdevelopから新しいブランチを作成して変更を持ち越す
 
 2. **品質チェック**: ソースコード（`.ts`、`.tsx`、`.js`、`.jsx`ファイル）への変更がある場合のみ、プロジェクトルートで以下を実行する。ドキュメントや設定ファイルのみの変更の場合はスキップ可。
-   - `npm run typecheck`
+   - `npm run type-check`
    - `npm run lint`
    - `npm test`
    エラーがあれば修正してから次に進む。

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -15,6 +15,11 @@ reviews:
   request_changes_workflow: true
   poem: false
   collapse_walkthrough: false
+  high_level_summary: true
+  high_level_summary_placeholder: "@coderabbitai summary"
+
+  # レビュースタイル
+  profile: assertive
 
   # レビュー強化機能
   auto_apply_labels: true
@@ -45,29 +50,16 @@ reviews:
   # パス別のレビュー指示
   path_instructions:
     - path: "admin/src/server/contexts/**"
-      instructions: |
-        このコードはBounded ContextパターンとDDDに基づく設計です。
-        以下のポイントを重点的にレビューしてください：
-        - レイヤー間の依存関係（presentation→application→domain↔infrastructure）
-        - loader/actionがusecaseを経由せずにrepositoryを直接呼んでいないか
-        - ドメインロジックがドメインモデルに適切に実装されているか
-        - server-onlyインポートの有無
-        詳細は docs/admin-architecture-guide.md を参照してください。
+      instructions: "docs/admin-architecture-guide.md に従ってレビューしてください。"
 
     - path: "admin/src/client/**"
-      instructions: |
-        このコードはadmin UIコンポーネントです。
-        以下のポイントを重点的にレビューしてください：
-        - shadcn/ui コンポーネントを使用しているか（カスタム実装は非推奨）
-        - CSS変数（bg-background, text-foreground等）を使用しているか
-        - cn()ユーティリティでクラス名を合成しているか
-        詳細は docs/admin-ui-guidelines.md を参照してください。
+      instructions: "docs/admin-ui-guidelines.md に従ってレビューしてください。"
 
     - path: "webapp/src/**"
-      instructions: |
-        webappのコードです。
-        サーバーコンポーネントを優先し、"use client"は必要最小限にしてください。
-        データ取得はloaders、副作用はactionsに分離してください。
+      instructions: "CLAUDE.md の「Next アプリケーション」セクションに従ってレビューしてください。"
+
+    - path: "admin/src/server/contexts/report/**"
+      instructions: "docs/report-format.md と docs/scope-by-2026Jan.md に従ってレビューしてください。"
 
   auto_review:
     drafts: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ PRを作成する際は [.claude/commands/pr.md](.claude/commands/pr.md) の手�
 
 ## 設計作業ルール
 
-設計ドキュメント作成時のルールは [docs/design-document-rules.md](docs/design-document-rules.md) を参照すること。
+設計ドキュメントを作成する場合は [.claude/commands/plan.md](.claude/commands/plan.md) の手順に従うこと。
 
 ## admin UI コンポーネント
 

--- a/docs/admin-ui-guidelines.md
+++ b/docs/admin-ui-guidelines.md
@@ -4,127 +4,21 @@ admin アプリケーションで shadcn UI を使用する際のルールを定
 
 ## 原則
 
-- **新規開発では shadcn UI コンポーネントを使用する**
-- カスタム UI (`Button.tsx`, `Input.tsx`, `Card.tsx`, `Selector.tsx`) は非推奨
-- 生の HTML 要素 (`<button>`, `<input>`) にスタイルを直書きしない
-
-## コンポーネント配置
-
-```
-admin/src/client/components/ui/
-├── button.tsx       # shadcn UI コンポーネント
-├── input.tsx
-├── card.tsx
-├── dialog.tsx
-├── select.tsx
-├── textarea.tsx
-├── checkbox.tsx
-├── label.tsx
-├── table.tsx
-├── form.tsx
-├── index.ts         # 全コンポーネントの re-export
-├── Button.tsx       # [非推奨] カスタム実装
-├── Input.tsx        # [非推奨] カスタム実装
-├── Card.tsx         # [非推奨] カスタム実装
-└── Selector.tsx     # [非推奨] カスタム実装
-```
-
-## import ルール
+- **shadcn UI コンポーネントを使用する**（カスタム実装は非推奨）
+- **import は index.ts 経由**で行う
+- **CSS 変数と cn() を使う**（直書きスタイル禁止）
 
 ```typescript
-// 推奨: index.ts 経由で import
-import { Button, Input, Label, Dialog } from "@/client/components/ui";
-
-// 非推奨: 個別ファイルから直接 import
-import Button from "@/client/components/ui/Button";
-import { Button } from "@/client/components/ui/button";
+import { Button, Input, Label } from "@/client/components/ui";
 ```
 
-## コンポーネント対応表
-
-| 用途 | 推奨（shadcn） | 非推奨（カスタム） |
-|------|----------------|-------------------|
-| ボタン | `Button` | カスタム `Button` |
-| テキスト入力 | `Input` | カスタム `Input` |
-| カード | `Card`, `CardHeader`, `CardContent` 等 | カスタム `Card` |
-| セレクト | `Select`, `SelectTrigger`, `SelectContent`, `SelectItem` | `Selector` |
-| ダイアログ | `Dialog`, `DialogContent`, `DialogHeader` 等 | カスタム実装のモーダル |
-| ラベル | `Label` | - |
-| テーブル | `Table`, `TableHeader`, `TableRow` 等 | - |
-| フォーム | `Form`, `FormField`, `FormItem` 等 | - |
-| チェックボックス | `Checkbox` | - |
-| テキストエリア | `Textarea` | - |
-
-## ダイアログ/モーダル
-
-shadcn `Dialog` コンポーネントを使用してください。
-
-```tsx
-// 推奨
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-  Button,
-} from "@/client/components/ui";
-
-function MyDialog({ open, onOpenChange }) {
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>タイトル</DialogTitle>
-        </DialogHeader>
-        {/* コンテンツ */}
-        <DialogFooter>
-          <Button>確定</Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-// 非推奨: カスタムモーダル実装
-function MyModal() {
-  return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
-      <div className="bg-card rounded-xl p-6">
-        {/* ... */}
-      </div>
-    </div>
-  );
-}
-```
-
-## スタイリング
-
-### テーマ
-
-shadcn/ui 公式の **Dark Blue テーマ**（ダークモード固定）を採用しています。
-テーマ定義は `admin/src/app/globals.css` の `@theme` ブロックにあります。
-
-### ダークモード対応
-
-admin はダークモード固定のため、shadcn コンポーネントの `dark:` プレフィックス付きクラスは自動的に適用されません。
-コンポーネントを追加・更新する際は、`dark:` プレフィックスの値をデフォルトとして適用してください。
-
-例:
-```tsx
-// 公式の定義
-"bg-transparent dark:bg-input/30"
-
-// admin での適用（dark: を除去してデフォルトに）
-"bg-input/30"
-```
+## リファレンス
 
 ### カラー変数
 
-shadcn UI 標準の CSS 変数を使用してください。
+shadcn UI 標準の CSS 変数を使用する。
 
 ```css
-/* 推奨: shadcn 標準変数 */
 bg-background         /* 背景色 */
 bg-card               /* カード背景 */
 text-foreground       /* テキスト色 */
@@ -135,21 +29,11 @@ bg-primary            /* プライマリ色 */
 bg-secondary          /* セカンダリ色（ホバー等） */
 bg-destructive        /* 危険色（赤） */
 ring-ring             /* フォーカスリング */
-
-/* 非推奨: カスタム変数 → 以下に移行 */
-bg-primary-bg       → bg-background
-bg-primary-panel    → bg-card
-text-primary-muted  → text-muted-foreground
-border-primary-border → border-border
-bg-primary-input    → bg-input
-bg-primary-hover    → bg-secondary
-text-primary-accent → text-primary
-ring-primary-accent → ring-ring
 ```
 
 ### クラス名の合成
 
-`cn()` ユーティリティを使用してください。
+`cn()` ユーティリティを使用する。
 
 ```typescript
 import { cn } from "@/client/lib";
@@ -158,75 +42,41 @@ import { cn } from "@/client/lib";
 <div className={cn("base-class", condition && "conditional-class", className)} />
 
 // 非推奨
-<div className={`base-class ${condition ? "conditional-class" : ""} ${className}`} />
+<div className={`base-class ${condition ? "conditional-class" : ""}`} />
 ```
 
-## インストール済みコンポーネント
+## 運用ガイド
 
-現在インストールされている shadcn コンポーネント:
+### 新規コンポーネント追加
 
-- `button` - ボタン
-- `card` - カード
-- `checkbox` - チェックボックス
-- `dialog` - ダイアログ/モーダル
-- `form` - フォーム（react-hook-form 連携）
-- `input` - テキスト入力
-- `label` - ラベル
-- `select` - セレクトボックス
-- `table` - テーブル
-- `textarea` - テキストエリア
+1. インストール
+   ```bash
+   cd admin
+   npx shadcn@latest add [component-name]
+   ```
 
-必要なコンポーネントは必要になったタイミングで追加してください。
+2. `admin/src/client/components/ui/index.ts` に re-export を追加
+   ```typescript
+   export { Tooltip, TooltipTrigger, TooltipContent } from "@/client/components/ui/tooltip";
+   ```
 
-## 新規コンポーネント追加
-
-### 1. コンポーネントをインストール
-
-```bash
-cd admin
-npx shadcn@latest add [component-name]
-```
+3. ダークモード対応を確認（後述）
 
 利用可能なコンポーネント一覧: https://ui.shadcn.com/docs/components
 
-例:
-```bash
-npx shadcn@latest add tooltip
-npx shadcn@latest add dropdown-menu
-npx shadcn@latest add tabs
+### ダークモード対応
+
+admin は **Dark Blue テーマ（ダークモード固定）** を採用している。
+テーマ定義は `admin/src/app/globals.css` の `@theme` ブロックにある。
+
+shadcn コンポーネントの `dark:` プレフィックス付きクラスは自動適用されないため、
+コンポーネント追加時は `dark:` の値をデフォルトとして適用する。
+
+```tsx
+// 公式の定義
+"bg-transparent dark:bg-input/30"
+
+// admin での適用（dark: を除去してデフォルトに）
+"bg-input/30"
 ```
 
-### 2. index.ts に re-export を追加
-
-`admin/src/client/components/ui/index.ts` に追加したコンポーネントの export を追記:
-
-```typescript
-// 例: tooltip を追加した場合
-export {
-  Tooltip,
-  TooltipTrigger,
-  TooltipContent,
-  TooltipProvider,
-} from "@/client/components/ui/tooltip";
-```
-
-### 3. ダークモード対応を確認
-
-追加したコンポーネントに `dark:` プレフィックス付きのクラスがある場合、
-admin はダークモード固定のため、`dark:` の値をデフォルトとして適用するよう修正が必要です。
-
-### 注意: components.json の設定
-
-`admin/components.json` は Tailwind v4 用に設定されています。
-この設定が正しくないと、CLI が古いバージョンのコンポーネントを取得します。
-
-```json
-{
-  "tailwind": {
-    "config": "",
-    "css": "src/app/globals.css",
-    "baseColor": "zinc",
-    "cssVariables": true
-  }
-}
-```


### PR DESCRIPTION
## Summary

- `/design` コマンドを `/plan` にリネーム（ビジュアルデザインとの混同を避けるため）
- `.coderabbit.yml` の `path_instructions` を簡潔化（詳細はナレッジベースのドキュメントを参照する形式に）
- `docs/admin-ui-guidelines.md` を「原則」「リファレンス」「運用ガイド」に再構成し、古くなった情報を削除

## Test plan

- [ ] `/plan` コマンドが正しく動作することを確認
- [ ] CodeRabbit がナレッジベースを参照してレビューできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)