### PR TITLE
fix: 取引先紐付け画面のフィルターUIを寄付者紐付け画面に統一

### DIFF
--- a/admin/src/client/components/counterpart-assignment/CounterpartAssignmentFilters.tsx
+++ b/admin/src/client/components/counterpart-assignment/CounterpartAssignmentFilters.tsx
@@ -101,7 +101,7 @@ export function CounterpartAssignmentFilters({
             checked={values.unassignedOnly}
             onCheckedChange={(checked) => onChange({ unassignedOnly: checked === true })}
           />
-          <Label htmlFor="unassigned-only" className="text-white text-sm cursor-pointer">
+          <Label htmlFor="unassigned-only" className="text-foreground text-sm cursor-pointer">
             未紐付けのみ表示
           </Label>
         </div>
@@ -114,7 +114,7 @@ export function CounterpartAssignmentFilters({
           />
           <Label
             htmlFor="counterpart-required-only"
-            className="text-white text-sm cursor-pointer flex items-center gap-1"
+            className="text-foreground text-sm cursor-pointer flex items-center gap-1"
           >
             取引先必須のみ表示
             <Tooltip>


### PR DESCRIPTION
## Summary
- 取引先紐付け画面 (`/assign/counterparts`) のフィルターUIを寄付者紐付け画面 (`/assign/donors`) と同じスタイルに統一
- Toggle + アイコンのスタイルから Checkbox + Label のシンプルなスタイルに変更
- 検索欄にクリアボタンを追加

## Updates since last revision
- CodeRabbitのレビューコメントに対応: `text-white` を `text-foreground` に変更（admin-ui-guidelines.md準拠）

## Review & Testing Checklist for Human
- [ ] `/assign/counterparts` ページにアクセスし、フィルターUIが `/assign/donors` と同じスタイルになっていることを確認
- [ ] チェックボックスのラベルテキストが正しく表示されていることを確認（`text-foreground` の適用）
- [ ] 「未紐付けのみ表示」「取引先必須のみ表示」チェックボックスが正常に動作することを確認
- [ ] 検索後にクリアボタンが表示され、クリックで検索がクリアされることを確認

### Notes
- Link to Devin run: https://app.devin.ai/sessions/a6e74812e7a543aa81f7a2171edff15c
- Requested by: @jujunjun110