### PR TITLE
docs: 交付金フラグUI表示設計を追加

### DIFF
--- a/docs/20251230_0106_交付金フラグUI表示設計.md
+++ b/docs/20251230_0106_交付金フラグUI表示設計.md
@@ -1,0 +1,131 @@
+# 交付金フラグUI表示設計
+
+## 概要
+
+`/assign/counterparts` ページのトランザクション行に `isGrantExpenditure` フラグの状態を表示し、トグル操作のUIを提供する。
+
+## 背景
+
+[docs/20251230_0039_交付金フラグカラム追加マイグレーション設計.md](20251230_0039_交付金フラグカラム追加マイグレーション設計.md) で `transactions` テーブルに追加された `is_grant_expenditure` カラムを、counterpart割当画面で確認・変更できるようにする。
+
+## 実装スコープ（Phase 1）
+
+1. テーブル行に交付金フラグの状態を表示する
+2. トグル操作で `alert("not implemented")` を表示する（実際の更新処理は後続タスク）
+
+## UI設計
+
+### 表示位置
+
+テーブルの「金額」列のセル内に、金額の下にトグルスイッチを配置する。
+
+### トグルコンポーネント
+
+shadcn UIの`Switch`コンポーネントを使用する。
+
+- **ON状態**: スイッチがON、ラベル「交付金」を表示
+- **OFF状態**: スイッチがOFF、ラベルは表示しない（またはグレーアウト）
+
+### 表示条件
+
+- 支出取引（`transactionType === "expense"`）のみ表示
+- 収入取引には表示しない（交付金フラグは支出に対して設定するものであるため）
+
+## 影響範囲
+
+### 1. ドメインモデル
+
+**ファイル**: [admin/src/server/contexts/report/domain/models/transaction-with-counterpart.ts](../admin/src/server/contexts/report/domain/models/transaction-with-counterpart.ts)
+
+`TransactionWithCounterpart` interface に以下を追加:
+
+```typescript
+/** 交付金に係る支出かどうか */
+isGrantExpenditure: boolean;
+```
+
+### 2. リポジトリ
+
+**ファイル**: [admin/src/server/contexts/report/infrastructure/repositories/prisma-report-transaction.repository.ts](../admin/src/server/contexts/report/infrastructure/repositories/prisma-report-transaction.repository.ts)
+
+#### findTransactionsWithCounterparts メソッド
+
+- selectに `isGrantExpenditure: true` を追加
+- 返却値のマッピングに `isGrantExpenditure: t.isGrantExpenditure` を追加
+
+#### findByCounterpart メソッド
+
+- selectに `isGrantExpenditure: true` を追加
+- 返却値のマッピングに `isGrantExpenditure: t.isGrantExpenditure` を追加
+
+#### findByIdWithCounterpart メソッド
+
+- 返却値に `isGrantExpenditure: transaction.isGrantExpenditure` を追加
+
+### 3. shadcn UIコンポーネント追加
+
+`admin/src/client/components/ui/switch.tsx` が存在しないため追加が必要:
+
+```bash
+cd admin && npx shadcn@latest add switch
+```
+
+追加後、[admin/src/client/components/ui/index.ts](../admin/src/client/components/ui/index.ts) に re-export を追加:
+
+```typescript
+export { Switch } from "@/client/components/ui/switch";
+```
+
+### 4. UIコンポーネント
+
+**ファイル**: [admin/src/client/components/counterpart-assignment/TransactionWithCounterpartTable.tsx](../admin/src/client/components/counterpart-assignment/TransactionWithCounterpartTable.tsx)
+
+#### 変更内容
+
+1. `Switch` コンポーネントをインポート
+2. 「金額」列（`debitAmount`）のセルにトグルスイッチを追加
+3. `transactionType === "expense"` の場合のみトグルを表示
+4. トグルクリック時に `alert("not implemented")` を表示
+
+#### 実装イメージ
+
+```tsx
+columnHelper.accessor("debitAmount", {
+  // ... header省略
+  cell: (info) => {
+    const transaction = info.row.original;
+    return (
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center gap-2">
+          <span>{formatAmount(info.getValue())}</span>
+          {transaction.requiresCounterpart && (
+            <span className="text-xs bg-amber-500/20 text-amber-400 px-1.5 py-0.5 rounded">
+              取引先必須
+            </span>
+          )}
+        </div>
+        {transaction.transactionType === "expense" && (
+          <div className="flex items-center gap-1.5">
+            <Switch
+              checked={transaction.isGrantExpenditure}
+              onCheckedChange={() => alert("not implemented")}
+              className="scale-75"
+            />
+            <span className={cn(
+              "text-xs",
+              transaction.isGrantExpenditure ? "text-primary" : "text-muted-foreground"
+            )}>
+              交付金
+            </span>
+          </div>
+        )}
+      </div>
+    );
+  },
+}),
+```
+
+## 備考
+
+- 実際の更新処理（action/usecase）は後続タスクで実装予定
+- 交付金フラグの一括更新機能も後続タスクで検討予定


### PR DESCRIPTION
## Summary

- `/assign/counterparts` ページのトランザクション行に `isGrantExpenditure` フラグのトグルUIを追加する設計

## 変更内容

- ドメインモデル `TransactionWithCounterpart` に `isGrantExpenditure` フィールドを追加
- リポジトリの3メソッドで `isGrantExpenditure` を取得
- shadcn UI `Switch` コンポーネントを新規追加
- 金額列に交付金フラグのトグルスイッチを表示（支出取引のみ）
- Phase 1 ではトグル操作時に `alert("not implemented")` を表示

## 関連

- [docs/20251230_0039_交付金フラグカラム追加マイグレーション設計.md](docs/20251230_0039_交付金フラグカラム追加マイグレーション設計.md)

## Test plan

- [ ] 設計ドキュメントの内容をレビュー
- [ ] アーキテクチャガイドとの整合性を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 取引一覧画面に「交付金」フラグの表示・切り替え機能を追加しました。経費取引の行に切り替えトグルが表示され、交付金として計上する取引を管理できます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->