### PR TITLE
feat: 政治資金パーティー対価のあっせんカテゴリを追加

### DIFF
--- a/shared/utils/category-mapping.ts
+++ b/shared/utils/category-mapping.ts
@@ -96,6 +96,14 @@ export const PL_CATEGORIES: Record<string, CategoryMapping> = {
     shortLabel: "あっせん寄附",
     type: "income"
   },
+  "政治資金パーティー対価のあっせんによるもの": {
+    key: "mediated-party-income",
+    category: "パーティー収入",
+    subcategory: "あっせんによるパーティー対価",
+    color: "#A78BFA",
+    shortLabel: "あっせんパーティー",
+    type: "income"
+  },
   "その他の収入": {
     key: "other-income",
     category: "その他",


### PR DESCRIPTION
## Summary

- report-format.mdのその12（SYUUSHI07_12）に対応する「政治資金パーティー対価のあっせんによるもの」を追加
- #809 に続くPLカテゴリ追加

## Test plan

- [x] typecheck パス
- [x] lint パス
- [x] test パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 政治資金の収入分類に新しいカテゴリーを追加しました。党対価の仲介による収入をより正確に分類・表示できるようになります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->