### PR TITLE
fix: SYUUSHI07_02のnull数値フィールドを0として出力

### DIFF
--- a/admin/src/server/contexts/report/domain/services/summary-serializer.ts
+++ b/admin/src/server/contexts/report/domain/services/summary-serializer.ts
@@ -26,17 +26,9 @@ export function serializeSummarySection(summary: SummaryData): XMLBuilder {
   sheet.ele("SISYUTU_SGK").txt(formatAmount(summary.sisyutuSgk));
   sheet.ele("YOKUNEN_KKS_GK").txt(formatAmount(summary.yokunenKksGk));
 
-  // 党費（スコープ外）
-  if (summary.kojinFutanKgk !== null) {
-    sheet.ele("KOJIN_FUTAN_KGK").txt(formatAmount(summary.kojinFutanKgk));
-  } else {
-    sheet.ele("KOJIN_FUTAN_KGK");
-  }
-  if (summary.kojinFutanSu !== null) {
-    sheet.ele("KOJIN_FUTAN_SU").txt(formatAmount(summary.kojinFutanSu));
-  } else {
-    sheet.ele("KOJIN_FUTAN_SU");
-  }
+  // 党費（スコープ外: nullの場合は0を出力）
+  sheet.ele("KOJIN_FUTAN_KGK").txt(formatAmount(summary.kojinFutanKgk ?? 0));
+  sheet.ele("KOJIN_FUTAN_SU").txt(formatAmount(summary.kojinFutanSu ?? 0));
 
   // 個人寄附
   sheet.ele("KOJIN_KIFU_GK").txt(formatAmount(summary.kojinKifuGk));
@@ -46,36 +38,24 @@ export function serializeSummarySection(summary: SummaryData): XMLBuilder {
     sheet.ele("KOJIN_KIFU_BIKOU");
   }
 
-  // 特定寄附（スコープ外）
-  if (summary.tokuteiKifuGk !== null) {
-    sheet.ele("TOKUTEI_KIFU_GK").txt(formatAmount(summary.tokuteiKifuGk));
-  } else {
-    sheet.ele("TOKUTEI_KIFU_GK");
-  }
+  // 特定寄附（スコープ外: nullの場合は0を出力）
+  sheet.ele("TOKUTEI_KIFU_GK").txt(formatAmount(summary.tokuteiKifuGk ?? 0));
   if (summary.tokuteiKifuBikou) {
     sheet.ele("TOKUTEI_KIFU_BIKOU").txt(summary.tokuteiKifuBikou);
   } else {
     sheet.ele("TOKUTEI_KIFU_BIKOU");
   }
 
-  // 法人寄附
-  if (summary.hojinKifuGk !== null) {
-    sheet.ele("HOJIN_KIFU_GK").txt(formatAmount(summary.hojinKifuGk));
-  } else {
-    sheet.ele("HOJIN_KIFU_GK");
-  }
+  // 法人寄附（スコープ外: nullの場合は0を出力）
+  sheet.ele("HOJIN_KIFU_GK").txt(formatAmount(summary.hojinKifuGk ?? 0));
   if (summary.hojinKifuBikou) {
     sheet.ele("HOJIN_KIFU_BIKOU").txt(summary.hojinKifuBikou);
   } else {
     sheet.ele("HOJIN_KIFU_BIKOU");
   }
 
-  // 政治団体寄附
-  if (summary.seijiKifuGk !== null) {
-    sheet.ele("SEIJI_KIFU_GK").txt(formatAmount(summary.seijiKifuGk));
-  } else {
-    sheet.ele("SEIJI_KIFU_GK");
-  }
+  // 政治団体寄附（スコープ外: nullの場合は0を出力）
+  sheet.ele("SEIJI_KIFU_GK").txt(formatAmount(summary.seijiKifuGk ?? 0));
   if (summary.seijiKifuBikou) {
     sheet.ele("SEIJI_KIFU_BIKOU").txt(summary.seijiKifuBikou);
   } else {
@@ -90,24 +70,16 @@ export function serializeSummarySection(summary: SummaryData): XMLBuilder {
     sheet.ele("KIFU_SKEI_BIKOU");
   }
 
-  // あっせんによるもの（スコープ外）
-  if (summary.atusenGk !== null) {
-    sheet.ele("ATUSEN_GK").txt(formatAmount(summary.atusenGk));
-  } else {
-    sheet.ele("ATUSEN_GK");
-  }
+  // あっせんによるもの（スコープ外: nullの場合は0を出力）
+  sheet.ele("ATUSEN_GK").txt(formatAmount(summary.atusenGk ?? 0));
   if (summary.atusenBikou) {
     sheet.ele("ATUSEN_BIKOU").txt(summary.atusenBikou);
   } else {
     sheet.ele("ATUSEN_BIKOU");
   }
 
-  // 政党匿名寄附（スコープ外）
-  if (summary.tokumeiKifuGk !== null) {
-    sheet.ele("TOKUMEI_KIFU_GK").txt(formatAmount(summary.tokumeiKifuGk));
-  } else {
-    sheet.ele("TOKUMEI_KIFU_GK");
-  }
+  // 政党匿名寄附（スコープ外: nullの場合は0を出力）
+  sheet.ele("TOKUMEI_KIFU_GK").txt(formatAmount(summary.tokumeiKifuGk ?? 0));
   if (summary.tokumeiBikou) {
     sheet.ele("TOKUMEI_KIFU_BIKOU").txt(summary.tokumeiBikou);
   } else {

--- a/admin/tests/server/contexts/report/domain/services/summary-serializer.test.ts
+++ b/admin/tests/server/contexts/report/domain/services/summary-serializer.test.ts
@@ -44,7 +44,7 @@ describe("serializeSummarySection", () => {
     expect(xml).toContain("<KIFU_GKEI_GK>200000</KIFU_GKEI_GK>");
   });
 
-  it("serializes null values as empty elements", () => {
+  it("serializes null number values as 0, null string values as empty elements", () => {
     const summary: SummaryData = {
       syunyuSgk: 0,
       zennenKksGk: 0,
@@ -74,19 +74,22 @@ describe("serializeSummarySection", () => {
     const xmlBuilder = serializeSummarySection(summary);
     const xml = xmlBuilder.toString();
 
-    expect(xml).toContain("<KOJIN_FUTAN_KGK/>");
-    expect(xml).toContain("<KOJIN_FUTAN_SU/>");
+    // null の数値フィールドは 0 として出力される（総務省バリデータ対応）
+    expect(xml).toContain("<KOJIN_FUTAN_KGK>0</KOJIN_FUTAN_KGK>");
+    expect(xml).toContain("<KOJIN_FUTAN_SU>0</KOJIN_FUTAN_SU>");
+    expect(xml).toContain("<TOKUTEI_KIFU_GK>0</TOKUTEI_KIFU_GK>");
+    expect(xml).toContain("<HOJIN_KIFU_GK>0</HOJIN_KIFU_GK>");
+    expect(xml).toContain("<SEIJI_KIFU_GK>0</SEIJI_KIFU_GK>");
+    expect(xml).toContain("<ATUSEN_GK>0</ATUSEN_GK>");
+    expect(xml).toContain("<TOKUMEI_KIFU_GK>0</TOKUMEI_KIFU_GK>");
+
+    // null の備考フィールドは空要素として出力される
     expect(xml).toContain("<KOJIN_KIFU_BIKOU/>");
-    expect(xml).toContain("<TOKUTEI_KIFU_GK/>");
     expect(xml).toContain("<TOKUTEI_KIFU_BIKOU/>");
-    expect(xml).toContain("<HOJIN_KIFU_GK/>");
     expect(xml).toContain("<HOJIN_KIFU_BIKOU/>");
-    expect(xml).toContain("<SEIJI_KIFU_GK/>");
     expect(xml).toContain("<SEIJI_KIFU_BIKOU/>");
     expect(xml).toContain("<KIFU_SKEI_BIKOU/>");
-    expect(xml).toContain("<ATUSEN_GK/>");
     expect(xml).toContain("<ATUSEN_BIKOU/>");
-    expect(xml).toContain("<TOKUMEI_KIFU_GK/>");
     expect(xml).toContain("<TOKUMEI_KIFU_BIKOU/>");
     expect(xml).toContain("<KIFU_GKEI_BIKOU/>");
   });


### PR DESCRIPTION
## Summary

- 収支総括表(SYUUSHI07_02)のスコープ外数値フィールドがnullの場合、空要素ではなく0を出力するように修正
- 総務省バリデータで「入力が必要ですが、何も入力されていません(E001)」エラーが発生していた問題を解消
- 対象フィールド: KOJIN_FUTAN_KGK, KOJIN_FUTAN_SU, TOKUTEI_KIFU_GK, HOJIN_KIFU_GK, SEIJI_KIFU_GK, ATUSEN_GK, TOKUMEI_KIFU_GK

## Test plan

- [x] summary-serializer.test.ts のテストがパスすることを確認
- [x] typecheck, lint, test 全て通過
- [ ] XMLエクスポート後、総務省バリデータでエラーが解消されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * レポート出力における数値フィールドで、null 値が適切に 0 として出力されるようになりました。これにより、資金関連項目の表示がより一貫性のある形式になり、より見やすくなります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->