### PR TITLE
docs: AI検索による正式会社名と郵便番号の拡張設計

### DIFF
--- a/docs/20251229_1520_AI検索による正式会社名と郵便番号の拡張.md
+++ b/docs/20251229_1520_AI検索による正式会社名と郵便番号の拡張.md
@@ -1,0 +1,294 @@
+# AI検索による正式会社名と郵便番号の拡張
+
+## 概要
+
+取引先（Counterpart）のAI検索機能を拡張し、以下の機能を追加する：
+
+1. **正式会社名の自動入力**: AI検索結果から正式な会社名（例：「株式会社アクセア」）をnameフィールドに反映できるようにする
+2. **郵便番号フィールドの追加**: Counterpartモデルに郵便番号（postalCode）を追加し、AI検索結果からセットできるようにする
+
+## 現状分析
+
+### 現在のAI検索フロー
+
+1. ユーザーが会社名（例：「アクセア」）を入力
+2. AI検索ボタンをクリック
+3. LLMがWeb検索を使って住所候補を取得
+4. 検索結果には `companyName`, `postalCode`, `address` が含まれる（[types.ts:1-7](admin/src/server/contexts/report/infrastructure/llm/types.ts#L1-L7)）
+5. **現状の問題**: ユーザーが候補を選択すると、住所（address）のみがセットされる（[AddressInput.tsx:58-61](admin/src/client/components/counterparts/AddressInput.tsx#L58-L61)）
+6. 正式会社名と郵便番号は表示されるが、フォームには反映されない
+
+### 現在のCounterpartモデル
+
+```
+Counterpart {
+  id: string
+  name: string           // 名前（MAX 120文字）
+  address: string | null // 住所（MAX 120文字）
+  createdAt: Date
+  updatedAt: Date
+}
+```
+
+データベーススキーマ（[schema.prisma:73-84](prisma/schema.prisma#L73-L84)）:
+- `postalCode`フィールドは存在しない
+- `name`と`address`のユニーク制約あり → 郵便番号追加時は制約の見直しが必要
+
+## 設計
+
+### 1. データベーススキーマ変更
+
+#### Counterpartテーブルの変更
+
+```prisma
+model Counterpart {
+  id         BigInt   @id @default(autoincrement())
+  name       String   @db.VarChar(120)
+  postalCode String?  @db.VarChar(10) @map("postal_code")  // 新規追加
+  address    String?  @db.VarChar(120)
+  createdAt  DateTime @default(now()) @map("created_at")
+  updatedAt  DateTime @updatedAt @map("updated_at")
+
+  transactionCounterparts TransactionCounterpart[]
+
+  @@unique([name, address])  // 変更なし（郵便番号は含めない）
+  @@map("counterparts")
+}
+```
+
+**設計判断**:
+- ユニーク制約は`[name, address]`のまま維持する
+  - 理由: 同一名称・同一住所の取引先は同一とみなすべき。郵便番号は住所の補足情報
+  - 郵便番号が異なっても、名前と住所が同じなら同一取引先として扱う
+
+### 2. ドメインモデル変更
+
+#### counterpart.ts の変更
+
+[counterpart.ts](admin/src/server/contexts/report/domain/models/counterpart.ts)を以下のように変更:
+
+```typescript
+export interface Counterpart {
+  id: string;
+  name: string;
+  postalCode: string | null;  // 新規追加
+  address: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface CreateCounterpartInput {
+  name: string;
+  postalCode: string | null;  // 新規追加
+  address: string | null;
+}
+
+export interface UpdateCounterpartInput {
+  name?: string;
+  postalCode?: string | null;  // 新規追加
+  address?: string | null;
+}
+
+export const MAX_POSTAL_CODE_LENGTH = 10;  // 新規追加
+
+// バリデーション関数の拡張
+export function validateCounterpartInput(input: CreateCounterpartInput): string[] {
+  const errors: string[] = [];
+  // ... 既存のバリデーション ...
+
+  if (input.postalCode) {
+    const normalizedPostalCode = normalizePostalCode(input.postalCode);
+    if (normalizedPostalCode === null) {
+      errors.push("郵便番号には英数字、ハイフン、スペースのみ使用できます");
+    }
+  }
+
+  return errors;
+}
+
+// 郵便番号の正規化関数（国際対応）
+export function normalizePostalCode(postalCode: string): string | null {
+  const trimmed = postalCode.trim();
+  if (!trimmed) return null;
+
+  // 全角→半角変換
+  const normalized = trimmed
+    .replace(/[〒]/g, "")
+    .replace(/[０-９]/g, (s) => String.fromCharCode(s.charCodeAt(0) - 0xFEE0))
+    .replace(/[Ａ-Ｚａ-ｚ]/g, (s) => String.fromCharCode(s.charCodeAt(0) - 0xFEE0))
+    .replace(/[－ー−]/g, "-")
+    .replace(/　/g, " ")  // 全角スペース→半角
+    .trim();
+
+  // 英数字、ハイフン、スペースのみ許可
+  if (!/^[A-Za-z0-9\- ]+$/.test(normalized)) {
+    return null;  // 不正な文字を含む
+  }
+
+  return normalized;
+}
+```
+
+### 3. リポジトリ層の変更
+
+#### ICounterpartRepository インターフェース
+
+変更なし（postalCodeはCreateCounterpartInput/UpdateCounterpartInputに含まれるため）
+
+#### PrismaCounterpartRepository
+
+[prisma-counterpart.repository.ts](admin/src/server/contexts/report/infrastructure/repositories/prisma-counterpart.repository.ts)の変更:
+
+- `mapToCounterpart`メソッドに`postalCode`を追加
+- `create`メソッドで`postalCode`を保存
+- `update`メソッドで`postalCode`を更新
+
+### 4. プレゼンテーション層（Actions）の変更
+
+#### create-counterpart.ts / update-counterpart.ts
+
+入力に`postalCode`を追加するのみ。Usecaseを通じて正規化・バリデーションが行われる。
+
+### 5. UIコンポーネントの変更
+
+#### AddressInput.tsx
+
+**変更内容**:
+- 候補選択時に`companyName`と`postalCode`も返すようにコールバックを拡張
+
+```typescript
+interface AddressInputProps {
+  companyName: string;
+  address: string;
+  postalCode: string;  // 新規追加
+  onChange: (data: {
+    address: string;
+    postalCode: string | null;
+    suggestedName: string | null;  // 新規追加: AI検索で取得した正式会社名
+  }) => void;
+  disabled?: boolean;
+}
+```
+
+候補選択時の処理:
+- `address`をセット
+- `postalCode`をセット
+- `suggestedName`（正式会社名）を親コンポーネントに通知
+
+#### CounterpartFormContent.tsx
+
+**変更内容**:
+
+1. 郵便番号入力フィールドの追加
+2. AI検索結果から正式会社名が返された場合、名前フィールドを更新するかユーザーに確認
+
+```typescript
+interface CounterpartFormContentProps {
+  // ... 既存のprops ...
+  initialData?: {
+    id: string;
+    name: string;
+    postalCode: string | null;  // 新規追加
+    address: string | null;
+    usageCount?: number;
+  };
+  // ...
+}
+```
+
+**正式会社名の反映フロー**:
+
+1. AI検索結果の候補を選択
+2. `suggestedName`が現在の`name`と異なる場合:
+   - 名前フィールドを自動的に更新する
+   - 視覚的なフィードバック（例: 入力欄のハイライト）でユーザーに変更を通知
+3. ユーザーは必要に応じて名前を手動で修正可能
+
+#### CounterpartFormDialog.tsx / AssignWithCounterpartContent.tsx
+
+- `onSubmit`のデータに`postalCode`を追加
+- `initialData`に`postalCode`を追加
+
+### 6. useAddressSearch フックの変更
+
+[useAddressSearch.ts](admin/src/client/components/counterparts/useAddressSearch.ts)
+
+選択された候補の情報を保持:
+
+```typescript
+interface UseAddressSearchReturn {
+  // ... 既存の状態 ...
+  selectedCandidate: AddressCandidate | null;  // 新規追加
+
+  // アクション
+  selectCandidate: (candidate: AddressCandidate) => void;
+  // ...
+}
+```
+
+## 変更対象ファイル一覧
+
+### スキーマ・マイグレーション
+- `prisma/schema.prisma` - postalCodeカラム追加
+
+### ドメイン層
+- `admin/src/server/contexts/report/domain/models/counterpart.ts` - モデル拡張、バリデーション追加
+
+### インフラストラクチャ層
+- `admin/src/server/contexts/report/infrastructure/repositories/prisma-counterpart.repository.ts` - マッピング更新
+
+### プレゼンテーション層
+- `admin/src/server/contexts/report/presentation/actions/create-counterpart.ts` - 入力拡張
+- `admin/src/server/contexts/report/presentation/actions/update-counterpart.ts` - 入力拡張
+
+### クライアント
+- `admin/src/client/components/counterparts/CounterpartFormContent.tsx` - 郵便番号フィールド追加、名前自動更新
+- `admin/src/client/components/counterparts/AddressInput.tsx` - コールバック拡張
+- `admin/src/client/components/counterparts/useAddressSearch.ts` - 選択候補の保持
+- `admin/src/client/components/counterparts/CounterpartFormDialog.tsx` - props拡張
+- `admin/src/client/components/counterpart-assignment/AssignWithCounterpartContent.tsx` - props拡張
+
+## 郵便番号のバリデーションと正規化ルール
+
+### 対応する郵便番号形式
+
+国際的な郵便番号形式に対応するため、汎用的なバリデーションを採用する。
+
+| 国 | 形式 | 例 |
+|---|---|---|
+| 日本 | 7桁（XXX-XXXX） | `123-4567` |
+| アメリカ | 5桁 or 5+4桁 | `12345`, `12345-6789` |
+| イギリス | 英数字6-8文字 | `SW1A 2AA` |
+| カナダ | A1A 1A1形式 | `V5K 3A9` |
+| オーストラリア | 4桁 | `2000` |
+| ドイツ・フランス | 5桁 | `20095`, `75001` |
+
+### 正規化ルール
+
+| 入力例 | 正規化結果 | 備考 |
+|--------|-----------|------|
+| `〒123-4567` | `123-4567` | 〒記号を除去 |
+| `123-4567` | `123-4567` | そのまま |
+| `１２３-４５６７` | `123-4567` | 全角→半角変換 |
+| `SW1A 2AA` | `SW1A 2AA` | イギリス形式（そのまま） |
+| `V5K 3A9` | `V5K 3A9` | カナダ形式（そのまま） |
+| `12345` | `12345` | アメリカ形式（そのまま） |
+| `あいう` | `null`（エラー） | 英数字以外を含む |
+| `###` | `null`（エラー） | 不正な記号を含む |
+
+### バリデーションルール
+
+- **許可する文字**: 英数字（A-Z, a-z, 0-9）、ハイフン（-）、スペース
+- **全角文字**: 自動的に半角に変換
+- **〒記号**: 自動的に除去
+- **空欄**: 許可（オプショナルフィールド）
+
+## 実装の注意点
+
+1. **マイグレーションの安全性**: 既存のCounterpartデータは`postalCode = null`として扱う。破壊的変更なし。
+
+2. **ユニーク制約**: `[name, address]`の制約は維持。郵便番号は制約に含めない。
+
+3. **AI検索結果の信頼性**: LLMが返す`companyName`は参考情報として扱い、ユーザーが最終確認する前提で設計する。
+
+4. **後方互換性**: 既存のAPIやUIは郵便番号なしでも動作するよう、オプショナルフィールドとして扱う。


### PR DESCRIPTION
## Summary

- 取引先（Counterpart）のAI検索機能を拡張する設計ドキュメントを追加
- 正式会社名の自動入力機能（例：「アクセア」→「株式会社アクセア」）
- 郵便番号フィールドの追加（国際対応のバリデーション）

## Test plan

- [ ] 設計ドキュメントの内容を確認
- [ ] アーキテクチャガイドとの整合性を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * AI検索による正式会社名と郵便番号の自動取得に対応しました
  * 住所入力フォームに郵便番号フィールドを追加
  * 国際フォーマット対応の郵便番号自動正規化機能を実装
  * AI検索結果から提案された正式会社名を自動反映する機能を追加

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->