### PR TITLE
fix: 交付金フラグのツールチップ説明を正確な内容に修正

### DIFF
--- a/admin/src/client/components/counterpart-assignment/TransactionWithCounterpartTable.tsx
+++ b/admin/src/client/components/counterpart-assignment/TransactionWithCounterpartTable.tsx
@@ -196,7 +196,7 @@ export function TransactionWithCounterpartTable({
                 </span>
               </TooltipTrigger>
               <TooltipContent side="bottom" className="max-w-xs">
-                交付金に係る支出かどうかを示すフラグです。ONにすると、この支出が政党交付金から支出されたものとして報告書に記載されます。
+                本部又は支部に対する交付金として支出したかどうかを示すフラグです。ONにすると、報告書のシート16「本部又は支部に対する交付金の支出」にも記載されます。
               </TooltipContent>
             </Tooltip>
           </div>


### PR DESCRIPTION
## Summary
- 交付金フラグのツールチップ説明文を正確な内容に修正
- 「政党交付金から支出されたもの」→「本部又は支部に対する交付金として支出したもの」
- 報告書のシート16への記載についても言及を追加

## 背景
設計ドキュメント（`docs/20251229_2237_交付金フラグ実装設計.md`）によると、このフラグは「政党交付金から支出された」ではなく、「本部又は支部に対して交付金として支出した」ことを示すものです。

## Test plan
- [ ] 取引先紐付け画面で「交付金」列のツールチップを確認し、新しい説明文が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * 交付金フラグのツールチップを更新し、本部または支部への交付金支出に関する説明をより明確にしました。報告書シート16での記載についても注記を追加しています。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->