### PR TITLE
feat: 交付金フラグUI表示と更新処理設計

### DIFF
--- a/docs/20251230_0149_交付金フラグ更新処理設計.md
+++ b/docs/20251230_0149_交付金フラグ更新処理設計.md
@@ -20,6 +20,7 @@
 admin アーキテクチャガイドに従い、以下のレイヤー構造で実装する。
 
 ```
+domain/models/         → grant-expenditure-rules.ts（新規：ドメインルール）
 presentation/actions/  → update-grant-expenditure-flag.ts
 application/usecases/  → update-grant-expenditure-flag-usecase.ts
 infrastructure/repositories/  → prisma-report-transaction.repository.ts に追加
@@ -27,7 +28,48 @@ infrastructure/repositories/  → prisma-report-transaction.repository.ts に追
 
 ## 実装詳細
 
-### 1. リポジトリインターフェース拡張
+### 1. ドメインモデル（交付金フラグルール）
+
+**ファイル**: `admin/src/server/contexts/report/domain/models/grant-expenditure-rules.ts`（新規作成）
+
+交付金フラグに関するビジネスルールをドメインモデルとして定義する。`counterpart-assignment-rules.ts` と同様のパターンを採用。
+
+```typescript
+/**
+ * 交付金フラグの更新可否を判定
+ *
+ * @param transactionType - 'income' | 'expense'
+ * @returns 交付金フラグを設定可能な場合true
+ */
+export function canSetGrantExpenditureFlag(
+  transactionType: "income" | "expense",
+): boolean;
+
+/**
+ * 交付金フラグ更新のバリデーション結果
+ */
+export interface GrantExpenditureFlagValidationResult {
+  isValid: boolean;
+  errorMessage?: string;
+}
+
+/**
+ * 交付金フラグ更新のバリデーションを実行
+ *
+ * @param transactionType - 'income' | 'expense'
+ * @returns バリデーション結果
+ */
+export function validateGrantExpenditureFlagUpdate(
+  transactionType: "income" | "expense",
+): GrantExpenditureFlagValidationResult;
+```
+
+このドメインモデルにより:
+- ビジネスルール（「支出取引のみ交付金フラグを設定可能」）がドメイン層に集約される
+- 将来のルール追加（例：会計期間との関連チェック、特定カテゴリの制約）に対応しやすい
+- ユースケースはドメインルールを呼び出すだけでよく、ロジックが分離される
+
+### 2. リポジトリインターフェース拡張
 
 **ファイル**: [admin/src/server/contexts/report/domain/repositories/report-transaction-repository.interface.ts](../admin/src/server/contexts/report/domain/repositories/report-transaction-repository.interface.ts)
 
@@ -42,7 +84,7 @@ infrastructure/repositories/  → prisma-report-transaction.repository.ts に追
 updateGrantExpenditureFlag(id: bigint, isGrantExpenditure: boolean): Promise<void>;
 ```
 
-### 2. リポジトリ実装
+### 3. リポジトリ実装
 
 **ファイル**: [admin/src/server/contexts/report/infrastructure/repositories/prisma-report-transaction.repository.ts](../admin/src/server/contexts/report/infrastructure/repositories/prisma-report-transaction.repository.ts)
 
@@ -51,7 +93,7 @@ updateGrantExpenditureFlag(id: bigint, isGrantExpenditure: boolean): Promise<voi
 - Prisma の `update` を使用して `isGrantExpenditure` フィールドを更新
 - 対象トランザクションが存在しない場合はエラーをスロー
 
-### 3. ユースケース
+### 4. ユースケース
 
 **ファイル**: `admin/src/server/contexts/report/application/usecases/update-grant-expenditure-flag-usecase.ts`（新規作成）
 
