### PR TITLE
feat(admin): 報告書プレビューにプロフィールセクションを追加

### DIFF
--- a/admin/src/client/components/export-report/ReportDataPreview.tsx
+++ b/admin/src/client/components/export-report/ReportDataPreview.tsx
@@ -1,15 +1,16 @@
 import type { ReportData } from "@/server/contexts/report/domain/models/report-data";
 import { DonationSection } from "./sections/DonationSection";
 import { IncomeSection } from "./sections/IncomeSection";
-import { RegularExpenseSection } from "./sections/RegularExpenseSection";
 import { PoliticalActivityExpenseSection } from "./sections/PoliticalActivityExpenseSection";
+import { ProfileSection } from "./sections/ProfileSection";
+import { RegularExpenseSection } from "./sections/RegularExpenseSection";
 
 interface ReportDataPreviewProps {
   reportData: ReportData;
 }
 
 export function ReportDataPreview({ reportData }: ReportDataPreviewProps) {
-  const { donations, income, expenses } = reportData;
+  const { profile, donations, income, expenses } = reportData;
 
   return (
     <div className="space-y-8">
@@ -19,6 +20,9 @@ export function ReportDataPreview({ reportData }: ReportDataPreviewProps) {
       </div>
 
       <div className="space-y-8">
+        {/* プロフィール */}
+        <ProfileSection profile={profile} />
+
         {/* 収入の部 */}
         <DonationSection personalDonations={donations.personalDonations} />
 

--- a/admin/src/client/components/export-report/sections/ProfileSection.tsx
+++ b/admin/src/client/components/export-report/sections/ProfileSection.tsx
@@ -1,0 +1,103 @@
+import type { OrganizationReportProfile } from "@/server/contexts/report/domain/models/organization-report-profile";
+
+interface ProfileSectionProps {
+  profile: OrganizationReportProfile;
+}
+
+function getActivityAreaLabel(activityArea: string | undefined): string {
+  switch (activityArea) {
+    case "1":
+      return "二以上の都道府県にまたがって活動";
+    case "2":
+      return "一つの都道府県区域で活動";
+    default:
+      return "-";
+  }
+}
+
+function getDietMemberRelationTypeLabel(type: string | undefined): string {
+  switch (type) {
+    case "0":
+      return "指定無し";
+    case "1":
+      return "1号団体";
+    case "2":
+      return "2号団体";
+    case "3":
+      return "1号団体かつ2号団体";
+    default:
+      return "-";
+  }
+}
+
+function formatFullName(person: { lastName: string; firstName: string } | undefined): string {
+  if (!person) return "-";
+  return `${person.lastName} ${person.firstName}`;
+}
+
+function formatAddress(
+  address: string | null | undefined,
+  building: string | null | undefined,
+): string {
+  if (!address) return "-";
+  if (building) {
+    return `${address} ${building}`;
+  }
+  return address;
+}
+
+interface ProfileRowProps {
+  label: string;
+  value: string;
+}
+
+function ProfileRow({ label, value }: ProfileRowProps) {
+  return (
+    <tr className="border-b border-gray-200">
+      <th className="py-2 px-4 text-left font-medium text-gray-700 bg-gray-50 w-1/3">{label}</th>
+      <td className="py-2 px-4 text-gray-900">{value}</td>
+    </tr>
+  );
+}
+
+export function ProfileSection({ profile }: ProfileSectionProps) {
+  const { details } = profile;
+
+  const contactPersonsDisplay =
+    details.contactPersons && details.contactPersons.length > 0
+      ? details.contactPersons
+          .map((person) => {
+            const name = `${person.lastName} ${person.firstName}`;
+            return person.tel ? `${name} (${person.tel})` : name;
+          })
+          .join("、")
+      : "-";
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-bold text-white">団体基本情報 (SYUUSHI07_01)</h2>
+
+      <div className="bg-white border border-black overflow-hidden">
+        <table className="w-full">
+          <tbody>
+            <ProfileRow label="報告年" value={String(profile.financialYear)} />
+            <ProfileRow label="政治団体名称" value={profile.officialName || "-"} />
+            <ProfileRow label="ふりがな" value={profile.officialNameKana || "-"} />
+            <ProfileRow
+              label="主たる事務所の所在地"
+              value={formatAddress(profile.officeAddress, profile.officeAddressBuilding)}
+            />
+            <ProfileRow label="代表者氏名" value={formatFullName(details.representative)} />
+            <ProfileRow label="会計責任者氏名" value={formatFullName(details.accountant)} />
+            <ProfileRow label="事務担当者" value={contactPersonsDisplay} />
+            <ProfileRow label="活動区域" value={getActivityAreaLabel(details.activityArea)} />
+            <ProfileRow
+              label="国会議員関係政治団体の区分"
+              value={getDietMemberRelationTypeLabel(details.dietMemberRelation?.type)}
+            />
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

`/export-report/[orgId]/[year]` ページの表形式プレビューに、団体プロフィール情報（SYUUSHI07_01）のセクションを追加しました。

設計ドキュメント: `docs/20251229_1546_報告書プレビューへのProfile表示追加.md`

### 変更内容
- `ProfileSection.tsx` を新規作成: 団体基本情報を表形式で表示
- `ReportDataPreview.tsx` を修正: ProfileSectionを最上部に追加

### 表示項目
- 報告年、政治団体名称、ふりがな、主たる事務所の所在地
- 代表者氏名、会計責任者氏名、事務担当者（複数名対応）
- 活動区域、国会議員関係政治団体の区分

## Review & Testing Checklist for Human

- [ ] `/export-report/[orgId]/[year]` ページでプロフィールセクションが正しく表示されるか確認
- [ ] 活動区域のラベル変換が正しいか確認（"1" → "二以上の都道府県にまたがって活動"、"2" → "一つの都道府県区域で活動"）
- [ ] 国会議員関係政治団体の区分のラベル変換が正しいか確認（"0" → "指定無し"、"1" → "1号団体"、"2" → "2号団体"、"3" → "1号団体かつ2号団体"）
- [ ] データが未設定の場合に "-" が表示されるか確認

**推奨テスト手順:**
1. admin画面で `/export-report/[orgId]/[year]` にアクセス
2. 「表形式プレビュー」タブでプロフィールセクションが最上部に表示されることを確認
3. 各項目の値が正しく表示されていることを確認

### Notes
- UI変更のみで、既存のデータ取得処理やAPI、ドメインロジックへの変更はありません
- `reportData.profile` は既に `loadReportPreviewData` で取得済みのため、追加のデータ取得は不要です
- 設計書の指示に従い、SectionWrapperは使用せず独自のテーブルレイアウトを採用しています

Link to Devin run: https://app.devin.ai/sessions/eba5115185da4895aa86dfb6292e49fb
Requested by: jujunjun110@gmail.com (@jujunjun110)