### PR TITLE
fix: revalidatePath のパスを /assign/donors に修正

### DIFF
--- a/admin/src/server/contexts/report/presentation/actions/bulk-assign-donor.ts
+++ b/admin/src/server/contexts/report/presentation/actions/bulk-assign-donor.ts
@@ -32,7 +32,7 @@ export async function bulkAssignDonorAction(
       return { success: false, errors: result.errors };
     }
 
-    revalidatePath("/assign/donor");
+    revalidatePath("/assign/donors");
     return { success: true, assignedCount: result.assignedCount };
   } catch (error) {
     console.error("Error bulk assigning donor:", error);

--- a/admin/src/server/contexts/report/presentation/actions/create-donor.ts
+++ b/admin/src/server/contexts/report/presentation/actions/create-donor.ts
@@ -23,7 +23,7 @@ export async function createDonorAction(input: CreateDonorInput): Promise<Create
       return { success: false, errors: result.errors };
     }
 
-    revalidatePath("/assign/donor");
+    revalidatePath("/assign/donors");
     return { success: true, donorId: result.donor?.id };
   } catch (error) {
     console.error("Error creating donor:", error);


### PR DESCRIPTION
## Summary

- 企業紐づけ後に変更が反映されない問題を修正
- `revalidatePath` のパスが `/assign/donor` (単数形) になっていたが、実際のページパスは `/assign/donors` (複数形) であったため、キャッシュが正しく無効化されていなかった
- `bulk-assign-donor.ts` と `create-donor.ts` の両方を修正

## Test plan

- [ ] `/assign/donors` ページで企業を紐づけた後、画面が即座に更新されることを確認
- [ ] 新規ドナーを作成した後、ドナーリストに即座に反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ドナー割り当て機能の内部パス処理を修正しました。データ更新の反映がより確実になります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->