### PR TITLE
config: CodeRabbitのmarkdownlintを無効化

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -83,3 +83,8 @@ reviews:
   pre_merge_checks:
     docstrings:
       mode: "off"
+
+  # Markdownの書式チェックを無効化
+  tools:
+    markdownlint:
+      enabled: false


### PR DESCRIPTION
## Summary

- CodeRabbitのmarkdownlintを無効化
- Markdownの書式に関するレビューコメント（MD036、言語指定、空行など）を抑制

## 背景

設計ドキュメントの書式に関するコメント（「強調の代わりにヘッディングを使用してください」「言語指定と空行を追加してください」など）が頻繁に発生するため、書式チェック全体を無効化しました。

## Test plan

- [x] CodeRabbitの設定ファイルが正しいYAML形式であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)