### PR TITLE
docs: その15政治活動費の費目別シート分割設計を追加

### DIFF
--- a/docs/20251227_2354_その15政治活動費の費目別シート分割設計.md
+++ b/docs/20251227_2354_その15政治活動費の費目別シート分割設計.md
@@ -1,0 +1,156 @@
+# その15（SYUUSHI07_15）政治活動費の費目別シート分割設計
+
+## 概要
+
+政治活動費（SYUUSHI07_15）において、`friendlyCategory`（補助科目）をXMLの`HIMOKU`（費目）として使用し、費目ごとに複数のSHEETを出力する機能を設計する。
+
+## 背景
+
+### 現状
+
+現在の実装では、各KUBUN（組織活動費、選挙関係費など）に対して1つのSHEETのみを出力している。`HIMOKU`（費目）は空文字で出力され、`friendlyCategory`は`MOKUTEKI`（目的）として使用されている。
+
+### 課題
+
+政治資金収支報告書の仕様では、「項目別区分」の下段に「小分類」として費目を記載する必要がある。現状では費目が空欄のままとなっており、仕様に沿っていない。
+
+### 解決策
+
+`friendlyCategory`を費目（HIMOKU）として使用し、同じ費目のトランザクションをグループ化して、費目ごとに別々のSHEETを出力する。
+
+## XML仕様の確認
+
+### その15（SYUUSHI07_15）のXML構造
+
+```xml
+<SYUUSHI07_15>
+  <KUBUN1>  <!-- 組織活動費 -->
+    <SHEET>
+      <HIMOKU>会議費</HIMOKU>
+      <KINGAKU_GK>合計金額</KINGAKU_GK>
+      <SONOTA_GK>その他の支出</SONOTA_GK>
+      <ROW>...</ROW>
+    </SHEET>
+    <SHEET>
+      <HIMOKU>交通費</HIMOKU>
+      <KINGAKU_GK>合計金額</KINGAKU_GK>
+      <SONOTA_GK>その他の支出</SONOTA_GK>
+      <ROW>...</ROW>
+    </SHEET>
+  </KUBUN1>
+  <!-- KUBUN2〜KUBUN9 も同様 -->
+</SYUUSHI07_15>
+```
+
+### 1つのKUBUNに複数SHEETが許容される根拠
+
+- その11（SYUUSHI07_11）では「パーティーごとに」複数のSHEETを持つ構造が定義されている
+- その15も同様に、費目ごとに複数のSHEETを持つことができる
+
+### SHEET直下の項目
+
+| 項目名 | タグ名 | 説明 |
+|--------|--------|------|
+| 費目 | HIMOKU | 費目の名称（例：会議費、交通費） |
+| 合計 | KINGAKU_GK | そのシート内の合計金額 |
+| その他の支出 | SONOTA_GK | 5万円以下の支出の合算 |
+
+## 設計
+
+### データフロー
+
+```
+Transaction (DB)
+  └─ friendlyCategory: "会議費"
+  └─ description: "会議室利用料"
+        ↓
+  グループ化（friendlyCategory別）
+        ↓
+OrganizationExpenseSection[]
+  └─ [0] himoku: "会議費", rows: [...]
+  └─ [1] himoku: "交通費", rows: [...]
+        ↓
+  シリアライズ
+        ↓
+<KUBUN1>
+  <SHEET><HIMOKU>会議費</HIMOKU>...</SHEET>
+  <SHEET><HIMOKU>交通費</HIMOKU>...</SHEET>
+</KUBUN1>
+```
+
+### フィールドマッピング
+
+| トランザクションフィールド | XMLフィールド | 説明 |
+|--------------------------|---------------|------|
+| `friendlyCategory` | `HIMOKU` | 費目（シート単位） |
+| `friendlyCategory` | `MOKUTEKI` | 目的（行単位） |
+
+※ HIMOKUとMOKUTEKIには同じ値（friendlyCategory）が入る。これは他の政治団体でも一般的なパターン。
+
+### 型定義の変更
+
+#### 変更前
+
+```
+OrganizationExpenseSection {
+  himoku: string;  // 常に空文字
+  totalAmount: number;
+  underThresholdAmount: number;
+  rows: PoliticalActivityExpenseRow[];
+}
+```
+
+#### 変更後
+
+各KUBUNのセクションは、費目ごとの複数シートを持つ配列となる。
+
+### 集約ロジック
+
+1. トランザクションを`friendlyCategory`でグループ化
+2. 各グループに対して：
+   - `himoku` = グループのキー（friendlyCategory）
+   - 5万円超のトランザクションを`rows`に
+   - 5万円以下のトランザクションを`underThresholdAmount`に合算
+   - `totalAmount` = 全トランザクションの合計
+
+### シリアライザーの変更
+
+各KUBUNに対して、配列内の各セクションをSHEETとして出力する。
+
+## 影響範囲
+
+### 変更が必要なファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `admin/src/server/contexts/report/domain/models/expense-transaction.ts` | セクション型を配列化、集約ロジックの変更 |
+| `admin/src/server/contexts/report/domain/services/expense-serializer.ts` | 複数SHEET出力に対応 |
+| `admin/tests/server/contexts/report/domain/services/expense-serializer.test.ts` | テストケースの更新 |
+| `admin/tests/server/contexts/report/domain/models/expense-transaction.test.ts` | テストケースの更新 |
+
+### MOKUTEKIフィールドの扱い
+
+`MOKUTEKI`（目的）にも`friendlyCategory`を使用する。他の政治団体でも同様のケースが多いため、この方針を採用する。
+
+| XMLフィールド | データソース | 例 |
+|---------------|-------------|-----|
+| HIMOKU（費目） | friendlyCategory | 会議費 |
+| MOKUTEKI（目的） | friendlyCategory | 会議費 |
+
+## 考慮事項
+
+### 空のfriendlyCategoryの扱い
+
+`friendlyCategory`がnullまたは空文字の場合の処理方針：
+- 空文字のHIMOKUを持つSHEETとしてグループ化する
+- または、デフォルト値（例：「その他」）を設定する
+
+### シートの並び順
+
+費目ごとのシートをどの順序で出力するか：
+- friendlyCategoryのアルファベット順
+- または、トランザクションの出現順
+
+### 既存のXML出力との互換性
+
+費目が1種類のみの場合、現行と同じ1シート構造となるため、後方互換性は保たれる。


### PR DESCRIPTION
## Summary

- SYUUSHI07_15（政治活動費）において、`friendlyCategory`を費目（HIMOKU）として使用し、費目ごとに複数のSHEETを出力する機能の設計ドキュメントを追加

## 設計のポイント

- `friendlyCategory` を `HIMOKU`（費目・シート単位）と `MOKUTEKI`（目的・行単位）の両方に使用
- 同じ費目のトランザクションをグループ化し、費目ごとに別々のSHEETを出力
- 他の政治団体でも一般的なパターンに準拠

## Test plan

- [ ] 設計ドキュメントの内容を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 政治活動費の支出項目別シート分割に関する設計ドキュメントを追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->