### PR TITLE
feat: サンプル党に現金残高スナップショットのseedデータを追加

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,6 +1,7 @@
 import { PrismaClient } from '@prisma/client';
 import 'dotenv/config';
 import type { Seeder } from './seeds/lib/types';
+import { balanceSnapshotsSeeder } from './seeds/balanceSnapshots';
 import { counterpartsSeeder } from './seeds/counterparts';
 import { donorsSeeder } from './seeds/donors';
 import { politicalOrganizationsSeeder } from './seeds/politicalOrganizations';
@@ -18,6 +19,7 @@ const seeders: Seeder[] = [
   counterpartsSeeder,
   donorsSeeder,
   transactionsSeeder,
+  balanceSnapshotsSeeder,
 ];
 
 async function main() {

--- a/prisma/seeds/balanceSnapshots.ts
+++ b/prisma/seeds/balanceSnapshots.ts
@@ -1,0 +1,61 @@
+import type { PrismaClient } from '@prisma/client';
+import type { Seeder } from './lib/types';
+
+interface BalanceSnapshotData {
+  organizationSlug: string;
+  snapshotDate: Date;
+  balance: number;
+}
+
+const data: BalanceSnapshotData[] = [
+  {
+    organizationSlug: 'sample-party',
+    snapshotDate: new Date('2024-12-31'),
+    balance: 2000000, // 200万円
+  },
+  {
+    organizationSlug: 'sample-party',
+    snapshotDate: new Date('2025-12-30'),
+    balance: 3000000, // 300万円
+  },
+];
+
+export const balanceSnapshotsSeeder: Seeder = {
+  name: 'Balance Snapshots',
+  async seed(prisma: PrismaClient) {
+    for (const item of data) {
+      const organization = await prisma.politicalOrganization.findUnique({
+        where: { slug: item.organizationSlug },
+      });
+
+      if (!organization) {
+        console.log(`⚠️  Organization not found: ${item.organizationSlug}`);
+        continue;
+      }
+
+      const existing = await prisma.balanceSnapshot.findFirst({
+        where: {
+          politicalOrganizationId: organization.id,
+          snapshotDate: item.snapshotDate,
+        },
+      });
+
+      if (!existing) {
+        await prisma.balanceSnapshot.create({
+          data: {
+            politicalOrganizationId: organization.id,
+            snapshotDate: item.snapshotDate,
+            balance: item.balance,
+          },
+        });
+        console.log(
+          `✅ Created: ${item.organizationSlug} - ${item.snapshotDate.toISOString().split('T')[0]} - ¥${item.balance.toLocaleString()}`
+        );
+      } else {
+        console.log(
+          `⏭️  Already exists: ${item.organizationSlug} - ${item.snapshotDate.toISOString().split('T')[0]}`
+        );
+      }
+    }
+  },
+};


### PR DESCRIPTION
## Summary
- サンプル党の初期現金残高としてBalanceSnapshotのseedデータを追加
- 2024-12-31: 200万円、2025-12-30: 300万円の2レコード

## Test plan
- [ ] `pnpm prisma db seed` でseedが正常に実行されることを確認
- [ ] BalanceSnapshotsテーブルにサンプル党のデータが登録されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チョア**
  * データベース初期化時に、組織のバランススナップショットデータを自動的に投入するシーディング機能を追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->