### PR TITLE
docs: 報告書エクスポートページのサーバーコンポーネント化設計

### DIFF
--- a/docs/20251228_0011_報告書エクスポートページのサーバーコンポーネント化.md
+++ b/docs/20251228_0011_報告書エクスポートページのサーバーコンポーネント化.md
@@ -1,0 +1,130 @@
+# 報告書エクスポートページのサーバーコンポーネント化設計
+
+## 概要
+
+現在の報告書エクスポートページ（`/export-report`）は、政治団体と年度を選択後「プレビュー」ボタンを押すことで報告書データを取得・表示する実装になっている。これを、URLパラメータに基づいてサーバーサイドでデータを取得し、リクエスト時にレンダリングする方式に変更する。
+
+## 現状の問題
+
+1. **クライアントサイドでのデータ取得**: プレビューボタンを押すとサーバーアクション経由でデータ取得を行っている
+2. **URLでの状態管理がない**: 政治団体IDと年度がローカルステートで管理されており、URLを共有できない
+3. **不要な"use client"**: データ取得のためにクライアントコンポーネント化されている
+
+## 変更方針
+
+### URLパス設計
+
+現在:
+```
+/export-report
+```
+
+変更後:
+```
+/export-report/[orgId]/[year]
+```
+
+- `orgId`: 政治団体ID
+- `year`: 報告年（西暦）
+
+### ファイル構成
+
+```
+admin/src/app/(auth)/export-report/
+├── page.tsx                     # リダイレクト用ページ（デフォルトの団体・年度へ）
+└── [orgId]/
+    └── [year]/
+        └── page.tsx             # サーバーコンポーネント（データ取得・レンダリング）
+```
+
+### コンポーネント設計
+
+#### 1. ルートページ (`/export-report/page.tsx`)
+
+- 政治団体一覧を取得
+- 最初の政治団体と現在年でリダイレクト
+- 団体が存在しない場合はエラーメッセージを表示
+
+#### 2. 詳細ページ (`/export-report/[orgId]/[year]/page.tsx`)
+
+サーバーコンポーネントとして以下を実装:
+
+- URLパラメータから`orgId`と`year`を取得
+- `loadReportPreviewData`ローダー経由でReportDataを取得
+- 政治団体一覧を取得（セレクタ用）
+- データをクライアントコンポーネントに渡してレンダリング
+
+#### 3. クライアントコンポーネント
+
+以下のクライアントコンポーネントに分割:
+
+| コンポーネント | 役割 |
+|---|---|
+| `ExportReportHeader` | タイトル・説明表示 |
+| `ExportReportSelectors` | 政治団体・年度セレクタ（URLナビゲーション用） |
+| `ExportReportPreview` | タブ切り替え付きプレビュー表示（表形式/XML） |
+| `DownloadButton` | XMLダウンロードボタン（既存API利用） |
+
+### データフロー
+
+```
+URL: /export-report/[orgId]/[year]
+        ↓
+    サーバーコンポーネント
+        ↓
+    loadReportPreviewData(orgId, year)
+        ↓
+    XmlExportUsecase.execute()
+        ↓
+    ReportData + XML string
+        ↓
+    クライアントコンポーネントへ props として渡す
+```
+
+### 新規ローダーの追加
+
+`admin/src/server/contexts/report/presentation/loaders/report-preview-loader.ts`:
+
+- `XmlExportUsecase`を呼び出して`ReportData`と`xml`を取得
+- `unstable_cache`でキャッシュ（既存ローダーと同様のパターン）
+- キャッシュキー: `["report-preview", orgId, year]`
+
+### セレクタの動作
+
+政治団体・年度のセレクタは選択変更時に`router.push()`でURLを更新する:
+
+```
+/export-report/{選択したorgId}/{選択したyear}
+```
+
+既存の`YearSelector`コンポーネントと同様のパターンを採用。
+
+### ダウンロード機能
+
+- ダウンロードボタンは既存の`apiClient.downloadReport()`を利用
+- Shift_JISエンコードはサーバーサイドのAPIルート(`/api/export-report`)で実施
+
+### エラーハンドリング
+
+- 政治団体が見つからない場合: `notFound()`
+- プロフィールが未登録の場合: エラーメッセージを表示し、プロフィール登録ページへのリンクを提示
+
+## 変更対象ファイル
+
+| ファイル | 変更内容 |
+|---|---|
+| `admin/src/app/(auth)/export-report/page.tsx` | リダイレクト処理のみに変更 |
+| `admin/src/app/(auth)/export-report/[orgId]/[year]/page.tsx` | 新規作成（サーバーコンポーネント） |
+| `admin/src/server/contexts/report/presentation/loaders/report-preview-loader.ts` | 新規作成（ローダー） |
+| `admin/src/client/components/export-report/ExportReportClient.tsx` | 削除 |
+| `admin/src/client/components/export-report/ExportReportSelectors.tsx` | 新規作成（セレクタ） |
+| `admin/src/client/components/export-report/ExportReportPreview.tsx` | 新規作成（プレビュー表示） |
+| `admin/src/client/components/export-report/DownloadButton.tsx` | 新規作成（ダウンロードボタン） |
+| `admin/src/client/components/export-report/ReportDataPreview.tsx` | 変更なし（既存流用） |
+| `admin/src/client/components/export-report/XmlPreview.tsx` | `"use client"`削除可能（状態を持たないため） |
+
+## キャッシュ戦略
+
+- ローダーで`unstable_cache`を使用し、60秒のrevalidateを設定
+- 報告書プロフィールや取引データが更新された場合は、該当するアクションで`revalidateTag`を呼び出す
+- タグ: `report-preview-${orgId}-${year}`


### PR DESCRIPTION
## Summary
- 報告書エクスポートページ (`/export-report`) のサーバーコンポーネント化に向けた設計ドキュメントを追加
- URLパラメータ (`/export-report/[orgId]/[year]`) による状態管理への変更方針を策定
- ローダー、コンポーネント分割、キャッシュ戦略を整理

## Test plan
- [ ] 設計ドキュメントの内容確認
- [ ] アーキテクチャガイドラインとの整合性確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)