### PR TITLE
feat(report): 個人寄附トランザクションにDonor情報を紐付け

### DIFF
--- a/admin/src/server/contexts/report/infrastructure/repositories/prisma-report-transaction.repository.ts
+++ b/admin/src/server/contexts/report/infrastructure/repositories/prisma-report-transaction.repository.ts
@@ -154,7 +154,6 @@ export class PrismaReportTransactionRepository implements IReportTransactionRepo
 
   /**
    * SYUUSHI07_07 KUBUN1: 個人からの寄附のトランザクションを取得
-   * TODO: 寄附者テーブル作成後に寄附者情報を実際のデータに置き換える
    */
   async findPersonalDonationTransactions(
     filters: TransactionFilters,
@@ -173,6 +172,17 @@ export class PrismaReportTransactionRepository implements IReportTransactionRepo
         debitAmount: true,
         creditAmount: true,
         memo: true,
+        transactionDonors: {
+          select: {
+            donor: {
+              select: {
+                name: true,
+                address: true,
+                occupation: true,
+              },
+            },
+          },
+        },
       },
     });
 
@@ -182,10 +192,9 @@ export class PrismaReportTransactionRepository implements IReportTransactionRepo
       debitAmount: Number(t.debitAmount),
       creditAmount: Number(t.creditAmount),
       memo: t.memo,
-      // TODO: 寄附者テーブル作成後に実際の値を取得する
-      donorName: "（仮）寄附者氏名",
-      donorAddress: "（仮）東京都千代田区永田町1-1-1",
-      donorOccupation: "（仮）会社員",
+      donorName: t.transactionDonors[0]?.donor.name ?? "",
+      donorAddress: t.transactionDonors[0]?.donor.address ?? "",
+      donorOccupation: t.transactionDonors[0]?.donor.occupation ?? "",
     }));
   }
 


### PR DESCRIPTION
## Summary

`findPersonalDonationTransactions`メソッドを修正し、ダミー値ではなく実際のDonorテーブルからデータを取得するように変更しました。

変更内容:
- `transactionDonors`リレーションをJOINして、紐付けられたDonor情報（名前、住所、職業）を取得
- Counterpartパターンと同様のクエリ構造を採用
- Donorが紐付いていない場合は空文字を返す（XMLエクスポート時のバリデーションでエラー検出される想定）

設計ドキュメント: [20251228_1406_donation-assembler寄附者情報実データ化設計.md](https://github.com/team-mirai-volunteer/marumie/blob/develop/docs/20251228_1406_donation-assembler寄附者情報実データ化設計.md)

## Review & Testing Checklist for Human

- [ ] Prismaクエリが正しく`transactionDonors`をJOINしているか確認
- [ ] 実際のDBにDonorデータを登録し、XMLエクスポートで寄附者情報が正しく出力されることを確認

### Notes

- 既存のテストはモックを使用しているため、リポジトリ実装の変更による影響はありません
- Donorが紐付いていない取引は空文字が返され、XMLエクスポート時のバリデーションで「寄附者氏名が入力されていません」等のエラーが検出されます

Link to Devin run: https://app.devin.ai/sessions/83f79698400d4d198906683d21419fe2
Requested by: jujunjun110@gmail.com (@jujunjun110)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 寄付トランザクション記録に寄付者情報（名前、住所、職業）が正しく表示されるようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->