### PR TITLE
docs: 交付金フラグXML出力設計ドキュメントを追加

### DIFF
--- a/docs/20251230_0240_交付金フラグXML出力設計.md
+++ b/docs/20251230_0240_交付金フラグXML出力設計.md
@@ -1,0 +1,318 @@
+# 交付金フラグXML出力設計
+
+## 1. 概要
+
+### 1.1 背景
+
+[docs/20251229_2237_交付金フラグ実装設計.md](20251229_2237_交付金フラグ実装設計.md) に基づき、DBに `isGrantExpenditure` フラグが実装された。本設計ではこのフラグをXML出力に正しく反映する方法を定める。
+
+### 1.2 対象シート
+
+| シート | 変更内容 |
+|--------|----------|
+| SYUUSHI07_13（その13） | 各費目の `*_KOUFU` タグに交付金金額を出力 |
+| SYUUSHI07_14（その14） | 各ROWに `KOUFUKIN` タグを出力 |
+| SYUUSHI07_15（その15） | 各ROWに `KOUFUKIN` タグを出力 |
+| SYUUSHI07_16（その16） | シート14/15から交付金フラグ付き明細を抽出して出力 |
+
+---
+
+## 2. XML仕様
+
+### 2.1 シート14/15のROW要素
+
+各支出明細行に `KOUFUKIN` タグを追加する。
+
+```xml
+<ROW>
+  <ICHIREN_NO>1</ICHIREN_NO>
+  <MOKUTEKI>事務所家賃</MOKUTEKI>
+  <KINGAKU>100000</KINGAKU>
+  <DT>r7/1/15</DT>
+  <NM>○○支部</NM>
+  <ADR>東京都千代田区...</ADR>
+  <BIKOU/>
+  <RYOUSYU>0</RYOUSYU>
+  <KOUFUKIN>1</KOUFUKIN>  <!-- 交付金フラグ: 0=通常, 1=交付金に係る支出 -->
+</ROW>
+```
+
+### 2.2 シート13の交付金列
+
+各費目について `*_KOUFU` タグに交付金の合計金額を出力する。
+
+```xml
+<SYUUSHI07_13>
+  <SHEET>
+    <JINKENHI_GK>500000</JINKENHI_GK>
+    <JINKENHI_KOUFU>0</JINKENHI_KOUFU>      <!-- 人件費のうち交付金 -->
+    <JINKENHI_BIKOU/>
+
+    <KOUNETU_GK>120000</KOUNETU_GK>
+    <KOUNETU_KOUFU>50000</KOUNETU_KOUFU>    <!-- 光熱水費のうち交付金 -->
+    <KOUNETU_BIKOU/>
+
+    <!-- ... 他の費目 ... -->
+
+    <KEIHI_SKEI_GK>1000000</KEIHI_SKEI_GK>
+    <KEIHI_SKEI_KOUFU>100000</KEIHI_SKEI_KOUFU>  <!-- 経常経費小計の交付金 -->
+    <KEIHI_SKEI_BIKOU/>
+
+    <!-- ... 政治活動費 ... -->
+
+    <KATUDOU_SKEI_GK>2000000</KATUDOU_SKEI_GK>
+    <KATUDOU_SKEI_KOUFU>300000</KATUDOU_SKEI_KOUFU>  <!-- 政治活動費小計の交付金 -->
+    <KATUDOU_SKEI_BIKOU/>
+
+    <GKEI_GK>3000000</GKEI_GK>
+  </SHEET>
+</SYUUSHI07_13>
+```
+
+### 2.3 シート16の構造
+
+シート14/15で `KOUFUKIN=1` の明細を抽出して出力する。
+
+```xml
+<SYUUSHI07_16>
+  <SHEET>
+    <KINGAKU_GK>400000</KINGAKU_GK>  <!-- 交付金総額 -->
+    <ROW>
+      <ICHIREN_NO>1</ICHIREN_NO>
+      <SHISYUTU_KMK>光熱水費</SHISYUTU_KMK>  <!-- 元の費目名 -->
+      <KINGAKU>50000</KINGAKU>
+      <DT>r7/1/15</DT>
+      <HONSIBU_NM>○○支部</HONSIBU_NM>        <!-- 本支部名称 -->
+      <JIMU_ADR>東京都千代田区...</JIMU_ADR>  <!-- 主たる事務所の所在地 -->
+      <BIKOU/>
+    </ROW>
+    <!-- ... -->
+  </SHEET>
+</SYUUSHI07_16>
+```
+
+### 2.4 バリデーションルール（E183/E184）
+
+```
+シート13.KEIHI_SKEI_KOUFU + シート13.KATUDOU_SKEI_KOUFU = シート16.KINGAKU_GK
+```
+
+この整合性を保証するため、シート13の交付金金額とシート16の合計金額は同一のデータソースから計算する。
+
+---
+
+## 3. データフロー
+
+### 3.1 トランザクションデータの取得
+
+各カテゴリのリポジトリメソッドが `isGrantExpenditure` フラグを含むトランザクションを返すようにする。
+
+```
+Transaction テーブル
+├── id
+├── category_id
+├── amount
+├── transaction_date
+├── is_grant_expenditure  ← このフラグを取得
+└── ...
+```
+
+### 3.2 データ変換の流れ
+
+```
+Repository
+    ↓ isGrantExpenditure を含むトランザクションを取得
+Domain Models (expense-transaction.ts)
+    ↓ ExpenseRow / PoliticalActivityExpenseRow に koufukin フィールドを追加
+Serializer (expense-serializer.ts)
+    ↓ KOUFUKIN タグを出力
+XML出力
+```
+
+### 3.3 シート16の生成
+
+シート16は独立したカテゴリではなく、シート14/15の交付金フラグ付き明細から抽出する。
+
+```
+シート14/15のExpenseRow (isGrantExpenditure=true)
+    ↓ フィルタリング
+GrantExpenditureSection
+    ↓ フィールド変換 (NM → HONSIBU_NM, ADR → JIMU_ADR)
+grant-expenditure-serializer.ts
+    ↓
+SYUUSHI07_16 XML
+```
+
+---
+
+## 4. 変更対象
+
+### 4.1 ドメインモデル（expense-transaction.ts）
+
+**変更箇所**: `BaseExpenseTransaction` インターフェース
+
+```
+追加フィールド:
+- isGrantExpenditure: boolean
+```
+
+**変更箇所**: `ExpenseRow` / `PoliticalActivityExpenseRow` インターフェース
+
+```
+追加フィールド:
+- koufukin?: number  // 0 or 1
+```
+
+**変更箇所**: `ExpenseTransactionBase.toRow()` メソッド
+
+交付金フラグを `koufukin` フィールドにマッピングする。
+
+### 4.2 ドメインモデル（expense-summary.ts）
+
+**変更箇所**: `createSummaryItem()` 関数
+
+現状 `grantAmount: null` を固定で返しているが、交付金フラグ付きトランザクションの金額合計を計算するように変更する。
+
+**変更箇所**: `ExpenseSummaryData.fromExpenseData()` メソッド
+
+各費目セクションから交付金金額（`isGrantExpenditure=true` のトランザクション金額合計）を計算し、`grantAmount` に設定する。
+
+### 4.3 新規ドメインモデル（grant-expenditure.ts）
+
+シート16用のドメインモデルを新規作成する。
+
+```typescript
+// シート16の明細行
+interface GrantExpenditureRow {
+  ichirenNo: string;
+  shisyutuKmk: string;   // 支出項目（費目名）
+  kingaku: number;
+  dt: Date;
+  honsibuNm: string;     // 本支部名称（= NM）
+  jimuAdr: string;       // 主たる事務所の所在地（= ADR）
+  bikou?: string;
+}
+
+// シート16のセクション
+interface GrantExpenditureSection {
+  totalAmount: number;   // KINGAKU_GK
+  rows: GrantExpenditureRow[];
+}
+```
+
+### 4.4 シリアライザー（expense-serializer.ts）
+
+**変更箇所**: `serializeExpenseKubun()` 関数
+
+ROW要素に `KOUFUKIN` タグを出力する。
+
+```
+追加出力:
+rowEle.ele("KOUFUKIN").txt(row.koufukin?.toString() ?? "0")
+```
+
+**変更箇所**: `serializePoliticalActivitySheet()` 関数
+
+同様に `KOUFUKIN` タグを出力する。
+
+### 4.5 新規シリアライザー（grant-expenditure-serializer.ts）
+
+シート16用のシリアライザーを新規作成する。
+
+```typescript
+export function serializeGrantExpenditureSection(
+  section: GrantExpenditureSection
+): XMLBuilder {
+  // SYUUSHI07_16 のXMLフラグメントを生成
+}
+```
+
+### 4.6 リポジトリ（PrismaReportTransactionRepository）
+
+**変更箇所**: 各カテゴリの取得メソッド
+
+`isGrantExpenditure` フィールドを含めて返すようにする。現状すでにPrismaスキーマに定義されているため、selectに追加するのみ。
+
+### 4.7 アセンブラー（ExpenseAssembler）
+
+**変更箇所**: `assembleExpenseData()` メソッド
+
+シート16用のデータ（`GrantExpenditureSection`）を組み立てる処理を追加する。シート14/15のデータから `isGrantExpenditure=true` の明細を抽出し、フィールドを変換する。
+
+### 4.8 レポートシリアライザー（report-serializer.ts）
+
+**変更箇所**: シート16の出力処理
+
+現在コメントアウトされているシート16の出力処理を有効化し、`grant-expenditure-serializer.ts` を呼び出す。
+
+**変更箇所**: `SYUUSHI_UMU_FLG`
+
+シート16のフラグ（34桁目）を、交付金データの有無に応じて設定する。
+
+---
+
+## 5. 処理順序
+
+シート13とシート16の整合性を保証するため、以下の順序で処理する。
+
+1. **リポジトリ**: 各カテゴリのトランザクションを `isGrantExpenditure` 付きで取得
+2. **セクション構築**: シート14/15用のセクションを構築（各ROWに `koufukin` を設定）
+3. **シート16構築**: シート14/15のデータから交付金フラグ付き明細を抽出してシート16を構築
+4. **シート13構築**: シート14/15のデータから交付金金額を集計してシート13を構築
+5. **シリアライズ**: 各シートをXMLに変換
+
+この順序により、シート13の `*_KOUFU` 金額とシート16の `KINGAKU_GK` が同一のデータソースから計算され、バリデーションエラー（E183/E184）を防止できる。
+
+---
+
+## 6. SYUUSHI_UMU_FLGへの影響
+
+| 桁 | 様式 | 条件 |
+|----|------|------|
+| 34 | その16（本部又は支部に対する交付金の支出） | 交付金フラグ付き明細が1件以上存在する場合に `1` |
+
+シート14/15に `KOUFUKIN=1` の明細が存在する場合、34桁目を `1` に設定する。
+
+---
+
+## 7. 考慮事項
+
+### 7.1 経常経費（シート14）の交付金
+
+XML仕様上、経常経費（光熱水費・備品消耗品費・事務所費）にも交付金フラグを設定可能。シート13の `KOUNETU_KOUFU`、`BIHIN_KOUFU`、`JIMUSYO_KOUFU` に反映される。
+
+### 7.2 人件費の交付金
+
+人件費はシート14に明細を出力しないが、シート13の `JINKENHI_KOUFU` には交付金金額を出力可能。ただし、シート16には人件費の交付金明細は出力されない（シート14/15の明細から抽出するため）。
+
+現状のスコープでは人件費への交付金フラグ設定は想定していないが、将来的に対応する場合はシート16への出力方法を検討する必要がある。
+
+### 7.3 費目名（SHISYUTU_KMK）のマッピング
+
+シート16の `SHISYUTU_KMK` には元の費目名を設定する。カテゴリIDから費目名への変換テーブルを用意する。
+
+| カテゴリ | SHISYUTU_KMK |
+|----------|--------------|
+| utility-expenses | 光熱水費 |
+| supplies-expenses | 備品・消耗品費 |
+| office-expenses | 事務所費 |
+| organization-expenses | 組織活動費 |
+| election-expenses | 選挙関係費 |
+| publication-expenses | 機関紙誌の発行事業費 |
+| advertising-expenses | 宣伝事業費 |
+| fundraising-party-expenses | 政治資金パーティー開催事業費 |
+| other-business-expenses | その他の事業費 |
+| research-expenses | 調査研究費 |
+| donation-grant-expenses | 寄附・交付金 |
+| other-political-expenses | その他の経費 |
+
+---
+
+## 8. アーキテクチャ準拠チェック
+
+本設計は [docs/admin-architecture-guide.md](admin-architecture-guide.md) のルールに準拠している。
+
+- **レイヤー分離**: ドメインモデル（domain/models）、シリアライザー（domain/services）、リポジトリ実装（infrastructure）の責務が明確
+- **Bounded Context**: report コンテキスト内で完結
+- **依存性逆転**: リポジトリはインターフェース経由で使用
+- **キャッシング**: 既存のloader/actionパターンを維持


### PR DESCRIPTION
## Summary

- 交付金フラグ(`isGrantExpenditure`)をXML出力に反映するための設計ドキュメントを追加
- シート13/14/15/16への出力仕様を定義
- シート13とシート16の整合性（E183/E184バリデーション）を保証する処理順序を設計

## 変更対象シート

| シート | 変更内容 |
|--------|----------|
| SYUUSHI07_13（その13） | 各費目の `*_KOUFU` タグに交付金金額を出力 |
| SYUUSHI07_14（その14） | 各ROWに `KOUFUKIN` タグを出力 |
| SYUUSHI07_15（その15） | 各ROWに `KOUFUKIN` タグを出力 |
| SYUUSHI07_16（その16） | シート14/15から交付金フラグ付き明細を抽出して出力 |

## Test plan

- [ ] 設計内容のレビュー
- [ ] admin-architecture-guide.md との整合性確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメンテーション**
  * 給付金支出情報の出力設計に関する技術ドキュメントを追加。複数シート間でのデータ流通、出力マッピング、検証ルール、処理順序を詳細に記述し、今後の実装ガイドラインを確立。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->