### PR TITLE
docs: ReportDataバリデーション設計ドキュメントを追加

### DIFF
--- a/docs/20251227_1726_ReportDataバリデーション設計.md
+++ b/docs/20251227_1726_ReportDataバリデーション設計.md
@@ -1,0 +1,243 @@
+# ReportData バリデーション設計
+
+## 背景・課題
+
+現在の `report-data.ts` は、開発・デバッグ時の利便性を重視し、政治資金報告書としての必須項目が欠けていても `ReportData` インスタンスを構築できるようになっている。
+
+しかし、実際に政治資金報告書XMLを出力する際には、ユーザーに対して：
+- データが不完全であること
+- 具体的にどの項目が不足・不正なのか
+
+を明確にフィードバックする必要がある。
+
+## 設計方針
+
+### リッチドメインモデルによるバリデーション
+
+バリデーションロジックは **ドメインモデル自身** に持たせる。外部のバリデーターサービスに委譲すると、モデルが単なるデータ構造（貧血ドメインモデル）になってしまうため、各モデルが自身の完全性を検証できる設計とする。
+
+**原則**:
+- 各ドメインモデルは自身の `validate()` メソッドを持つ
+- 複合モデル（`ReportData`）は、子モデルの `validate()` を呼び出して結果を集約する
+- 型定義のみ共通ファイルに切り出す
+
+### 階層構造
+
+```
+ReportData.validate()
+├── OrganizationReportProfile.validate()
+├── DonationData.validate()
+│   └── PersonalDonationSection.validate()
+├── IncomeData.validate()
+│   ├── BusinessIncomeSection.validate()
+│   ├── LoanIncomeSection.validate()
+│   ├── GrantIncomeSection.validate()
+│   └── OtherIncomeSection.validate()
+├── ExpenseData.validate()
+│   ├── UtilityExpenseSection.validate()
+│   ├── ... (各支出セクション)
+│   └── OtherPoliticalExpenseSection.validate()
+└── ReportData 固有の整合性チェック（収支総括表など）
+```
+
+## バリデーション結果の設計
+
+### 型定義（`types/validation.ts`）
+
+```typescript
+interface ValidationError {
+  path: string;        // エラー箇所のパス（例: "profile.officialName"）
+  code: string;        // エラーコード（例: "REQUIRED", "INVALID_FORMAT"）
+  message: string;     // 日本語メッセージ
+  severity: "error" | "warning";
+}
+
+interface ValidationResult {
+  isValid: boolean;
+  errors: ValidationError[];
+  warnings: ValidationError[];
+}
+```
+
+- `error`: XMLとして出力できない致命的な問題
+- `warning`: 出力は可能だが確認が必要な問題（例: 未分類の取引がある）
+
+## バリデーション対象項目（2026年1月スコープ）
+
+[docs/scope-by-2026Jan.md](scope-by-2026Jan.md) に基づき、対応必須の様式に対するバリデーションを実装する。
+
+### SYUUSHI07_01（団体基本情報）
+
+| フィールド | バリデーション内容 |
+|-----------|------------------|
+| 報告年 (HOUKOKU_NEN) | 必須、4桁数字 |
+| 政治団体名称 (DANTAI_NM) | 必須、120文字以内 |
+| 政治団体ふりがな (DANTAI_KANA) | 必須、120文字以内 |
+| 事務所住所 (JIM_ADR) | 必須、80文字以内 |
+| 代表者氏名 (DAI_NM1, DAI_NM2) | 必須、各30文字以内 |
+| 会計責任者氏名 (KAI_NM1, KAI_NM2) | 必須、各30文字以内 |
+| 活動区域 (KATU_KUKI) | 必須、"1" or "2" |
+| 資金管理団体の指定の有無 (SIKIN_UMU) | 必須、"0" or "1" |
+| 国会議員関係政治団体の区分 (GIIN_DANTAI_KBN) | 必須、"0"〜"3" |
+
+### SYUUSHI07_02（収支総括表）
+
+計算結果の整合性チェック：
+- 収入総額 = 前年繰越額 + 本年収入額
+- 翌年繰越額 = 収入総額 - 支出総額
+- 寄附小計 = 個人 + 特定 + 法人 + 政治団体
+- 寄附合計 = 寄附小計 + あっせん + 政党匿名
+
+### SYUUSHI07_07（寄附の明細）
+
+| フィールド | バリデーション内容 |
+|-----------|------------------|
+| 寄附者氏名 (KIFUSYA_NM) | 必須、120文字以内 |
+| 金額 (KINGAKU) | 必須、正の整数 |
+| 年月日 (DT) | 必須、和暦形式 |
+| 住所 (ADR) | 必須、120文字以内 |
+| 職業 (SYOKUGYO) | 必須、50文字以内 |
+
+### SYUUSHI07_14, SYUUSHI07_15（経常経費・政治活動費）
+
+| フィールド | バリデーション内容 |
+|-----------|------------------|
+| 目的 (MOKUTEKI) | 必須、200文字以内 |
+| 金額 (KINGAKU) | 必須、正の整数 |
+| 年月日 (DT) | 必須、和暦形式 |
+| 氏名 (NM) | 必須、120文字以内 |
+| 住所 (ADR) | 必須、120文字以内 |
+
+## 実装方針
+
+### 各セクションモデルに `validate()` を追加
+
+既存の `namespace + interface` パターンに従い、各モデルに `validate` メソッドを追加する。
+
+例: `donation-transaction.ts`
+
+```typescript
+export const PersonalDonationSection = {
+  // ... 既存メソッド ...
+
+  /**
+   * セクションのバリデーションを実行する
+   */
+  validate: (section: PersonalDonationSection): ValidationError[] => {
+    const errors: ValidationError[] = [];
+
+    section.rows.forEach((row, index) => {
+      if (!row.kifusyaNm) {
+        errors.push({
+          path: `donations.personalDonations.rows[${index}].kifusyaNm`,
+          code: "REQUIRED",
+          message: `個人寄附の${index + 1}行目: 寄附者氏名が入力されていません`,
+          severity: "error"
+        });
+      }
+      // ... 他のフィールドも同様
+    });
+
+    return errors;
+  },
+} as const;
+```
+
+### `ReportData.validate()` で全体を集約
+
+```typescript
+// report-data.ts
+export const ReportData = {
+  // ... 既存メソッド（buildSyuushiUmuFlg, getSummary）...
+
+  /**
+   * ReportData全体のバリデーションを実行する
+   */
+  validate: (data: ReportData): ValidationResult => {
+    const errors: ValidationError[] = [];
+    const warnings: ValidationError[] = [];
+
+    // 各サブモデルのバリデーションを呼び出し
+    errors.push(...OrganizationReportProfile.validate(data.profile));
+    errors.push(...DonationData.validate(data.donations));
+    errors.push(...IncomeData.validate(data.income));
+    errors.push(...ExpenseData.validate(data.expenses));
+
+    // ReportData 固有の整合性チェック（収支総括表の計算など）
+    errors.push(...ReportData.validateSummaryConsistency(data));
+
+    return {
+      isValid: errors.length === 0,
+      errors,
+      warnings,
+    };
+  },
+
+  /**
+   * 収支総括表の整合性をチェックする
+   */
+  validateSummaryConsistency: (data: ReportData): ValidationError[] => {
+    const errors: ValidationError[] = [];
+    // 収入総額 = 前年繰越額 + 本年収入額 などのチェック
+    return errors;
+  },
+};
+```
+
+### 中間層（`DonationData`, `IncomeData`, `ExpenseData`）にも `validate()` を追加
+
+```typescript
+// report-data.ts 内
+export const DonationData = {
+  validate: (data: DonationData): ValidationError[] => {
+    const errors: ValidationError[] = [];
+    errors.push(...PersonalDonationSection.validate(data.personalDonations));
+    // corporateDonations, politicalDonations も実装時に追加
+    return errors;
+  },
+};
+
+export const IncomeData = {
+  validate: (data: IncomeData): ValidationError[] => {
+    const errors: ValidationError[] = [];
+    errors.push(...BusinessIncomeSection.validate(data.businessIncome));
+    errors.push(...LoanIncomeSection.validate(data.loanIncome));
+    errors.push(...GrantIncomeSection.validate(data.grantIncome));
+    errors.push(...OtherIncomeSection.validate(data.otherIncome));
+    return errors;
+  },
+};
+
+// ExpenseData も同様
+```
+
+## ファイル構成（最終形）
+
+```
+admin/src/server/contexts/report/domain/
+├── models/
+│   ├── report-data.ts                 # validate() 追加、DonationData/IncomeData/ExpenseData の validate() も含む
+│   ├── organization-report-profile.ts # validate() 追加
+│   ├── donation-transaction.ts        # PersonalDonationSection.validate() 追加
+│   ├── income-transaction.ts          # 各Section.validate() 追加
+│   ├── expense-transaction.ts         # 各Section.validate() 追加
+│   └── summary-data.ts                # 既存（変更なし）
+└── types/
+    └── validation.ts                  # ValidationError, ValidationResult の型定義
+```
+
+## UIへの反映
+
+バリデーション結果は XML エクスポート画面で以下のように表示する：
+
+1. **エクスポート前チェック**: 「チェックする」ボタンでバリデーション実行
+2. **エラー表示**: エラーがある場合は一覧表示し、該当箇所へのリンクを提供
+3. **警告表示**: 警告は確認可能だが、エクスポート自体はブロックしない
+4. **エクスポートボタン**: エラーがある場合は無効化
+
+## 結論
+
+- バリデーションロジックは **各ドメインモデル自身** が持つ（リッチドメインモデル）
+- `ReportData.validate()` が全体の集約点となり、子モデルの `validate()` を呼び出す
+- 型定義（`ValidationError`, `ValidationResult`）のみ共通ファイルに切り出す
+- これにより、ドメインモデルが振る舞いを持ち、貧血ドメインモデルを回避できる


### PR DESCRIPTION
## Summary

- 政治資金報告書XMLエクスポート時のバリデーション機能の設計ドキュメントを追加
- リッチドメインモデルによる階層的バリデーションの設計方針を記載
- 各ドメインモデルが自身の`validate()`メソッドを持つ設計（貧血ドメインモデルを回避）

## Test plan

- [ ] ドキュメントの内容を確認
- [ ] 設計方針が適切かレビュー

🤖 Generated with [Claude Code](https://claude.com/claude-code)