### PR TITLE
docs: SYUUSHI07_13・SYUUSHI07_16の実装設計書を追加

### DIFF
--- a/docs/20251227_1722_SYUUSHI07_13_支出項目別金額内訳実装設計.md
+++ b/docs/20251227_1722_SYUUSHI07_13_支出項目別金額内訳実装設計.md
@@ -412,18 +412,26 @@ serializeBranchGrantExpenseSection(section: BranchGrantExpenseSection): XMLBuild
 
 | 桁位置 | シート | 判定条件 |
 |--------|--------|----------|
-| 21 | その13（支出項目別内訳） | シート14/15にデータがある場合 |
+| 21 | その13（支出項目別内訳） | 支出総額が0でない場合（人件費のみの場合も含む） |
 | 34 | その16（本支部交付金） | 本支部交付金データがある場合 |
 
 ### 7.2 フラグ判定ロジック
 
 ```
-// シート13
-shouldOutputSheet13 = shouldOutputRegularExpenseSheet(expenses) || shouldOutputPoliticalActivitySheet(expenses)
+// シート13: 支出が「０」の場合は不要、それ以外は出力
+// 人件費のみの場合も考慮する必要がある（シート14にKUBUNがないため個別判定が必要）
+shouldOutputSheet13 = (
+  expenses.personnelExpenses.totalAmount > 0 ||
+  ExpenseData.shouldOutputRegularExpenseSheet(expenses) ||
+  ExpenseData.shouldOutputPoliticalActivitySheet(expenses)
+)
 
 // シート16
 shouldOutputSheet16 = branchGrantExpenses.rows.length > 0 || branchGrantExpenses.totalAmount > 0
 ```
+
+**注意**: 人件費はシート14にKUBUNがないため、`shouldOutputRegularExpenseSheet`では検出されない。
+そのため、人件費のみがある場合でもシート13を出力するために、人件費の個別判定を追加する。
 
 ---
 


### PR DESCRIPTION
## Summary
- SYUUSHI07_13（支出項目別金額の内訳）とSYUUSHI07_16（本部または支部に対する交付金）の実装設計書を追加
- 人件費の特殊な扱い（SYUUSHI07_14にKUBUNなし、SYUUSHI07_13のみに計上）について設計に反映
- 既存のドメインモデル・シリアライザパターンに従った設計

## Test plan
- [ ] 設計ドキュメントのレビュー

🤖 Generated with [Claude Code](https://claude.com/claude-code)