### PR TITLE
docs: 報告書プレビューへのProfile表示追加の設計

### DIFF
--- a/docs/20251229_1546_報告書プレビューへのProfile表示追加.md
+++ b/docs/20251229_1546_報告書プレビューへのProfile表示追加.md
@@ -1,0 +1,115 @@
+# 報告書プレビューへのProfile表示追加 設計
+
+## 概要
+
+`/export-report/[orgId]/[year]` ページの表形式プレビューに、団体プロフィール情報（SYUUSHI07_01）のセクションを追加する。
+
+## 現状
+
+### 表形式プレビューの構成
+
+現在の `ReportDataPreview` コンポーネントでは以下のセクションを表示している:
+
+1. **収入の部**
+   - 寄附 (SYUUSHI07_07) - `DonationSection`
+   - 事業収入・借入金・交付金・その他収入 (SYUUSHI07_03〜06) - `IncomeSection`
+
+2. **支出の部**
+   - 経常経費 (SYUUSHI07_14) - `RegularExpenseSection`
+   - 政治活動費 (SYUUSHI07_15) - `PoliticalActivityExpenseSection`
+
+### データ構造
+
+`ReportData` インターフェースには既に `profile: OrganizationReportProfile` が含まれている。
+
+```typescript
+export interface ReportData {
+  profile: OrganizationReportProfile; // SYUUSHI07_01: 団体プロフィール
+  donations: DonationData;
+  income: IncomeData;
+  expenses: ExpenseData;
+}
+```
+
+`OrganizationReportProfile` の主な項目:
+
+- `officialName`: 政治団体名称
+- `officialNameKana`: ふりがな
+- `officeAddress`: 事務所住所
+- `officeAddressBuilding`: アパート・ビル名
+- `details.representative`: 代表者氏名（姓・名）
+- `details.accountant`: 会計責任者氏名（姓・名）
+- `details.contactPersons`: 事務担当者情報（最大3名）
+- `details.activityArea`: 活動区域（1: 二以上の都道府県、2: 一つの都道府県）
+- `details.fundManagement`: 資金管理団体情報
+- `details.dietMemberRelation`: 国会議員関係政治団体情報
+
+## 設計
+
+### 変更対象ファイル
+
+1. **新規作成**: `admin/src/client/components/export-report/sections/ProfileSection.tsx`
+2. **修正**: `admin/src/client/components/export-report/ReportDataPreview.tsx`
+
+### ProfileSection コンポーネント
+
+プロフィール情報を表形式で表示するコンポーネントを新規作成する。
+
+#### 表示項目
+
+| 項目名 | 対応フィールド | 備考 |
+|--------|----------------|------|
+| 報告年 | `financialYear` | |
+| 政治団体名称 | `officialName` | |
+| ふりがな | `officialNameKana` | |
+| 主たる事務所の所在地 | `officeAddress` + `officeAddressBuilding` | 結合して表示 |
+| 代表者氏名 | `details.representative` | 姓 + 名 |
+| 会計責任者氏名 | `details.accountant` | 姓 + 名 |
+| 事務担当者 | `details.contactPersons` | 複数名、電話番号含む |
+| 活動区域 | `details.activityArea` | ラベル変換して表示 |
+| 国会議員関係政治団体の区分 | `details.dietMemberRelation.type` | ラベル変換して表示 |
+
+#### UI設計
+
+既存の `SectionWrapper` コンポーネントを使わず、シンプルなテーブル形式で表示する。理由:
+- `SectionWrapper` は金額系セクション向けに設計されている（totalAmount、underThresholdAmount）
+- プロフィール情報は属性値の一覧であり、金額合計の概念がない
+
+代わりに、以下のようなレイアウトを採用:
+- タイトル: 「団体基本情報 (SYUUSHI07_01)」
+- コンテンツ: 2カラムの定義リスト形式（項目名: 値）
+
+### ReportDataPreview の修正
+
+`ProfileSection` を最上部に追加する。
+
+```
+<div className="space-y-8">
+  {/* プロフィール */}
+  <ProfileSection profile={reportData.profile} />
+
+  {/* 収入の部 */}
+  <DonationSection ... />
+  <IncomeSection ... />
+
+  {/* 支出の部 */}
+  <RegularExpenseSection ... />
+  <PoliticalActivityExpenseSection ... />
+</div>
+```
+
+### ラベル変換
+
+| フィールド | 値 | 表示ラベル |
+|------------|-----|------------|
+| `activityArea` | "1" | 二以上の都道府県にまたがって活動 |
+| `activityArea` | "2" | 一つの都道府県区域で活動 |
+| `dietMemberRelation.type` | "0" | 指定無し |
+| `dietMemberRelation.type` | "1" | 1号団体 |
+| `dietMemberRelation.type` | "2" | 2号団体 |
+| `dietMemberRelation.type` | "3" | 1号団体かつ2号団体 |
+
+## 影響範囲
+
+- **UI変更のみ**: 既存のデータ取得処理やAPI、ドメインロジックへの変更は不要
+- `reportData.profile` は既に `loadReportPreviewData` で取得済みのため、追加のデータ取得は不要


### PR DESCRIPTION
## Summary

- 報告書エクスポートページの表形式プレビューに、団体プロフィール情報（SYUUSHI07_01）を表示する機能の設計ドキュメントを追加

## 変更内容

- `ProfileSection` コンポーネントの新規作成方針
- `ReportDataPreview` への組み込み方法
- 表示項目とラベル変換の定義

## Test plan

- [ ] 設計ドキュメントのレビュー

🤖 Generated with [Claude Code](https://claude.com/claude-code)