### PR TITLE
refactor(donor-assignment): 冗長な「寄付者紐付け対象のみ」フィルタを削除

### DIFF
--- a/admin/src/app/(auth)/assign/donors/page.tsx
+++ b/admin/src/app/(auth)/assign/donors/page.tsx
@@ -23,7 +23,6 @@ interface DonorAssignmentPageProps {
     orgId?: string;
     year?: string;
     unassigned?: string;
-    donorRequired?: string;
     category?: string;
     search?: string;
     sort?: string;
@@ -52,7 +51,6 @@ export default async function DonorAssignmentPage({ searchParams }: DonorAssignm
           politicalOrganizationId: "",
           financialYear: new Date().getFullYear(),
           unassignedOnly: false,
-          donorRequiredOnly: false,
           categoryKey: "",
           searchQuery: "",
           sortField: "transactionDate",
@@ -67,7 +65,6 @@ export default async function DonorAssignmentPage({ searchParams }: DonorAssignm
   const politicalOrganizationId = params.orgId || organizations[0].id;
   const financialYear = params.year ? Number.parseInt(params.year, 10) : new Date().getFullYear();
   const unassignedOnly = params.unassigned !== "false";
-  const donorRequiredOnly = params.donorRequired !== "false";
   const categoryKey = params.category || "";
   const searchQuery = params.search || "";
   const sortField =
@@ -81,7 +78,6 @@ export default async function DonorAssignmentPage({ searchParams }: DonorAssignm
     politicalOrganizationId,
     financialYear,
     unassignedOnly,
-    requiresDonorOnly: donorRequiredOnly,
     categoryKey: categoryKey || undefined,
     searchQuery: searchQuery || undefined,
     page,
@@ -101,7 +97,6 @@ export default async function DonorAssignmentPage({ searchParams }: DonorAssignm
         politicalOrganizationId,
         financialYear,
         unassignedOnly,
-        donorRequiredOnly,
         categoryKey,
         searchQuery,
         sortField,

--- a/admin/src/client/components/donor-assignment/DonorAssignmentClient.tsx
+++ b/admin/src/client/components/donor-assignment/DonorAssignmentClient.tsx
@@ -26,7 +26,6 @@ interface DonorAssignmentClientProps {
     politicalOrganizationId: string;
     financialYear: number;
     unassignedOnly: boolean;
-    donorRequiredOnly: boolean;
     categoryKey: string;
     searchQuery: string;
     sortField: "transactionDate" | "debitAmount" | "categoryKey";
@@ -58,7 +57,6 @@ export function DonorAssignmentClient({
     initialFilters.financialYear || initialFinancialYear,
   );
   const [unassignedOnly, setUnassignedOnly] = useState(initialFilters.unassignedOnly);
-  const [donorRequiredOnly, setDonorRequiredOnly] = useState(initialFilters.donorRequiredOnly);
   const [categoryKey, setCategoryKey] = useState(
     initialFilters.categoryKey || ALL_CATEGORIES_VALUE,
   );
@@ -110,7 +108,6 @@ export function DonorAssignmentClient({
     orgId?: string;
     year?: number;
     unassigned?: boolean;
-    donorRequired?: boolean;
     category?: string;
     search?: string;
     sort?: string;
@@ -121,7 +118,6 @@ export function DonorAssignmentClient({
     searchParams.set("orgId", params.orgId ?? selectedOrganizationId);
     searchParams.set("year", String(params.year ?? financialYear));
     searchParams.set("unassigned", String(params.unassigned ?? unassignedOnly));
-    searchParams.set("donorRequired", String(params.donorRequired ?? donorRequiredOnly));
     if (params.category ?? categoryKey) {
       searchParams.set("category", params.category ?? categoryKey);
     }
@@ -131,7 +127,7 @@ export function DonorAssignmentClient({
     searchParams.set("sort", params.sort ?? sortField);
     searchParams.set("order", params.order ?? sortOrder);
     searchParams.set("page", String(params.page ?? 1));
-    return `/assign/donor?${searchParams.toString()}`;
+    return `/assign/donors?${searchParams.toString()}`;
   };
 
   const handleFilterChange = (changes: Partial<DonorAssignmentFilterValues>) => {
@@ -143,9 +139,6 @@ export function DonorAssignmentClient({
     }
     if (changes.unassignedOnly !== undefined) {
       setUnassignedOnly(changes.unassignedOnly);
-    }
-    if (changes.donorRequiredOnly !== undefined) {
-      setDonorRequiredOnly(changes.donorRequiredOnly);
     }
 
     const categoryForUrl =
@@ -159,7 +152,6 @@ export function DonorAssignmentClient({
           category: categoryForUrl,
           search: changes.searchQuery ?? searchQuery,
           unassigned: changes.unassignedOnly ?? unassignedOnly,
-          donorRequired: changes.donorRequiredOnly ?? donorRequiredOnly,
           page: 1,
         }),
       );
@@ -250,7 +242,6 @@ export function DonorAssignmentClient({
           categoryKey,
           searchQuery,
           unassignedOnly,
-          donorRequiredOnly,
         }}
         categoryOptions={categoryOptions}
         onChange={handleFilterChange}

--- a/admin/src/client/components/donor-assignment/DonorAssignmentFilters.tsx
+++ b/admin/src/client/components/donor-assignment/DonorAssignmentFilters.tsx
@@ -15,7 +15,6 @@ export interface DonorAssignmentFilterValues {
   categoryKey: string;
   searchQuery: string;
   unassignedOnly: boolean;
-  donorRequiredOnly: boolean;
 }
 
 interface DonorAssignmentFiltersProps {
@@ -91,17 +90,6 @@ export function DonorAssignmentFilters({
           />
           <Label htmlFor="unassigned-only" className="text-white text-sm cursor-pointer">
             未紐付けのみ表示
-          </Label>
-        </div>
-
-        <div className="flex items-center gap-2 cursor-pointer">
-          <Checkbox
-            id="donor-required-only"
-            checked={values.donorRequiredOnly}
-            onCheckedChange={(checked) => onChange({ donorRequiredOnly: checked === true })}
-          />
-          <Label htmlFor="donor-required-only" className="text-white text-sm cursor-pointer">
-            寄付者紐付け対象のみ表示
           </Label>
         </div>
       </div>

--- a/admin/src/client/components/donor-assignment/TransactionWithDonorTable.tsx
+++ b/admin/src/client/components/donor-assignment/TransactionWithDonorTable.tsx
@@ -117,19 +117,7 @@ export function TransactionWithDonorTable({
             )}
           </button>
         ),
-        cell: (info) => {
-          const transaction = info.row.original;
-          return (
-            <div className="flex items-center gap-2">
-              <span>{formatAmount(info.getValue())}</span>
-              {transaction.requiresDonor && (
-                <span className="text-xs bg-amber-500/20 text-amber-400 px-1.5 py-0.5 rounded">
-                  寄付者必須
-                </span>
-              )}
-            </div>
-          );
-        },
+        cell: (info) => formatAmount(info.getValue()),
       }),
       columnHelper.accessor("categoryKey", {
         header: () => (

--- a/admin/src/server/contexts/report/application/usecases/get-transactions-with-donors-usecase.ts
+++ b/admin/src/server/contexts/report/application/usecases/get-transactions-with-donors-usecase.ts
@@ -10,7 +10,6 @@ export interface GetTransactionsWithDonorsInput {
   politicalOrganizationId: string;
   financialYear: number;
   unassignedOnly?: boolean;
-  requiresDonorOnly?: boolean;
   categoryKey?: string;
   searchQuery?: string;
   page?: number;
@@ -38,7 +37,6 @@ export class GetTransactionsWithDonorsUsecase {
       politicalOrganizationId: input.politicalOrganizationId,
       financialYear: input.financialYear,
       unassignedOnly: input.unassignedOnly,
-      requiresDonorOnly: input.requiresDonorOnly,
       categoryKey: input.categoryKey,
       searchQuery: input.searchQuery,
       limit: perPage,

--- a/admin/src/server/contexts/report/domain/models/transaction-with-donor.ts
+++ b/admin/src/server/contexts/report/domain/models/transaction-with-donor.ts
@@ -32,7 +32,6 @@ export interface TransactionWithDonorFilters {
   politicalOrganizationId: string;
   financialYear: number;
   unassignedOnly?: boolean;
-  requiresDonorOnly?: boolean;
   categoryKey?: string;
   searchQuery?: string;
   limit?: number;

--- a/admin/src/server/contexts/report/infrastructure/repositories/prisma-transaction-with-donor.repository.ts
+++ b/admin/src/server/contexts/report/infrastructure/repositories/prisma-transaction-with-donor.repository.ts
@@ -36,7 +36,6 @@ export class PrismaTransactionWithDonorRepository implements ITransactionWithDon
       politicalOrganizationId,
       financialYear,
       unassignedOnly,
-      requiresDonorOnly = false,
       categoryKey,
       searchQuery,
       limit = 50,
@@ -84,12 +83,6 @@ export class PrismaTransactionWithDonorRepository implements ITransactionWithDon
     if (unassignedOnly) {
       conditions.push({
         transactionDonors: { none: {} },
-      });
-    }
-
-    if (requiresDonorOnly) {
-      conditions.push({
-        categoryKey: { in: [...DONOR_REQUIRED_CATEGORIES] },
       });
     }
 

--- a/admin/src/server/contexts/report/presentation/loaders/transactions-with-donors-loader.ts
+++ b/admin/src/server/contexts/report/presentation/loaders/transactions-with-donors-loader.ts
@@ -26,7 +26,6 @@ export async function loadTransactionsWithDonorsData(
     input.politicalOrganizationId,
     String(input.financialYear),
     String(input.unassignedOnly ?? false),
-    String(input.requiresDonorOnly ?? false),
     input.categoryKey ?? "",
     input.searchQuery ?? "",
     String(page),

--- a/docs/20251227_2135_寄付者紐付けページ設計.md
+++ b/docs/20251227_2135_寄付者紐付けページ設計.md
@@ -219,7 +219,6 @@ Counterpart紐付けページと同様のパラメータ構成:
 | `orgId` | string | 政治団体ID |
 | `year` | number | 報告年（西暦） |
 | `unassigned` | boolean | 未紐付けのみ表示（デフォルト: true） |
-| `donorRequired` | boolean | Donor必須の取引のみ表示（デフォルト: true） |
 | `category` | string | カテゴリフィルタ |
 | `search` | string | 検索クエリ |
 | `sort` | string | ソート対象フィールド |
@@ -238,7 +237,7 @@ Counterpart紐付けページと同様のパラメータ構成:
 │ └─────────────────────────────────────────────────────────┘ │
 ├─────────────────────────────────────────────────────────────┤
 │ [カテゴリ: すべて ▼] [検索: ________]                       │
-│ [✓] 未紐付けのみ  [✓] 寄付者必須のみ                        │
+│ [✓] 未紐付けのみ                                            │
 ├─────────────────────────────────────────────────────────────┤
 │ XX件のTransaction                                           │
 │ ┌─────────────────────────────────────────────────────────┐ │
@@ -337,7 +336,6 @@ interface TransactionWithDonorFilter {
   politicalOrganizationId: string;
   financialYear: number;
   unassignedOnly?: boolean;
-  requiresDonorOnly?: boolean;
   categoryKey?: string;
   searchQuery?: string;
   page?: number;

--- a/docs/20251229_1429_donorRequiredOnlyフィルタ削除設計.md
+++ b/docs/20251229_1429_donorRequiredOnlyフィルタ削除設計.md
@@ -1,0 +1,119 @@
+# donorRequiredOnlyフィルタ削除設計
+
+## 概要
+
+寄付者紐付けページ（`/assign/donors`）の「寄付者紐付け対象のみ表示」チェックボックスを削除する。このフィルタは冗長であり、機能的に意味を持たないため。
+
+## 背景
+
+### 問題
+
+寄付者紐付けページには「寄付者紐付け対象のみ表示」（`donorRequiredOnly`）というフィルタが存在するが、このフィルタは以下の理由で冗長である：
+
+1. **ベースクエリで既に絞り込まれている**: `prisma-transaction-with-donor.repository.ts` の `findTransactionsWithDonors` メソッドでは、ベースクエリとして `categoryKey: { in: [...DONOR_REQUIRED_CATEGORIES] }` の条件が常に適用されている
+2. **フィルタON時の条件が重複**: `requiresDonorOnly` フィルタを ON にすると、同じ条件 `categoryKey: { in: [...DONOR_REQUIRED_CATEGORIES] }` が追加されるが、これはベースクエリと完全に重複している
+3. **寄附には閾値がない**: Counterpart紐付けページでは経常経費に閾値（10万円）があるため類似のフィルタに意味があるが、Donor紐付けでは全ての寄附が記載対象
+
+つまり、このページに表示される取引はすべて `DONOR_REQUIRED_CATEGORIES` に属する取引であり、フィルタを ON にしても OFF にしても結果は変わらない。
+
+### DONOR_REQUIRED_CATEGORIESに含まれるカテゴリ
+
+- 個人からの寄附
+- 個人からの寄附（特定寄附）
+- 法人その他の団体からの寄附
+- 政治団体からの寄附
+- 寄附のあっせんによるもの
+- 政治資金パーティーの対価に係る収入
+- 政治資金パーティー対価のあっせんによるもの
+
+## 削除対象箇所
+
+### 1. クライアントコンポーネント
+
+#### DonorAssignmentFilters.tsx
+
+| 行番号 | 削除内容 |
+|--------|----------|
+| 18行目 | `DonorAssignmentFilterValues` インターフェースから `donorRequiredOnly: boolean;` を削除 |
+| 97-106行目 | チェックボックスUI全体を削除 |
+
+#### DonorAssignmentClient.tsx
+
+| 行番号 | 削除内容 |
+|--------|----------|
+| 29行目 | `initialFilters` 型から `donorRequiredOnly` を削除 |
+| 61行目 | `donorRequiredOnly` の state 定義を削除 |
+| 113行目 | `buildUrl` の引数型から `donorRequired` を削除 |
+| 124行目 | `searchParams.set("donorRequired", ...)` を削除 |
+| 147-148行目 | `handleFilterChange` 内の `donorRequiredOnly` 処理を削除 |
+| 162行目 | `buildUrl` 呼び出しから `donorRequired` 引数を削除 |
+| 253行目 | `DonorAssignmentFilters` への `donorRequiredOnly` props を削除 |
+
+### 2. サーバーコンポーネント（ページ）
+
+#### page.tsx（/assign/donors）
+
+| 行番号 | 削除内容 |
+|--------|----------|
+| 26行目 | `searchParams` 型から `donorRequired?: string;` を削除 |
+| 55行目 | fallback用 `initialFilters` から `donorRequiredOnly` を削除 |
+| 70行目 | `donorRequiredOnly` 変数定義を削除 |
+| 84行目 | `loadTransactionsWithDonorsData` 呼び出しから `requiresDonorOnly` を削除 |
+| 104行目 | `initialFilters` から `donorRequiredOnly` を削除 |
+
+### 3. ローダー
+
+#### transactions-with-donors-loader.ts
+
+| 行番号 | 削除内容 |
+|--------|----------|
+| 29行目 | キャッシュキーから `requiresDonorOnly` を削除 |
+
+### 4. ユースケース
+
+#### get-transactions-with-donors-usecase.ts
+
+| 行番号 | 削除内容 |
+|--------|----------|
+| 13行目 | `GetTransactionsWithDonorsInput` から `requiresDonorOnly?: boolean;` を削除 |
+| 41行目 | `filters` オブジェクトから `requiresDonorOnly` を削除 |
+
+### 5. ドメインモデル
+
+#### transaction-with-donor.ts
+
+| 行番号 | 削除内容 |
+|--------|----------|
+| 35行目 | `TransactionWithDonorFilters` から `requiresDonorOnly?: boolean;` を削除 |
+
+### 6. インフラストラクチャ（リポジトリ）
+
+#### prisma-transaction-with-donor.repository.ts
+
+| 行番号 | 削除内容 |
+|--------|----------|
+| 39行目 | `requiresDonorOnly` の destructuring を削除 |
+| 90-94行目 | `requiresDonorOnly` による条件分岐を削除 |
+
+## 影響範囲
+
+- `/assign/donors` ページのUIからチェックボックスが1つ削除される
+- URLクエリパラメータ `donorRequired` が無効になる（既存のブックマーク等は引き続き動作するが、パラメータは無視される）
+- API/データ取得ロジックの簡素化
+
+## 削除しない箇所
+
+以下は削除対象外：
+
+- `donor-assignment-rules.ts` の `DONOR_REQUIRED_CATEGORIES` 定義: ベースクエリのフィルタリングに使用されているため維持
+- `isDonorRequired` 関数: `TransactionWithDonor` の `requiresDonor` プロパティ算出に使用されているため維持
+- `TransactionWithDonor` の `requiresDonor` プロパティ: UI表示やバリデーションで使用される可能性があるため維持
+
+## 設計ドキュメント更新
+
+本修正完了後、以下の設計ドキュメントを更新する：
+
+- `docs/20251227_2135_寄付者紐付けページ設計.md`
+  - 検索パラメータ表から `donorRequired` を削除
+  - `TransactionWithDonorFilter` から `requiresDonorOnly` を削除
+  - UI構成図から該当チェックボックスを削除


### PR DESCRIPTION
## Summary

- 寄付者紐付けページ（`/assign/donors`）から冗長な「寄付者紐付け対象のみ表示」チェックボックスを削除
- 関連する `donorRequiredOnly` / `requiresDonorOnly` フィルタロジックを全レイヤーから削除
- テーブルの「寄付者必須」ラベル表示も削除

### 背景

このページでは、ベースクエリで既に `DONOR_REQUIRED_CATEGORIES` に属する取引のみを取得しており、「寄付者紐付け対象のみ」フィルタはON/OFFに関わらず結果が変わらない冗長な機能でした。寄附には閾値がなく、全てのレコードが紐付け対象であるため、このフィルタは不要です。

## Test plan

- [ ] `/assign/donors` ページにアクセスし、チェックボックスが「未紐付けのみ表示」のみになっていることを確認
- [ ] テーブルの金額列に「寄付者必須」ラベルが表示されないことを確認
- [ ] フィルタ操作（カテゴリ選択、検索、未紐付けのみ）が正常に動作することを確認
- [ ] TypeScriptビルドおよびテストがパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 寄付者割り当てページから「寄付者必須のみ」フィルタを削除し、UIを簡潔にしました
  * トランザクション一覧の金額表示から「寄付者必須」バッジを削除し、表示をシンプル化しました

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->