### PR TITLE
feat: 政治資金報告書に必要なPLカテゴリを追加

### DIFF
--- a/shared/utils/category-mapping.ts
+++ b/shared/utils/category-mapping.ts
@@ -81,6 +81,21 @@ export const PL_CATEGORIES: Record<string, CategoryMapping> = {
     shortLabel: "交付金",
     type: "income"
   },
+  "政治資金パーティーの対価に係る収入": {
+    key: "party-income",
+    category: "パーティー収入",
+    color: "#DDD6FE",
+    shortLabel: "パーティー収入",
+    type: "income"
+  },
+  "寄附のあっせんによるもの": {
+    key: "mediated-donations",
+    category: "寄附",
+    subcategory: "あっせんによる寄附",
+    color: "#C4B5FD",
+    shortLabel: "あっせん寄附",
+    type: "income"
+  },
   "その他の収入": {
     key: "other-income",
     category: "その他",
@@ -192,6 +207,13 @@ export const PL_CATEGORIES: Record<string, CategoryMapping> = {
     subcategory: "その他の経費",
     color: "#334155",
     shortLabel: "その他経費",
+    type: "expense"
+  },
+  "本部又は支部に対する交付金": {
+    key: "branch-grants-expenses",
+    category: "本支部交付金",
+    color: "#F472B6",
+    shortLabel: "本支部交付金",
     type: "expense"
   }
 };


### PR DESCRIPTION
## Summary

- 政治資金報告書のフォーマット（report-format.md）と比較して、category-mapping.ts に不足していたPLカテゴリを追加
- 収入項目: 政治資金パーティーの対価に係る収入（その10対応）、寄附のあっせんによるもの（その8対応）
- 支出項目: 本部又は支部に対する交付金（その16対応）

## Test plan

- [x] typecheck パス
- [x] lint パス
- [x] test パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
* 政治資金分類を拡張しました
  * パーティー収入カテゴリーを新規追加
  * あっせん寄附カテゴリーを新規追加
  * 本支部交付金カテゴリーを新規追加

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->