### PR TITLE
docs: donorシードデータの設計ドキュメントを追加

### DIFF
--- a/docs/20251227_2206_donorシードデータ設計.md
+++ b/docs/20251227_2206_donorシードデータ設計.md
@@ -1,0 +1,158 @@
+# Donor シードデータ設計
+
+## 概要
+
+donorテーブルにシードデータを追加し、transactionsシーダーでdonorとの紐付け（transaction_donors）も行う設計。
+
+## 背景
+
+- donorテーブルが [docs/20251224_1500_donorテーブル設計.md](20251224_1500_donorテーブル設計.md) に基づいて作成された
+- donorはcounterpartと異なり、`donor_type`（individual/corporation/political_organization）と`occupation`（個人のみ必須）を持つ
+- donorを紐付けるには、取引の`category_key`が特定の値（寄附・パーティー関連）である必要がある
+- 既存のtransactionsシーダーでは寄附関連取引が`other-income`で登録されているため、`category_key`の修正も必要
+
+## 設計方針
+
+### 1. 新規シーダーファイルの作成
+
+`prisma/seeds/donors.ts` を新規作成する。
+
+### 2. Donorシードデータの構成
+
+donorテーブル設計で定義された3種類のdonor_typeごとにテストデータを用意する:
+
+#### 個人（individual）
+
+| name | address | occupation | 用途 |
+|------|---------|------------|------|
+| 寄附　太郎 | 東京都渋谷区神南一丁目1番1号 | 会社員 | 個人からの寄附 |
+| 寄附　花子 | 東京都港区六本木三丁目2番1号 | 自営業 | 個人からの寄附 |
+| 寄附　次郎 | 東京都新宿区西新宿二丁目8番1号 | 会社役員 | 個人からの寄附 |
+| 寄附　三郎 | 東京都千代田区丸の内一丁目9番2号 | 弁護士 | 個人からの寄附 |
+| 寄附　四郎 | 東京都品川区東品川二丁目2番20号 | 医師 | 境界値テスト用 |
+| パーティー　一郎 | 東京都文京区本郷三丁目1番1号 | 公務員 | パーティー対価支払 |
+| パーティー　二郎 | 東京都台東区浅草一丁目1番1号 | 教員 | パーティー対価支払 |
+
+#### 法人その他の団体（corporation）
+
+| name | address | occupation | 用途 |
+|------|---------|------------|------|
+| 株式会社デジタル未来 | 東京都港区芝浦一丁目2番3号 | NULL | 法人からの寄附 |
+| 一般社団法人政治改革推進会 | 東京都中央区日本橋二丁目1番1号 | NULL | 法人からの寄附 |
+| NPO法人民主主義研究所 | 東京都世田谷区三軒茶屋一丁目1番1号 | NULL | 法人からの寄附 |
+| 株式会社イノベーション | 東京都港区六本木六丁目10番1号 | NULL | パーティー対価支払 |
+
+#### 政治団体（political_organization）
+
+| name | address | occupation | 用途 |
+|------|---------|------------|------|
+| デジタル政策推進団体 | 東京都千代田区永田町二丁目1番2号 | NULL | 政治団体からの寄附 |
+| 若手政治家の会 | 東京都港区赤坂一丁目11番28号 | NULL | 政治団体からの寄附 |
+| 地方創生研究会 | 東京都新宿区四谷一丁目1番1号 | NULL | パーティー対価支払 |
+
+### 3. Transactionsシーダーの修正
+
+#### 3.1 category_keyの修正
+
+donorを紐付けるため、既存の寄附関連取引の`category_key`を修正する。
+
+**注**: この修正は `fix/seed-account-names-and-counterpart-trigger` ブランチで実施予定。本設計ではそのブランチでの修正後の状態を前提とする。
+
+| transactionNo | 修正後のcategory_key |
+|---------------|---------------------|
+| T2025-0012 | individual-donations |
+| T2025-0013 | individual-donations |
+| T2025-0014 | individual-donations |
+| T2025-0015 | individual-donations |
+| T2025-0016 | individual-donations |
+| T2025-0017 | corporate-donations |
+| T2025-0018 | corporate-donations |
+| T2025-0019 | corporate-donations |
+| T2025-0020 | political-donations |
+| T2025-0021 | political-donations |
+
+#### 3.2 パーティー対価収入取引の追加
+
+政治資金パーティー対価支払者のテストデータとして、新規取引を追加する:
+
+| transactionNo | transactionDate | category_key | amount | description | donorName |
+|---------------|-----------------|--------------|--------|-------------|-----------|
+| T2025-0050 | 2025-07-20 | party-income | 200000 | パーティー対価収入（個人） | パーティー　一郎 |
+| T2025-0051 | 2025-07-20 | party-income | 150000 | パーティー対価収入（個人） | パーティー　二郎 |
+| T2025-0052 | 2025-07-20 | party-income | 500000 | パーティー対価収入（法人） | 株式会社イノベーション |
+| T2025-0053 | 2025-07-20 | party-income | 300000 | パーティー対価収入（政治団体） | 地方創生研究会 |
+
+#### 3.3 donorNameフィールドの追加
+
+TransactionSeedData型に`donorName`フィールドを追加し、donorとの紐付けに使用する:
+
+```typescript
+interface TransactionSeedData {
+  // ... 既存フィールド
+  counterpartName?: string;
+  donorName?: string;  // 新規追加
+}
+```
+
+#### 3.4 取引とDonorの紐付けマッピング
+
+| transactionNo | donorName | donor_type |
+|---------------|-----------|------------|
+| T2025-0012 | 寄附　太郎 | individual |
+| T2025-0013 | 寄附　花子 | individual |
+| T2025-0014 | 寄附　次郎 | individual |
+| T2025-0015 | 寄附　三郎 | individual |
+| T2025-0016 | 寄附　四郎 | individual |
+| T2025-0017 | 株式会社デジタル未来 | corporation |
+| T2025-0018 | 一般社団法人政治改革推進会 | corporation |
+| T2025-0019 | NPO法人民主主義研究所 | corporation |
+| T2025-0020 | デジタル政策推進団体 | political_organization |
+| T2025-0021 | 若手政治家の会 | political_organization |
+| T2025-0050 | パーティー　一郎 | individual |
+| T2025-0051 | パーティー　二郎 | individual |
+| T2025-0052 | 株式会社イノベーション | corporation |
+| T2025-0053 | 地方創生研究会 | political_organization |
+
+### 4. シーダーの実行順序
+
+`prisma/seed.ts` の実行順序:
+
+1. politicalOrganizationsSeeder
+2. reportProfilesSeeder
+3. usersSeeder
+4. counterpartsSeeder
+5. **donorsSeeder** ← 新規追加
+6. transactionsSeeder ← 修正（donor紐付け追加）
+
+donorsSeederはtransactionsSeederより前に実行する（donorが存在しないと紐付けできないため）。
+
+### 5. 重複チェックの実装
+
+#### donorsSeeder
+
+donorテーブルは `(name, address, donor_type)` の複合ユニーク制約を持つ。シーダーでは既存レコードの有無を `findFirst` でチェックし、存在しない場合のみ作成する。
+
+#### transactionsSeeder
+
+transaction_donorsテーブルは `(transaction_id)` のユニーク制約を持つ。取引作成後、donorNameが指定されている場合にdonorを検索し、transaction_donorsを作成する。
+
+### 6. バリデーショントリガーへの対応
+
+#### donorテーブルのトリガー
+
+- `validate_donor_occupation`: 個人の場合はoccupation必須、法人・政治団体の場合はNULL必須
+- `validate_donor_address`: 住所が未入力の場合はNOTICE警告
+
+シードデータはこれらに適合:
+- 個人（individual）: occupationを必ず設定
+- 法人・政治団体: occupationをnullに設定
+
+#### transaction_donorsテーブルのトリガー
+
+- `validate_transaction_donor`: 取引の`transaction_type`と`category_key`、donorの`donor_type`の整合性をチェック
+
+シードデータはこれらに適合:
+- `individual-donations`にはindividualのdonorのみ紐付け
+- `corporate-donations`にはcorporationのdonorのみ紐付け
+- `political-donations`にはpolitical_organizationのdonorのみ紐付け
+- `party-income`には全donor_typeを紐付け可能


### PR DESCRIPTION
## Summary

- donorテーブルへのシードデータ投入設計（個人7件、法人4件、政治団体3件）
- transactionsシーダーでのdonor紐付け（transaction_donors）設計
- パーティー対価収入取引の追加設計（4件）

## 前提

- `fix/seed-account-names-and-counterpart-trigger` ブランチでのcategory_key修正後に実装予定

## Test plan

- [ ] 設計内容のレビュー

🤖 Generated with [Claude Code](https://claude.com/claude-code)