### PR TITLE
docs: 寄付者(Donor)紐付けページの設計ドキュメントを追加

### DIFF
--- a/docs/20251227_2135_寄付者紐付けページ設計.md
+++ b/docs/20251227_2135_寄付者紐付けページ設計.md
@@ -75,6 +75,83 @@ admin/src/server/contexts/report/domain/models/donor.ts
 - createdAt: Date
 - updatedAt: Date
 
+## ドメインサービス
+
+### DonorBulkAssignmentValidator（新規追加）
+
+複数取引への一括Donor紐付け時の整合性チェックを担当するドメインサービス。
+
+```
+admin/src/server/contexts/report/domain/services/donor-bulk-assignment-validator.ts
+```
+
+**責務:**
+- 複数取引のcategory_keyから許可されるdonor_typeの集合を算出
+- 選択されたDonorのdonor_typeが全取引で許可されているかを検証
+- ビジネスルールをドメイン層に集約し、再利用可能にする
+
+**インターフェース:**
+```typescript
+interface BulkAssignmentValidationResult {
+  isValid: boolean;
+  allowedDonorTypes: DonorType[];  // 全取引で共通して許可されるdonor_type
+  errors: BulkAssignmentValidationError[];
+}
+
+interface BulkAssignmentValidationError {
+  type: 'incompatible_categories' | 'donor_type_mismatch';
+  message: string;
+  details: {
+    transactionIds?: string[];
+    categoryKeys?: string[];
+    donorType?: DonorType;
+  };
+}
+
+class DonorBulkAssignmentValidator {
+  /**
+   * 複数取引のカテゴリ整合性をチェックし、許可されるdonor_typeを算出
+   */
+  validateCategoryCompatibility(
+    transactions: TransactionWithDonor[]
+  ): BulkAssignmentValidationResult;
+
+  /**
+   * 指定されたDonorが全取引に紐付け可能かをチェック
+   */
+  validateDonorAssignment(
+    transactions: TransactionWithDonor[],
+    donor: Donor
+  ): BulkAssignmentValidationResult;
+}
+```
+
+**ロジック詳細:**
+
+1. **カテゴリ整合性チェック** (`validateCategoryCompatibility`)
+   - 各取引のcategory_keyから許可されるdonor_typeの集合を取得（donor-assignment-rulesを利用）
+   - 全取引の許可donor_typeの積集合を算出
+   - 積集合が空の場合、`incompatible_categories`エラーを返す
+
+2. **Donor紐付け可能性チェック** (`validateDonorAssignment`)
+   - まずカテゴリ整合性をチェック
+   - Donorのdonor_typeが許可donor_typeに含まれるかをチェック
+   - 含まれない場合、`donor_type_mismatch`エラーを返す
+
+**使用例:**
+```typescript
+// BulkAssignDonorUsecase内での使用
+const validator = new DonorBulkAssignmentValidator();
+const result = validator.validateDonorAssignment(transactions, donor);
+
+if (!result.isValid) {
+  return { success: false, errors: result.errors };
+}
+
+// 紐付け実行
+await transactionDonorRepository.bulkAssign(transactionIds, donorId);
+```
+
 ## アーキテクチャ構成
 
 admin のBounded Context/レイヤードアーキテクチャに従い、以下の構成とする。
@@ -102,6 +179,8 @@ admin/src/server/contexts/report/
 │   │   ├── donor.ts
 │   │   ├── donor-assignment-rules.ts
 │   │   └── transaction-with-donor.ts
+│   ├── services/
+│   │   └── donor-bulk-assignment-validator.ts  # 一括紐付け整合性チェック
 │   └── repositories/
 │       ├── donor-repository.interface.ts
 │       └── transaction-donor-repository.interface.ts
@@ -305,8 +384,13 @@ interface TransactionWithDonorFilter {
 **処理:**
 1. 全取引の存在確認
 2. Donorの存在確認
-3. 各取引のcategory_keyとDonorのdonor_typeの整合性チェック
-4. 一括紐付け実行（トランザクション内で処理）
+3. **DonorBulkAssignmentValidator（Domain Service）を呼び出して整合性チェック**
+   - カテゴリ整合性チェック
+   - donor_type整合性チェック
+4. バリデーションエラーがあればResult型でエラーを返す
+5. 一括紐付け実行（トランザクション内で処理）
+
+**依存:** DonorBulkAssignmentValidator, TransactionDonorRepository, DonorRepository
 
 ## Server Action
 
@@ -367,7 +451,42 @@ interface CreateDonorInput {
 
 2. **donor_type整合性**: 選択したDonorのdonor_typeが、選択された全取引のカテゴリで許可されていること
 
-UIでは、異なるdonor_type制約を持つ取引が選択された場合、一括紐付けボタンを非活性にするか、警告メッセージを表示する。
+### レイヤー別の責務
+
+整合性チェックは**UI層**と**Domain Service層**の両方で実装する:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ UI層 (DonorAssignmentClient.tsx)                            │
+│ - 選択された取引のcategory_keyを見て一括紐付けボタン制御     │
+│ - UX向上のための早期フィードバック（親切機能）              │
+│ - donor-assignment-rulesを参照してクライアント側で判定      │
+└─────────────────────────────────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────┐
+│ Presentation層 (bulk-assign-donor.ts)                       │
+│ - Server Action、usecaseを呼び出すだけ                      │
+│ - バリデーションロジックは持たない                          │
+└─────────────────────────────────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────┐
+│ Application層 (bulk-assign-donor-usecase.ts)                │
+│ - Domain Serviceを呼び出して整合性チェック                   │
+│ - 整合性エラーがあればResult型で返す                        │
+└─────────────────────────────────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────┐
+│ Domain層 (donor-bulk-assignment-validator.ts)               │
+│ - 複数取引のカテゴリ整合性チェック                          │
+│ - donor_typeと各取引カテゴリの整合性チェック                │
+│ - ビジネスルールの単一責任・再利用可能                      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**設計の意図:**
+- **UI層**: ユーザー体験向上のため、不正な組み合わせを選択した時点で即座にフィードバック
+- **Domain Service層**: ビジネスルールの正式な実装場所。UIをバイパスされても（API直接呼び出し等）ルールが守られる
+- 両層で同じルール（donor-assignment-rules）を参照することで、判定ロジックの一貫性を保証
 
 ## Counterpartページとの差分
 


### PR DESCRIPTION
## Summary

- `/assign/donor` ページの設計ドキュメントを追加
- donorテーブル設計に基づき、寄付者紐付けUIの詳細設計をドキュメント化
- 既存のcounterpart紐付けページとの整合性・差分を明確化

## 内容

- ページ構成とUI設計（ワイヤーフレーム含む）
- ドメインモデル構成（donor-assignment-rules, transaction-with-donor等）
- レイヤー構成（presentation/application/domain/infrastructure）
- Server Actions / Loaders / Usecases / Repositories 設計
- donor_typeに応じたカテゴリ制約の反映

## Test plan

- [ ] 設計ドキュメントの内容確認
- [ ] donorテーブル設計との整合性確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 寄付者紐付け機能の設計ドキュメントを追加。UIフロー、画面構成、入力/出力契約、フィルタ／ソート／ページネーション、寄付者タイプ制約、単体／一括割当の検証ルール、および全体的なアーキテクチャと運用フローを網羅しています。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->