### PR TITLE
docs: donorテーブル設計をcategory-mapping体系に合わせて更新

### DIFF
--- a/docs/20251224_1500_donorテーブル設計.md
+++ b/docs/20251224_1500_donorテーブル設計.md
@@ -152,10 +152,11 @@ name、address、donor_type の組み合わせに複合UNIQUE制約を設定す�
 
 `transaction_donors` テーブルへのINSERT/UPDATE時に発火し、以下をチェック:
 
-1. 対象取引の `transaction_type` が `income` であること
-2. 対象取引の `category_key` が許可リストに含まれること
-3. donor_type制限があるカテゴリの場合、donor_typeが一致すること
-4. 条件を満たさない場合は RAISE EXCEPTION でエラーを返す
+1. donor_typeが有効な値（individual/corporation/political_organization）であること
+2. 対象取引の `transaction_type` が `income` であること
+3. 対象取引の `category_key` が許可リストに含まれること
+4. donor_type制限があるカテゴリの場合、donor_typeが一致すること
+5. 条件を満たさない場合は RAISE EXCEPTION でエラーを返す
 
 ```sql
 CREATE OR REPLACE FUNCTION validate_transaction_donor()
@@ -196,6 +197,11 @@ BEGIN
   INTO v_donor_type
   FROM donors
   WHERE id = NEW.donor_id;
+
+  -- donor_typeの妥当性チェック
+  IF v_donor_type NOT IN ('individual', 'corporation', 'political_organization') THEN
+    RAISE EXCEPTION 'Unknown donor_type: %', v_donor_type;
+  END IF;
 
   -- 収入取引のみ許可
   IF v_transaction_type != 'income' THEN


### PR DESCRIPTION
## Summary

- donorテーブル設計ドキュメントのcategory_keyを現行のPL_CATEGORIES（ケバブケース）に統一
- donor_typeとcategory_keyの整合性ルールを明確化
- XML出力時のdonor_typeによる振り分けルールを追加

## 変更内容

### category_keyの更新
- `income_donation_individual` → `individual-donations` などケバブケースに変更
- `shared/utils/category-mapping.ts` のPL_CATEGORIESと一致

### 整合性ルールの明確化
| category_key | 許可されるdonor_type |
|--------------|---------------------|
| `individual-donations` | individual のみ |
| `specific-individual-donations` | individual のみ |
| `corporate-donations` | corporation のみ |
| `political-donations` | political_organization のみ |
| `mediated-donations` | すべて |
| `party-income` | すべて |
| `mediated-party-income` | すべて |

- 寄附者種別が明確なカテゴリは対応するdonor_typeのみ許可
- あっせん・パーティー対価は任意のdonor_typeを許可し、XML出力時に振り分け

### PostgreSQL Triggerの更新
- 新しい整合性ルールに合わせてトリガーSQLを更新

## Test plan
- [ ] ドキュメントの内容確認
- [ ] category_keyがPL_CATEGORIESと一致していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)