### PR TITLE
docs: 収支総括表プレビュー実装の設計ドキュメントを追加

### DIFF
--- a/docs/20251230_1046_収支総括表プレビュー実装設計.md
+++ b/docs/20251230_1046_収支総括表プレビュー実装設計.md
@@ -1,0 +1,165 @@
+# 収支総括表プレビュー実装設計
+
+## 概要
+
+報告書エクスポートページ (`/export-report/[orgId]/[year]`) の表形式プレビューに、収支総括表（SYUUSHI07_02）のUIコンポーネントを追加する。
+
+現在、バックエンドでは `ReportData.getSummary()` で収支総括表データの計算ロジックが実装済みだが、UIとしては表示されていない状態。
+
+## スコープ
+
+### 対象
+
+- 収支総括表（SYUUSHI07_02）のUIコンポーネント実装
+
+### 対象外
+
+- 前年繰越額の入力機能（初期値0で固定）
+- 備考欄の入力機能
+- 党費（個人負担党費金額・員数）の表示
+
+## 現状分析
+
+### バックエンドの実装状況
+
+| 機能 | 実装状況 | 備考 |
+|------|----------|------|
+| `SummaryData` 型定義 | ✅ 実装済み | [summary-data.ts](../admin/src/server/contexts/report/domain/models/summary-data.ts) |
+| `ReportData.getSummary()` | ✅ 実装済み | [report-data.ts](../admin/src/server/contexts/report/domain/models/report-data.ts) |
+| loaderからの返却 | ❌ 未実装 | summaryDataをloaderの返却値に含めていない |
+
+### フロントエンドの実装状況
+
+| 機能 | 実装状況 | 備考 |
+|------|----------|------|
+| `SummarySection` コンポーネント | ❌ 未実装 | - |
+| `ReportDataPreview` への組み込み | ❌ 未実装 | - |
+
+## 設計
+
+### 1. データフロー
+
+```
+[loader] report-preview-loader.ts
+    ↓ XmlExportUsecase.execute() の結果を受け取る
+    ↓ ReportData.getSummary(reportData) を呼び出してsummaryDataを生成
+    ↓ { xml, reportData, summaryData } を返却
+
+[page] export-report/[orgId]/[year]/page.tsx
+    ↓ previewData.summaryData を ExportReportPreview に渡す
+
+[component] ExportReportPreview.tsx
+    ↓ summaryData を ReportDataPreview に渡す
+
+[component] ReportDataPreview.tsx
+    ↓ SummarySection を追加（ProfileSectionの直後）
+
+[component] SummarySection.tsx
+    → 収支総括表を表形式で表示
+```
+
+### 2. コンポーネント設計
+
+#### 2.1 SummarySection
+
+**配置場所**: `admin/src/client/components/export-report/sections/SummarySection.tsx`
+
+**Props**:
+
+```typescript
+interface SummarySectionProps {
+  summaryData: SummaryData;
+}
+```
+
+**表示レイアウト**:
+
+報告書フォーマットに準拠し、以下の構造で表示する。
+
+```
+収支総括表 (SYUUSHI07_02)
+┌─────────────────────────────────────────┐
+│ 【収支総括】                             │
+├────────────────────┬────────────────────┤
+│ 収入総額           │ ¥XXX,XXX           │
+│ 前年繰越額         │ ¥XXX,XXX           │
+│ 本年収入額         │ ¥XXX,XXX           │
+│ 支出総額           │ ¥XXX,XXX           │
+│ 翌年繰越額         │ ¥XXX,XXX           │
+├────────────────────┴────────────────────┤
+│ 【寄附の内訳】                           │
+├────────────────────┬────────────────────┤
+│ 個人寄附           │ ¥XXX,XXX           │
+│ 法人寄附           │ -（未実装）        │
+│ 政治団体寄附       │ -（未実装）        │
+│ 寄附小計           │ ¥XXX,XXX           │
+│ 寄附合計           │ ¥XXX,XXX           │
+└────────────────────┴────────────────────┘
+```
+
+**表示ルール**:
+- 金額は `¥XXX,XXX` 形式でフォーマット（他のセクションと同様）
+- `null` 値は「-」または「（未実装）」で表示
+- スコープ外の項目（党費、特定寄附、あっせん、政党匿名寄附）は非表示
+
+### 3. 型定義の変更
+
+#### 3.1 ReportPreviewData の拡張
+
+**ファイル**: `admin/src/server/contexts/report/presentation/loaders/report-preview-loader.ts`
+
+```typescript
+export interface ReportPreviewData {
+  xml: string;
+  reportData: ReportData;
+  summaryData: SummaryData;  // 追加
+}
+```
+
+### 4. ファイル変更一覧
+
+| ファイル | 変更内容 |
+|----------|----------|
+| `admin/src/server/contexts/report/presentation/loaders/report-preview-loader.ts` | `SummaryData` を返却値に追加 |
+| `admin/src/client/components/export-report/ExportReportPreview.tsx` | `summaryData` をpropsに追加、`ReportDataPreview`に渡す |
+| `admin/src/client/components/export-report/ReportDataPreview.tsx` | `SummarySection` を追加 |
+| `admin/src/client/components/export-report/sections/SummarySection.tsx` | **新規作成** |
+| `admin/src/client/components/export-report/sections/index.ts` | `SummarySection` をexport（必要であれば） |
+| `admin/src/app/(auth)/export-report/[orgId]/[year]/page.tsx` | `summaryData` をコンポーネントに渡す |
+
+### 5. 表示項目マッピング
+
+| XML項目名 | SummaryData プロパティ | 表示ラベル | 表示 |
+|-----------|----------------------|-----------|------|
+| SYUNYU_SGK | syunyuSgk | 収入総額 | ✅ |
+| ZENNEN_KKS_GK | zennenKksGk | 前年繰越額 | ✅ |
+| HONNEN_SYUNYU_GK | honnenSyunyuGk | 本年収入額 | ✅ |
+| SISYUTU_SGK | sisyutuSgk | 支出総額 | ✅ |
+| YOKUNEN_KKS_GK | yokunenKksGk | 翌年繰越額 | ✅ |
+| KOJIN_FUTAN_KGK | kojinFutanKgk | 個人負担党費金額 | ❌（スコープ外） |
+| KOJIN_FUTAN_SU | kojinFutanSu | 個人負担党費員数 | ❌（スコープ外） |
+| KOJIN_KIFU_GK | kojinKifuGk | 個人寄附 | ✅ |
+| TOKUTEI_KIFU_GK | tokuteiKifuGk | 特定寄附 | ❌（スコープ外） |
+| HOJIN_KIFU_GK | hojinKifuGk | 法人寄附 | ✅（未実装表示） |
+| SEIJI_KIFU_GK | seijiKifuGk | 政治団体寄附 | ✅（未実装表示） |
+| KIFU_SKEI_GK | kifuSkeiGk | 寄附小計 | ✅ |
+| ATUSEN_GK | atusenGk | あっせんによるもの | ❌（スコープ外） |
+| TOKUMEI_KIFU_GK | tokumeiKifuGk | 政党匿名寄附 | ❌（スコープ外） |
+| KIFU_GKEI_GK | kifuGkeiGk | 寄附合計 | ✅ |
+
+## アーキテクチャ適合性
+
+### レイヤー分離
+
+- ✅ Presentation層（loader）がUsecaseを呼び出し、summaryDataを計算
+- ✅ Domain層（ReportData.getSummary）にビジネスロジックを集約
+- ✅ UIコンポーネントは純粋な表示のみを担当
+
+### Bounded Context
+
+- ✅ reportコンテキスト内で完結
+- ✅ sharedへの不要な依存なし
+
+### キャッシング
+
+- ✅ 既存の `unstable_cache` ラッパー内で処理されるため、追加のキャッシュ設定不要


### PR DESCRIPTION
## Summary

- 報告書エクスポートページの表形式プレビューに収支総括表（SYUUSHI07_02）を追加するための設計ドキュメント
- バックエンドの `ReportData.getSummary()` は実装済みだがUIが未実装の状態を解消する設計

## Test plan

- [ ] 設計ドキュメントの内容を確認
- [ ] アーキテクチャガイドとの整合性を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
* エクスポートレポートプレビューにサマリーセクションを追加しました。財務サマリーデータを表形式で表示し、通貨フォーマット、データ検証、およびスコープに基づいた項目の表示制御に対応しています。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->