### PR TITLE
config: CodeRabbitでdocs配下の設計ドキュメントをレビュー対象に追加

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -31,7 +31,9 @@ reviews:
     - "prisma/**"
     - "supabase/**"
     - "docs/**"
-    - "!**/*.md"
+    # docs配下のMarkdownはレビュー対象（設計ドキュメントのアーキテクチャレビュー）
+    - "!webapp/**/*.md"
+    - "!admin/**/*.md"
     - "!**/*.mdx"
     - "!**/*.svg"
     - "!**/*.png"
@@ -60,6 +62,19 @@ reviews:
 
     - path: "admin/src/server/contexts/report/**"
       instructions: "docs/report-format.md と docs/scope-by-2026Jan.md に従ってレビューしてください。"
+
+    - path: "docs/**/*.md"
+      instructions: |
+        これは設計ドキュメントです。以下の観点でアーキテクチャレビューを行ってください：
+
+        1. **アーキテクチャ整合性**: docs/admin-architecture-guide.md のレイヤードアーキテクチャ（presentation → application → domain ↔ infrastructure）に従っているか
+        2. **Bounded Context**: 適切なコンテキスト境界が設定されているか、責務が明確か
+        3. **ドメインモデル設計**: ドメインロジックがモデルに適切に配置されているか
+        4. **依存関係**: 依存性逆転の原則に違反していないか
+        5. **実装の実現可能性**: 設計が現実的に実装可能か、技術的な問題がないか
+        6. **既存コードとの整合性**: プロジェクトの既存パターンと一貫性があるか
+
+        設計の問題点や改善提案があれば具体的に指摘してください。
 
   auto_review:
     drafts: true


### PR DESCRIPTION
## Summary

- CodeRabbit の path_filters を変更し、`docs/**/*.md` をレビュー対象に追加
- 設計ドキュメント向けの path_instructions を追加（アーキテクチャ観点でのレビュー指示）

## 変更内容

### path_filters
- `!**/*.md` → `!webapp/**/*.md` と `!admin/**/*.md` に変更
- これにより `docs/` 配下の Markdown はレビュー対象に含まれる

### path_instructions 追加
`docs/**/*.md` に対して以下の観点でレビューするよう指示：
1. アーキテクチャ整合性（レイヤードアーキテクチャ準拠）
2. Bounded Context の適切性
3. ドメインモデル設計
4. 依存関係（依存性逆転の原則）
5. 実装の実現可能性
6. 既存コードとの整合性

## Test plan

- [ ] PRに設計ドキュメント（`docs/*.md`）を含めて、CodeRabbitがアーキテクチャ観点でレビューすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)