### PR TITLE
fix(admin): 団体基本情報と収支総括表の余白スタイルを他セクションに統一

### DIFF
--- a/admin/src/client/components/export-report/sections/ProfileSection.tsx
+++ b/admin/src/client/components/export-report/sections/ProfileSection.tsx
@@ -53,9 +53,11 @@ interface ProfileRowProps {
 
 function ProfileRow({ label, value }: ProfileRowProps) {
   return (
-    <tr className="border-b border-gray-200">
-      <th className="py-2 px-4 text-left font-medium text-gray-700 bg-gray-50 w-1/3">{label}</th>
-      <td className="py-2 px-4 text-gray-900">{value}</td>
+    <tr className="border border-black">
+      <th className="py-2 px-4 text-left font-medium text-gray-700 bg-gray-50 w-1/3 border border-black">
+        {label}
+      </th>
+      <td className="py-2 px-4 text-gray-900 border border-black">{value}</td>
     </tr>
   );
 }
@@ -74,29 +76,34 @@ export function ProfileSection({ profile }: ProfileSectionProps) {
       : "-";
 
   return (
-    <div className="space-y-4">
-      <h2 className="text-xl font-bold text-white">団体基本情報 (SYUUSHI07_01)</h2>
+    <div className="space-y-6">
+      <h2 className="text-xl font-bold text-white">団体基本情報</h2>
 
       <div className="bg-white border border-black overflow-hidden">
-        <table className="w-full">
-          <tbody>
-            <ProfileRow label="報告年" value={String(profile.financialYear)} />
-            <ProfileRow label="政治団体名称" value={profile.officialName || "-"} />
-            <ProfileRow label="ふりがな" value={profile.officialNameKana || "-"} />
-            <ProfileRow
-              label="主たる事務所の所在地"
-              value={formatAddress(profile.officeAddress, profile.officeAddressBuilding)}
-            />
-            <ProfileRow label="代表者氏名" value={formatFullName(details.representative)} />
-            <ProfileRow label="会計責任者氏名" value={formatFullName(details.accountant)} />
-            <ProfileRow label="事務担当者" value={contactPersonsDisplay} />
-            <ProfileRow label="活動区域" value={getActivityAreaLabel(details.activityArea)} />
-            <ProfileRow
-              label="国会議員関係政治団体の区分"
-              value={getDietMemberRelationTypeLabel(details.dietMemberRelation?.type)}
-            />
-          </tbody>
-        </table>
+        <div className="bg-gray-100 border-b border-black px-4 py-3">
+          <h3 className="text-lg font-semibold text-black">団体基本情報 (SYUUSHI07_01)</h3>
+        </div>
+        <div className="p-4">
+          <table className="w-full border-collapse border border-black">
+            <tbody>
+              <ProfileRow label="報告年" value={String(profile.financialYear)} />
+              <ProfileRow label="政治団体名称" value={profile.officialName || "-"} />
+              <ProfileRow label="ふりがな" value={profile.officialNameKana || "-"} />
+              <ProfileRow
+                label="主たる事務所の所在地"
+                value={formatAddress(profile.officeAddress, profile.officeAddressBuilding)}
+              />
+              <ProfileRow label="代表者氏名" value={formatFullName(details.representative)} />
+              <ProfileRow label="会計責任者氏名" value={formatFullName(details.accountant)} />
+              <ProfileRow label="事務担当者" value={contactPersonsDisplay} />
+              <ProfileRow label="活動区域" value={getActivityAreaLabel(details.activityArea)} />
+              <ProfileRow
+                label="国会議員関係政治団体の区分"
+                value={getDietMemberRelationTypeLabel(details.dietMemberRelation?.type)}
+              />
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   );

--- a/admin/src/client/components/export-report/sections/SummarySection.tsx
+++ b/admin/src/client/components/export-report/sections/SummarySection.tsx
@@ -22,9 +22,11 @@ interface SummaryRowProps {
 
 function SummaryRow({ label, value }: SummaryRowProps) {
   return (
-    <tr className="border-b border-gray-200">
-      <th className="py-2 px-4 text-left font-medium text-gray-700 bg-gray-50 w-1/3">{label}</th>
-      <td className="py-2 px-4 text-gray-900 text-right">{value}</td>
+    <tr className="border border-black">
+      <th className="py-2 px-4 text-left font-medium text-gray-700 bg-gray-50 w-1/3 border border-black">
+        {label}
+      </th>
+      <td className="py-2 px-4 text-gray-900 text-right border border-black">{value}</td>
     </tr>
   );
 }
@@ -35,8 +37,11 @@ interface SectionHeaderProps {
 
 function SectionHeader({ title }: SectionHeaderProps) {
   return (
-    <tr className="border-b border-gray-200">
-      <th colSpan={2} className="py-2 px-4 text-left font-bold text-gray-800 bg-gray-100">
+    <tr className="border border-black">
+      <th
+        colSpan={2}
+        className="py-2 px-4 text-left font-bold text-gray-800 bg-gray-100 border border-black"
+      >
         {title}
       </th>
     </tr>
@@ -45,30 +50,38 @@ function SectionHeader({ title }: SectionHeaderProps) {
 
 export function SummarySection({ summaryData }: SummarySectionProps) {
   return (
-    <div className="space-y-4">
-      <h2 className="text-xl font-bold text-white">収支総括表 (SYUUSHI07_02)</h2>
+    <div className="space-y-6">
+      <h2 className="text-xl font-bold text-white">収支総括表</h2>
 
       <div className="bg-white border border-black overflow-hidden">
-        <table className="w-full">
-          <tbody>
-            <SectionHeader title="【収支総括】" />
-            <SummaryRow label="収入総額" value={formatCurrency(summaryData.syunyuSgk)} />
-            <SummaryRow label="前年繰越額" value={formatCurrency(summaryData.zennenKksGk)} />
-            <SummaryRow label="本年収入額" value={formatCurrency(summaryData.honnenSyunyuGk)} />
-            <SummaryRow label="支出総額" value={formatCurrency(summaryData.sisyutuSgk)} />
-            <SummaryRow label="翌年繰越額" value={formatCurrency(summaryData.yokunenKksGk)} />
+        <div className="bg-gray-100 border-b border-black px-4 py-3">
+          <h3 className="text-lg font-semibold text-black">収支総括表 (SYUUSHI07_02)</h3>
+        </div>
+        <div className="p-4">
+          <table className="w-full border-collapse border border-black">
+            <tbody>
+              <SectionHeader title="【収支総括】" />
+              <SummaryRow label="収入総額" value={formatCurrency(summaryData.syunyuSgk)} />
+              <SummaryRow label="前年繰越額" value={formatCurrency(summaryData.zennenKksGk)} />
+              <SummaryRow label="本年収入額" value={formatCurrency(summaryData.honnenSyunyuGk)} />
+              <SummaryRow label="支出総額" value={formatCurrency(summaryData.sisyutuSgk)} />
+              <SummaryRow label="翌年繰越額" value={formatCurrency(summaryData.yokunenKksGk)} />
 
-            <SectionHeader title="【寄附の内訳】" />
-            <SummaryRow label="個人寄附" value={formatCurrency(summaryData.kojinKifuGk)} />
-            <SummaryRow label="法人寄附" value={formatNullableCurrency(summaryData.hojinKifuGk)} />
-            <SummaryRow
-              label="政治団体寄附"
-              value={formatNullableCurrency(summaryData.seijiKifuGk)}
-            />
-            <SummaryRow label="寄附小計" value={formatCurrency(summaryData.kifuSkeiGk)} />
-            <SummaryRow label="寄附合計" value={formatCurrency(summaryData.kifuGkeiGk)} />
-          </tbody>
-        </table>
+              <SectionHeader title="【寄附の内訳】" />
+              <SummaryRow label="個人寄附" value={formatCurrency(summaryData.kojinKifuGk)} />
+              <SummaryRow
+                label="法人寄附"
+                value={formatNullableCurrency(summaryData.hojinKifuGk)}
+              />
+              <SummaryRow
+                label="政治団体寄附"
+                value={formatNullableCurrency(summaryData.seijiKifuGk)}
+              />
+              <SummaryRow label="寄附小計" value={formatCurrency(summaryData.kifuSkeiGk)} />
+              <SummaryRow label="寄附合計" value={formatCurrency(summaryData.kifuGkeiGk)} />
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- ProfileSection と SummarySection の余白スタイルを SectionWrapper を使用している他セクションと統一
- ヘッダー部分（グレー背景）と内部余白（p-4）を追加
- テーブルのボーダースタイルを黒に統一

## Test plan
- [ ] http://localhost:3001/export-report/1/2025 で団体基本情報と収支総括表の余白が他の表と同じになっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル改善**
  * 報告書セクションの表示スタイルを更新しました。テーブルボーダーをグレーから黒に変更し、セクションヘッダーに灰色背景を追加しました。
  * セクション間隔と余白を調整し、より見やすいレイアウトに改善しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->