### PR TITLE
feat(seed): その他の経費に5万円以上のテストデータを追加

### DIFF
--- a/prisma/seeds/counterparts.ts
+++ b/prisma/seeds/counterparts.ts
@@ -80,6 +80,9 @@ const data: CounterpartSeedData[] = [
   // 政治活動費（その他の経費）
   { name: '株式会社会計クラウド', address: '東京都渋谷区道玄坂一丁目2番3号' },
   { name: 'みずほ銀行', address: '東京都千代田区大手町一丁目5番5号' },
+  { name: '株式会社法務コンサルティング', address: '東京都中央区銀座一丁目1番1号' },
+  { name: '行政書士事務所山田', address: '東京都港区新橋二丁目2番2号' },
+  { name: '税理士法人田中事務所', address: '東京都千代田区霞が関三丁目3番3号' },
 ];
 
 export const counterpartsSeeder: Seeder = {

--- a/prisma/seeds/transactions.ts
+++ b/prisma/seeds/transactions.ts
@@ -605,7 +605,7 @@ const data: TransactionSeedData[] = [
     friendlyCategory: '政治団体寄附',
   },
 
-  // SYUUSHI07_15: 政治活動費の支出（KUBUN9: その他の経費）
+  // SYUUSHI07_15: 政治活動費の支出（KUBUN9: その他の経費、境界値テスト: 5万円）
   {
     transactionNo: 'T2025-0046',
     transactionDate: '2025-12-31',
@@ -631,6 +631,45 @@ const data: TransactionSeedData[] = [
     categoryKey: 'other-expenses',
     counterpartName: 'みずほ銀行',
     friendlyCategory: '振込手数料',
+  },
+  {
+    transactionNo: 'T2025-0050',
+    transactionDate: '2025-10-20',
+    transactionType: 'expense',
+    debitAccount: 'その他の経費',
+    debitAmount: '80000',
+    creditAccount: '普通預金',
+    creditAmount: '80000',
+    description: '法務相談費用',
+    categoryKey: 'other-expenses',
+    counterpartName: '株式会社法務コンサルティング',
+    friendlyCategory: '法務相談料',
+  },
+  {
+    transactionNo: 'T2025-0051',
+    transactionDate: '2025-11-15',
+    transactionType: 'expense',
+    debitAccount: 'その他の経費',
+    debitAmount: '50000',
+    creditAccount: '普通預金',
+    creditAmount: '50000',
+    description: '届出書類作成代行（境界値: ちょうど5万円）',
+    categoryKey: 'other-expenses',
+    counterpartName: '行政書士事務所山田',
+    friendlyCategory: '行政書士報酬',
+  },
+  {
+    transactionNo: 'T2025-0052',
+    transactionDate: '2025-12-10',
+    transactionType: 'expense',
+    debitAccount: 'その他の経費',
+    debitAmount: '150000',
+    creditAccount: '普通預金',
+    creditAmount: '150000',
+    description: '税務顧問料',
+    categoryKey: 'other-expenses',
+    counterpartName: '税理士法人田中事務所',
+    friendlyCategory: '税理士報酬',
   },
 
   // SYUUSHI07_16: 本部または支部に対する交付金の支出


### PR DESCRIPTION
## Summary
- 政治活動費（その他の経費）の境界値テストを網羅するため、5万円以上のデータを3件追加
- 5万円未満（合算対象）と5万円以上（明細行）の両方のケースをテスト可能に

### 追加データ
| No | 金額 | 説明 | 支払先 |
|---|---|---|---|
| T2025-0050 | 80,000円 | 法務相談費用 | 株式会社法務コンサルティング |
| T2025-0051 | 50,000円 | 届出書類作成代行（境界値） | 行政書士事務所山田 |
| T2025-0052 | 150,000円 | 税務顧問料 | 税理士法人田中事務所 |

## Test plan
- [ ] `pnpm db:seed` が正常に実行されること
- [ ] 報告書エクスポートページで「その他の経費」に5万円以上の明細が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * シード データの拡張：3 つの新しい取引先情報と 3 つの経費取引エントリを追加しました。政治活動費カテゴリーに法務、行政書士、税理士関連の取引先および対応する経費レコードが追加されています。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->