### PR TITLE
refactor: 報告書プレビューの表示改善と不要なuse clientの削除

### DIFF
--- a/admin/src/client/components/export-report/ReportDataPreview.tsx
+++ b/admin/src/client/components/export-report/ReportDataPreview.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import type { ReportData } from "@/server/contexts/report/domain/models/report-data";
 import { DonationSection } from "./sections/DonationSection";
 import { IncomeSection } from "./sections/IncomeSection";

--- a/admin/src/client/components/export-report/sections/DonationSection.tsx
+++ b/admin/src/client/components/export-report/sections/DonationSection.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import {
   Table,
   TableBody,
@@ -40,28 +38,32 @@ function PersonalDonationTable({ rows }: PersonalDonationTableProps) {
   }
 
   return (
-    <Table>
+    <Table className="border-collapse border border-black">
       <TableHeader>
-        <TableRow className="border-black">
-          <TableHead className="w-[50px] text-black">No.</TableHead>
-          <TableHead className="w-[150px] text-black">寄附者氏名</TableHead>
-          <TableHead className="w-[100px] text-right text-black">金額</TableHead>
-          <TableHead className="w-[100px] text-black">年月日</TableHead>
-          <TableHead className="w-[200px] text-black">住所</TableHead>
-          <TableHead className="w-[100px] text-black">職業</TableHead>
-          <TableHead className="w-[150px] text-black">備考</TableHead>
+        <TableRow className="border border-black">
+          <TableHead className="w-[50px] text-black border border-black">行番号</TableHead>
+          <TableHead className="w-[150px] text-black border border-black">寄附者氏名</TableHead>
+          <TableHead className="w-[100px] text-right text-black border border-black">
+            金額
+          </TableHead>
+          <TableHead className="w-[100px] text-black border border-black">年月日</TableHead>
+          <TableHead className="w-[200px] text-black border border-black">住所</TableHead>
+          <TableHead className="w-[100px] text-black border border-black">職業</TableHead>
+          <TableHead className="w-[150px] text-black border border-black">備考</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
         {rows.map((row) => (
-          <TableRow key={row.ichirenNo} className="border-black">
-            <TableCell className="text-black">{row.ichirenNo}</TableCell>
-            <TableCell className="text-black">{row.kifusyaNm}</TableCell>
-            <TableCell className="text-right text-black">{formatCurrency(row.kingaku)}</TableCell>
-            <TableCell className="text-black">{formatDate(row.dt)}</TableCell>
-            <TableCell className="text-black">{row.adr}</TableCell>
-            <TableCell className="text-black">{row.syokugyo}</TableCell>
-            <TableCell className="text-black">{row.bikou || ""}</TableCell>
+          <TableRow key={row.ichirenNo} className="border border-black">
+            <TableCell className="text-black border border-black">{row.ichirenNo}</TableCell>
+            <TableCell className="text-black border border-black">{row.kifusyaNm}</TableCell>
+            <TableCell className="text-right text-black border border-black">
+              {formatCurrency(row.kingaku)}
+            </TableCell>
+            <TableCell className="text-black border border-black">{formatDate(row.dt)}</TableCell>
+            <TableCell className="text-black border border-black">{row.adr}</TableCell>
+            <TableCell className="text-black border border-black">{row.syokugyo}</TableCell>
+            <TableCell className="text-black border border-black">{row.bikou || ""}</TableCell>
           </TableRow>
         ))}
       </TableBody>

--- a/admin/src/client/components/export-report/sections/IncomeSection.tsx
+++ b/admin/src/client/components/export-report/sections/IncomeSection.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import {
   Table,
   TableBody,
@@ -49,22 +47,26 @@ function BusinessIncomeTable({ rows }: BusinessIncomeTableProps) {
   }
 
   return (
-    <Table>
+    <Table className="border-collapse border border-black">
       <TableHeader>
-        <TableRow className="border-black">
-          <TableHead className="w-[50px] text-black">No.</TableHead>
-          <TableHead className="w-[250px] text-black">事業の種類</TableHead>
-          <TableHead className="w-[100px] text-right text-black">金額</TableHead>
-          <TableHead className="w-[200px] text-black">備考</TableHead>
+        <TableRow className="border border-black">
+          <TableHead className="w-[50px] text-black border border-black">行番号</TableHead>
+          <TableHead className="w-[250px] text-black border border-black">事業の種類</TableHead>
+          <TableHead className="w-[100px] text-right text-black border border-black">
+            金額
+          </TableHead>
+          <TableHead className="w-[200px] text-black border border-black">備考</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
         {rows.map((row) => (
-          <TableRow key={row.ichirenNo} className="border-black">
-            <TableCell className="text-black">{row.ichirenNo}</TableCell>
-            <TableCell className="text-black">{row.gigyouSyurui}</TableCell>
-            <TableCell className="text-right text-black">{formatCurrency(row.kingaku)}</TableCell>
-            <TableCell className="text-black">{row.bikou || ""}</TableCell>
+          <TableRow key={row.ichirenNo} className="border border-black">
+            <TableCell className="text-black border border-black">{row.ichirenNo}</TableCell>
+            <TableCell className="text-black border border-black">{row.gigyouSyurui}</TableCell>
+            <TableCell className="text-right text-black border border-black">
+              {formatCurrency(row.kingaku)}
+            </TableCell>
+            <TableCell className="text-black border border-black">{row.bikou || ""}</TableCell>
           </TableRow>
         ))}
       </TableBody>
@@ -82,22 +84,26 @@ function LoanIncomeTable({ rows }: LoanIncomeTableProps) {
   }
 
   return (
-    <Table>
+    <Table className="border-collapse border border-black">
       <TableHeader>
-        <TableRow className="border-black">
-          <TableHead className="w-[50px] text-black">No.</TableHead>
-          <TableHead className="w-[250px] text-black">借入先</TableHead>
-          <TableHead className="w-[100px] text-right text-black">金額</TableHead>
-          <TableHead className="w-[200px] text-black">備考</TableHead>
+        <TableRow className="border border-black">
+          <TableHead className="w-[50px] text-black border border-black">行番号</TableHead>
+          <TableHead className="w-[250px] text-black border border-black">借入先</TableHead>
+          <TableHead className="w-[100px] text-right text-black border border-black">
+            金額
+          </TableHead>
+          <TableHead className="w-[200px] text-black border border-black">備考</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
         {rows.map((row) => (
-          <TableRow key={row.ichirenNo} className="border-black">
-            <TableCell className="text-black">{row.ichirenNo}</TableCell>
-            <TableCell className="text-black">{row.kariiresaki}</TableCell>
-            <TableCell className="text-right text-black">{formatCurrency(row.kingaku)}</TableCell>
-            <TableCell className="text-black">{row.bikou || ""}</TableCell>
+          <TableRow key={row.ichirenNo} className="border border-black">
+            <TableCell className="text-black border border-black">{row.ichirenNo}</TableCell>
+            <TableCell className="text-black border border-black">{row.kariiresaki}</TableCell>
+            <TableCell className="text-right text-black border border-black">
+              {formatCurrency(row.kingaku)}
+            </TableCell>
+            <TableCell className="text-black border border-black">{row.bikou || ""}</TableCell>
           </TableRow>
         ))}
       </TableBody>
@@ -115,26 +121,30 @@ function GrantIncomeTable({ rows }: GrantIncomeTableProps) {
   }
 
   return (
-    <Table>
+    <Table className="border-collapse border border-black">
       <TableHeader>
-        <TableRow className="border-black">
-          <TableHead className="w-[50px] text-black">No.</TableHead>
-          <TableHead className="w-[200px] text-black">本支部名称</TableHead>
-          <TableHead className="w-[100px] text-right text-black">金額</TableHead>
-          <TableHead className="w-[100px] text-black">年月日</TableHead>
-          <TableHead className="w-[200px] text-black">事務所所在地</TableHead>
-          <TableHead className="w-[150px] text-black">備考</TableHead>
+        <TableRow className="border border-black">
+          <TableHead className="w-[50px] text-black border border-black">行番号</TableHead>
+          <TableHead className="w-[200px] text-black border border-black">本支部名称</TableHead>
+          <TableHead className="w-[100px] text-right text-black border border-black">
+            金額
+          </TableHead>
+          <TableHead className="w-[100px] text-black border border-black">年月日</TableHead>
+          <TableHead className="w-[200px] text-black border border-black">事務所所在地</TableHead>
+          <TableHead className="w-[150px] text-black border border-black">備考</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
         {rows.map((row) => (
-          <TableRow key={row.ichirenNo} className="border-black">
-            <TableCell className="text-black">{row.ichirenNo}</TableCell>
-            <TableCell className="text-black">{row.honsibuNm}</TableCell>
-            <TableCell className="text-right text-black">{formatCurrency(row.kingaku)}</TableCell>
-            <TableCell className="text-black">{formatDate(row.dt)}</TableCell>
-            <TableCell className="text-black">{row.jimuAdr}</TableCell>
-            <TableCell className="text-black">{row.bikou || ""}</TableCell>
+          <TableRow key={row.ichirenNo} className="border border-black">
+            <TableCell className="text-black border border-black">{row.ichirenNo}</TableCell>
+            <TableCell className="text-black border border-black">{row.honsibuNm}</TableCell>
+            <TableCell className="text-right text-black border border-black">
+              {formatCurrency(row.kingaku)}
+            </TableCell>
+            <TableCell className="text-black border border-black">{formatDate(row.dt)}</TableCell>
+            <TableCell className="text-black border border-black">{row.jimuAdr}</TableCell>
+            <TableCell className="text-black border border-black">{row.bikou || ""}</TableCell>
           </TableRow>
         ))}
       </TableBody>
@@ -152,22 +162,26 @@ function OtherIncomeTable({ rows }: OtherIncomeTableProps) {
   }
 
   return (
-    <Table>
+    <Table className="border-collapse border border-black">
       <TableHeader>
-        <TableRow className="border-black">
-          <TableHead className="w-[50px] text-black">No.</TableHead>
-          <TableHead className="w-[250px] text-black">摘要</TableHead>
-          <TableHead className="w-[100px] text-right text-black">金額</TableHead>
-          <TableHead className="w-[200px] text-black">備考</TableHead>
+        <TableRow className="border border-black">
+          <TableHead className="w-[50px] text-black border border-black">行番号</TableHead>
+          <TableHead className="w-[250px] text-black border border-black">摘要</TableHead>
+          <TableHead className="w-[100px] text-right text-black border border-black">
+            金額
+          </TableHead>
+          <TableHead className="w-[200px] text-black border border-black">備考</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
         {rows.map((row) => (
-          <TableRow key={row.ichirenNo} className="border-black">
-            <TableCell className="text-black">{row.ichirenNo}</TableCell>
-            <TableCell className="text-black">{row.tekiyou}</TableCell>
-            <TableCell className="text-right text-black">{formatCurrency(row.kingaku)}</TableCell>
-            <TableCell className="text-black">{row.bikou || ""}</TableCell>
+          <TableRow key={row.ichirenNo} className="border border-black">
+            <TableCell className="text-black border border-black">{row.ichirenNo}</TableCell>
+            <TableCell className="text-black border border-black">{row.tekiyou}</TableCell>
+            <TableCell className="text-right text-black border border-black">
+              {formatCurrency(row.kingaku)}
+            </TableCell>
+            <TableCell className="text-black border border-black">{row.bikou || ""}</TableCell>
           </TableRow>
         ))}
       </TableBody>

--- a/admin/src/client/components/export-report/sections/PoliticalActivityExpenseSection.tsx
+++ b/admin/src/client/components/export-report/sections/PoliticalActivityExpenseSection.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import {
   Table,
   TableBody,
@@ -56,28 +54,32 @@ function PoliticalActivityExpenseTable({ rows }: PoliticalActivityExpenseTablePr
   }
 
   return (
-    <Table>
+    <Table className="border-collapse border border-black">
       <TableHeader>
-        <TableRow className="border-black">
-          <TableHead className="w-[50px] text-black">No.</TableHead>
-          <TableHead className="w-[200px] text-black">目的</TableHead>
-          <TableHead className="w-[100px] text-right text-black">金額</TableHead>
-          <TableHead className="w-[100px] text-black">年月日</TableHead>
-          <TableHead className="w-[150px] text-black">氏名</TableHead>
-          <TableHead className="w-[200px] text-black">住所</TableHead>
-          <TableHead className="w-[150px] text-black">備考</TableHead>
+        <TableRow className="border border-black">
+          <TableHead className="w-[50px] text-black border border-black">行番号</TableHead>
+          <TableHead className="w-[200px] text-black border border-black">目的</TableHead>
+          <TableHead className="w-[100px] text-right text-black border border-black">
+            金額
+          </TableHead>
+          <TableHead className="w-[100px] text-black border border-black">年月日</TableHead>
+          <TableHead className="w-[150px] text-black border border-black">氏名</TableHead>
+          <TableHead className="w-[200px] text-black border border-black">住所</TableHead>
+          <TableHead className="w-[150px] text-black border border-black">備考</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
         {rows.map((row) => (
-          <TableRow key={row.ichirenNo} className="border-black">
-            <TableCell className="text-black">{row.ichirenNo}</TableCell>
-            <TableCell className="text-black">{row.mokuteki}</TableCell>
-            <TableCell className="text-right text-black">{formatCurrency(row.kingaku)}</TableCell>
-            <TableCell className="text-black">{formatDate(row.dt)}</TableCell>
-            <TableCell className="text-black">{row.nm}</TableCell>
-            <TableCell className="text-black">{row.adr}</TableCell>
-            <TableCell className="text-black">{row.bikou || ""}</TableCell>
+          <TableRow key={row.ichirenNo} className="border border-black">
+            <TableCell className="text-black border border-black">{row.ichirenNo}</TableCell>
+            <TableCell className="text-black border border-black">{row.mokuteki}</TableCell>
+            <TableCell className="text-right text-black border border-black">
+              {formatCurrency(row.kingaku)}
+            </TableCell>
+            <TableCell className="text-black border border-black">{formatDate(row.dt)}</TableCell>
+            <TableCell className="text-black border border-black">{row.nm}</TableCell>
+            <TableCell className="text-black border border-black">{row.adr}</TableCell>
+            <TableCell className="text-black border border-black">{row.bikou || ""}</TableCell>
           </TableRow>
         ))}
       </TableBody>

--- a/admin/src/client/components/export-report/sections/RegularExpenseSection.tsx
+++ b/admin/src/client/components/export-report/sections/RegularExpenseSection.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import {
   Table,
   TableBody,
@@ -44,28 +42,32 @@ function ExpenseTable({ rows }: ExpenseTableProps) {
   }
 
   return (
-    <Table>
+    <Table className="border-collapse border border-black">
       <TableHeader>
-        <TableRow className="border-black">
-          <TableHead className="w-[50px] text-black">No.</TableHead>
-          <TableHead className="w-[200px] text-black">目的</TableHead>
-          <TableHead className="w-[100px] text-right text-black">金額</TableHead>
-          <TableHead className="w-[100px] text-black">年月日</TableHead>
-          <TableHead className="w-[150px] text-black">氏名</TableHead>
-          <TableHead className="w-[200px] text-black">住所</TableHead>
-          <TableHead className="w-[150px] text-black">備考</TableHead>
+        <TableRow className="border border-black">
+          <TableHead className="w-[50px] text-black border border-black">行番号</TableHead>
+          <TableHead className="w-[200px] text-black border border-black">目的</TableHead>
+          <TableHead className="w-[100px] text-right text-black border border-black">
+            金額
+          </TableHead>
+          <TableHead className="w-[100px] text-black border border-black">年月日</TableHead>
+          <TableHead className="w-[150px] text-black border border-black">氏名</TableHead>
+          <TableHead className="w-[200px] text-black border border-black">住所</TableHead>
+          <TableHead className="w-[150px] text-black border border-black">備考</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
         {rows.map((row) => (
-          <TableRow key={row.ichirenNo} className="border-black">
-            <TableCell className="text-black">{row.ichirenNo}</TableCell>
-            <TableCell className="text-black">{row.mokuteki}</TableCell>
-            <TableCell className="text-right text-black">{formatCurrency(row.kingaku)}</TableCell>
-            <TableCell className="text-black">{formatDate(row.dt)}</TableCell>
-            <TableCell className="text-black">{row.nm}</TableCell>
-            <TableCell className="text-black">{row.adr}</TableCell>
-            <TableCell className="text-black">{row.bikou || ""}</TableCell>
+          <TableRow key={row.ichirenNo} className="border border-black">
+            <TableCell className="text-black border border-black">{row.ichirenNo}</TableCell>
+            <TableCell className="text-black border border-black">{row.mokuteki}</TableCell>
+            <TableCell className="text-right text-black border border-black">
+              {formatCurrency(row.kingaku)}
+            </TableCell>
+            <TableCell className="text-black border border-black">{formatDate(row.dt)}</TableCell>
+            <TableCell className="text-black border border-black">{row.nm}</TableCell>
+            <TableCell className="text-black border border-black">{row.adr}</TableCell>
+            <TableCell className="text-black border border-black">{row.bikou || ""}</TableCell>
           </TableRow>
         ))}
       </TableBody>

--- a/admin/src/client/components/export-report/sections/SectionWrapper.tsx
+++ b/admin/src/client/components/export-report/sections/SectionWrapper.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import type { ReactNode } from "react";
 
 interface SectionWrapperProps {
@@ -26,9 +24,7 @@ export function SectionWrapper({
   children,
 }: SectionWrapperProps) {
   return (
-    <div
-      className={`bg-white border border-black rounded-lg overflow-hidden ${isEmpty ? "opacity-50" : ""}`}
-    >
+    <div className={`bg-white border border-black overflow-hidden ${isEmpty ? "opacity-50" : ""}`}>
       <div className="bg-gray-100 border-b border-black px-4 py-3">
         <div className="flex flex-col gap-1">
           <h3 className="text-lg font-semibold text-black">

--- a/admin/src/client/components/ui/table.tsx
+++ b/admin/src/client/components/ui/table.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import type * as React from "react";
 
 import { cn } from "@/client/lib/index";


### PR DESCRIPTION
## Summary
- 報告書エクスポートページのプレビュー表示をシート風に改善
  - 白いエリアの角丸を削除
  - 全セルに1pxの黒い罫線を追加
  - 「No.」を「行番号」に変更
- 不要な`"use client"`を削除してバンドルサイズを軽量化
  - `table.tsx`および各セクションコンポーネントは動的処理がないため共有コンポーネントとして扱う

## Test plan
- [ ] `/export-report` ページでプレビューを生成し、テーブルの表示を確認
- [ ] 角丸がなく、全セルに罫線が表示されていることを確認
- [ ] ヘッダーが「行番号」になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)