@@ -76,18 +118,20 @@ interface UpdateGrantExpenditureFlagResult {
 #### 処理フロー
 
 1. `transactionId` を BigInt に変換、失敗時はエラー
-2. トランザクションの存在確認
-3. トランザクションが支出取引であることを確認（`transactionType === "expense"`）
+2. トランザクションの存在確認（リポジトリ経由）
+3. ドメインルール `validateGrantExpenditureFlagUpdate` でバリデーション
 4. リポジトリで `isGrantExpenditure` を更新
 5. 成功を返却
 
 #### バリデーション
 
-- 無効なトランザクションID → エラー
-- 存在しないトランザクション → エラー
-- 収入取引への更新試行 → エラー（「収入取引には交付金フラグを設定できません」）
+ドメインモデル `grant-expenditure-rules.ts` の関数を使用:
 
-### 4. サーバーアクション
+- 無効なトランザクションID → エラー（ユースケース内でチェック）
+- 存在しないトランザクション → エラー（ユースケース内でチェック）
+- 収入取引への更新試行 → エラー（ドメインルール `validateGrantExpenditureFlagUpdate` が返却）
+
+### 5. サーバーアクション
 
 **ファイル**: `admin/src/server/contexts/report/presentation/actions/update-grant-expenditure-flag.ts`（新規作成）
 
@@ -105,7 +149,7 @@ export async function updateGrantExpenditureFlagAction(
 3. 成功時: `revalidatePath("/assign/counterparts")` でキャッシュ無効化
 4. 結果を返却
 
-### 5. UIコンポーネント更新
+### 6. UIコンポーネント更新
 
 **ファイル**: [admin/src/client/components/counterpart-assignment/TransactionWithCounterpartTable.tsx](../admin/src/client/components/counterpart-assignment/TransactionWithCounterpartTable.tsx)
 
@@ -134,7 +178,7 @@ export async function updateGrantExpenditureFlagAction(
 - 交付金フラグの更新は独立した操作であり、他の状態と連携する必要がない
 - revalidatePathによるサーバー側キャッシュ無効化で整合性を担保
 
-### 6. トースト通知
+### 7. トースト通知
 
 エラー発生時にトースト通知を表示する。admin では既に toast 機能が利用可能。
 
@@ -145,6 +189,7 @@ export async function updateGrantExpenditureFlagAction(
 
 | ファイル | 変更内容 |
 |---------|---------|
+| `grant-expenditure-rules.ts` (domain/models) | 新規作成：交付金フラグのドメインルール |
 | `report-transaction-repository.interface.ts` | `updateGrantExpenditureFlag` メソッド追加 |
 | `prisma-report-transaction.repository.ts` | `updateGrantExpenditureFlag` 実装追加 |
 | `update-grant-expenditure-flag-usecase.ts` | 新規作成 |


### PR DESCRIPTION
## Summary

- Counterpart割当画面（`/assign/counterparts`）に交付金フラグ（`isGrantExpenditure`）の表示とトグルUIを追加
- 支出取引のみにトグルスイッチを表示し、交付金に係る支出かどうかを設定可能に
- Phase 2として更新処理の設計ドキュメントを追加

## 変更内容

### 実装済み（Phase 1）
- `TransactionWithCounterpart` モデルに `isGrantExpenditure` フィールドを追加
- リポジトリで `isGrantExpenditure` を取得するように変更
- テーブルに交付金フラグ列を追加（独立したカラムとして配置）
- ツールチップで交付金フラグの説明を表示
- トグル操作時は `alert("not implemented")` を表示（仮実装）

### 設計追加（Phase 2準備）
- `docs/20251230_0149_交付金フラグ更新処理設計.md` を追加
- トグル操作でDB更新を行うための設計（リポジトリ、ユースケース、アクション、UI更新）

## Test plan

- [ ] `/assign/counterparts` ページで支出取引に交付金フラグのトグルが表示される
- [ ] 収入取引には `-` が表示される
- [ ] ツールチップにカーソルを合わせると説明が表示される
- [ ] トグル操作で `alert("not implemented")` が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 経費取引の交付金フラグをUIのトグルで切り替え可能にする設計を追加。トグル操作は即時に画面に反映（楽観的更新）され、失敗時はエラー通知とロールバックが行われます。更新は経費取引のみ・一件ずつ行われます。

* **Documentation**
  * バリデーション、エラーケース、キャッシュ再検証（成功時の再取得）などのフローを詳述した設計ドキュメントを追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->