### PR TITLE
docs: authコンテキスト4レイヤー移行設計を追加

### DIFF
--- a/docs/20251230_1625_authコンテキスト4レイヤー移行設計.md
+++ b/docs/20251230_1625_authコンテキスト4レイヤー移行設計.md
@@ -137,16 +137,20 @@ admin/src/server/contexts/auth/
 
 3. `auth/domain/repositories/auth-provider.interface.ts` を作成
    - Supabase Auth の操作を抽象化したインターフェースを定義
-   - 以下のメソッドを定義（詳細は「5. AuthProvider インターフェース詳細」を参照）：
-     - `signInWithPassword(email, password): Promise<AuthProviderResult<AuthSession>>`
-     - `signOut(): Promise<AuthProviderResult<void>>`
-     - `getUser(): Promise<AuthProviderResult<SupabaseAuthUser | null>>`
-     - `updateUser(data): Promise<AuthProviderResult<SupabaseAuthUser>>`
-     - `setSession(accessToken, refreshToken): Promise<AuthProviderResult<AuthSession>>`
-     - `exchangeCodeForSession(code): Promise<AuthProviderResult<AuthSession>>`
+   - エラー時は AuthError を throw（詳細は「6. AuthProvider インターフェース詳細」を参照）
+   - 以下のメソッドを定義：
+     - `signInWithPassword(email, password): Promise<AuthSession>`
+     - `signOut(): Promise<void>`
+     - `getUser(): Promise<SupabaseAuthUser | null>`
+     - `updateUser(data): Promise<SupabaseAuthUser>`
+     - `setSession(accessToken, refreshToken): Promise<AuthSession>`
+     - `exchangeCodeForSession(code): Promise<AuthSession>`
 
-4. `auth/domain/repositories/admin-auth-provider.interface.ts` を作成（Admin 専用操作を分離）
-   - `inviteUserByEmail(email, redirectTo): Promise<AuthProviderResult<void>>`
+4. `auth/domain/errors/auth-error.ts` を作成
+   - AuthError クラスと AuthErrorCode 型を定義（詳細は「5.4 AuthError クラスの定義」を参照）
+
+5. `auth/domain/repositories/admin-auth-provider.interface.ts` を作成（Admin 専用操作を分離）
+   - `inviteUserByEmail(email, redirectTo): Promise<void>`
 
 ### Step 2: infrastructure 層の作成
 
@@ -255,26 +259,29 @@ admin-architecture-guide.md のエラーハンドリング規約に準拠しつ�
 | **エラー情報の段階的抽象化** | 下位層（Infrastructure）→ 上位層（Presentation）に向かってエラー情報を段階的に抽象化する。技術的詳細は下位層に留め、上位層ではユーザー理解可能な情報のみを伝える |
 | **セキュリティ情報の秘匿** | 認証エラーの詳細（「ユーザーが存在しない」vs「パスワードが違う」）は攻撃者に有用な情報となるため、Presentation 層では汎用メッセージに統一する |
 | **ログと UI の分離** | 詳細なエラー情報はサーバーログに記録し、ユーザーには簡潔なメッセージのみを表示する |
-| **Result 型による明示的なエラー伝播** | 例外の throw ではなく Result 型を使用し、エラーの可能性を型で明示する |
+| **カスタムエラークラス + throw** | admin-architecture-guide.md に準拠し、Application 層では `throw new AuthError(code, message)` パターンを使用。Presentation 層で `instanceof` と `code` で分岐する |
 
 ### 5.2 各レイヤーのエラーハンドリング責務
 
 #### Infrastructure 層
 
-**責務**: 外部サービス（Supabase）のエラーをキャッチし、ドメイン固有のエラー型に変換する
+**責務**: 外部サービス（Supabase）のエラーをキャッチし、AuthError として throw する
 
 **詳細度**: 技術的な詳細を含む（デバッグ用）
 
-```
-// Supabase のエラーをキャッチして AuthProviderError に変換
-try {
-  const { data, error } = await supabase.auth.signInWithPassword({ email, password });
-  if (error) {
-    return { ok: false, error: { code: "AUTH_FAILED", message: error.message, cause: error } };
+```typescript
+// Supabase のエラーをキャッチして AuthError を throw
+async signInWithPassword(email: string, password: string): Promise<AuthSession> {
+  try {
+    const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error) {
+      throw new AuthError("AUTH_FAILED", error.message, error);
+    }
+    return mapToAuthSession(data);
+  } catch (e) {
+    if (e instanceof AuthError) throw e;
+    throw new AuthError("NETWORK_ERROR", "認証サービスに接続できません", e);
   }
-  return { ok: true, data };
-} catch (e) {
-  return { ok: false, error: { code: "NETWORK_ERROR", message: "認証サービスに接続できません", cause: e } };
 }
 ```
 
@@ -286,22 +293,28 @@ try {
 
 #### Application 層（Usecase）
 
-**責務**: Infrastructure 層のエラーを受け取り、ビジネスコンテキストを付加する
+**責務**: Infrastructure 層のエラーを受け取り、ビジネスコンテキストを付加して再 throw する
 
 **詳細度**: ビジネス操作の文脈を含む（「ログイン処理に失敗」など）
 
-```
-// Usecase での処理
-const result = await this.authProvider.signInWithPassword(email, password);
-if (!result.ok) {
-  // ログに詳細を記録
-  console.error(`Login failed for ${email}:`, result.error);
-  // Application 層のエラーとして返す
-  return { ok: false, error: { code: "LOGIN_FAILED", message: "ログインに失敗しました" } };
+```typescript
+// Usecase での処理（admin-architecture-guide.md 準拠の throw パターン）
+async execute(email: string, password: string): Promise<AuthSession> {
+  try {
+    return await this.authProvider.signInWithPassword(email, password);
+  } catch (e) {
+    // ログに詳細を記録
+    console.error(`Login failed for ${email}:`, e);
+    // ビジネスコンテキストを付加して再 throw
+    if (e instanceof AuthError) {
+      throw new AuthError(e.code, `Failed to login: ${e.message}`, e);
+    }
+    throw new AuthError("AUTH_FAILED", `Failed to login: ${String(e)}`, e);
+  }
 }
 ```
 
-**ロギング**: Application 層でエラーの詳細をサーバーログに記録する（Infrastructure 層の cause を含む）
+**ロギング**: Application 層でエラーの詳細をサーバーログに記録する（cause を含む）
 
 #### Domain 層（Services）
 
@@ -321,16 +334,25 @@ function validateRole(currentRole: UserRole, requiredRole: UserRole): RoleValida
 
 #### Presentation 層（Actions/Loaders）
 
-**責務**: エラーをユーザー向けメッセージに変換し、UI が処理可能な形式で返す
+**責務**: エラーを catch してユーザー向けメッセージに変換し、UI が処理可能な形式で返す
 
 **詳細度**: ユーザーが理解・対処可能な情報のみ
 
-```
-// Action でのエラー処理
-const result = await usecase.execute(email, password);
-if (!result.ok) {
-  // セキュリティ: 認証エラーは具体的な理由を隠す
-  return { ok: false, error: "メールアドレスまたはパスワードが正しくありません" };
+```typescript
+// Action でのエラー処理（instanceof + code で分岐）
+export async function loginAction(email: string, password: string) {
+  try {
+    await usecase.execute(email, password);
+    return { ok: true };
+  } catch (e) {
+    if (e instanceof AuthError) {
+      // code で分岐してユーザー向けメッセージに変換
+      const userMessage = AUTH_ERROR_MESSAGES[e.code] ?? "エラーが発生しました";
+      return { ok: false, error: userMessage };
+    }
+    // 予期しないエラー
+    return { ok: false, error: "エラーが発生しました" };
+  }
 }
 ```
 
@@ -348,20 +370,12 @@ if (!result.ok) {
 | `WEAK_PASSWORD` | "パスワードは6文字以上で入力してください" | バリデーションエラー |
 | `INVITE_FAILED` | "招待メールの送信に失敗しました" | |
 
-### 5.4 Result 型の定義
+### 5.4 AuthError クラスの定義
 
 ```typescript
-// domain/types/result.ts
-type AuthProviderResult<T> =
-  | { ok: true; data: T }
-  | { ok: false; error: AuthProviderError };
+// domain/errors/auth-error.ts
 
-type AuthProviderError = {
-  code: AuthErrorCode;
-  message: string;  // 開発者向け詳細メッセージ
-  cause?: unknown;  // 元のエラー（ログ用）
-};
-
+// エラーコードの型定義（網羅性チェック用）
 type AuthErrorCode =
   | "AUTH_FAILED"
   | "SESSION_EXPIRED"
@@ -372,7 +386,38 @@ type AuthErrorCode =
   | "INVALID_EMAIL"
   | "WEAK_PASSWORD"
   | "INVITE_FAILED";
+
+// カスタムエラークラス（単一クラス + code パターン）
+class AuthError extends Error {
+  constructor(
+    public readonly code: AuthErrorCode,
+    message: string,
+    public readonly cause?: unknown
+  ) {
+    super(message);
+    this.name = "AuthError";
+  }
+}
+
+// ユーザー向けメッセージ変換マップ（Presentation 層で使用）
+const AUTH_ERROR_MESSAGES: Record<AuthErrorCode, string> = {
+  AUTH_FAILED: "メールアドレスまたはパスワードが正しくありません",
+  SESSION_EXPIRED: "セッションの有効期限が切れました。再度ログインしてください",
+  INVALID_TOKEN: "認証情報が無効です。再度ログインしてください",
+  NETWORK_ERROR: "認証サービスに接続できませんでした。しばらく待ってから再試行してください",
+  INSUFFICIENT_PERMISSION: "この操作を行う権限がありません",
+  USER_NOT_FOUND: "ユーザーが見つかりません",
+  INVALID_EMAIL: "有効なメールアドレスを入力してください",
+  WEAK_PASSWORD: "パスワードは6文字以上で入力してください",
+  INVITE_FAILED: "招待メールの送信に失敗しました",
+};
 ```
+
+**ポイント**:
+- 単一クラス + `code` プロパティで分岐（クラス数の爆発を防ぐ）
+- `instanceof AuthError` で認証エラーかどうかを判定
+- `e.code` の switch で網羅性チェック（TypeScript の exhaustive check が効く）
+- `cause` で元のエラーを保持（ログ用）
 
 ---
 
@@ -380,22 +425,23 @@ type AuthErrorCode =
 
 ### 6.1 インターフェース分離
 
-通常の認証操作と Admin 専用操作を分離する：
+通常の認証操作と Admin 専用操作を分離する。エラー時は AuthError を throw する（Result 型ではなく throw パターン）。
 
 ```typescript
 // domain/repositories/auth-provider.interface.ts
+// エラー時は AuthError を throw
 interface AuthProvider {
-  signInWithPassword(email: string, password: string): Promise<AuthProviderResult<AuthSession>>;
-  signOut(): Promise<AuthProviderResult<void>>;
-  getUser(): Promise<AuthProviderResult<SupabaseAuthUser | null>>;
-  updateUser(data: { password?: string }): Promise<AuthProviderResult<SupabaseAuthUser>>;
-  setSession(accessToken: string, refreshToken: string): Promise<AuthProviderResult<AuthSession>>;
-  exchangeCodeForSession(code: string): Promise<AuthProviderResult<AuthSession>>;
+  signInWithPassword(email: string, password: string): Promise<AuthSession>;
+  signOut(): Promise<void>;
+  getUser(): Promise<SupabaseAuthUser | null>;
+  updateUser(data: { password?: string }): Promise<SupabaseAuthUser>;
+  setSession(accessToken: string, refreshToken: string): Promise<AuthSession>;
+  exchangeCodeForSession(code: string): Promise<AuthSession>;
 }
 
 // domain/repositories/admin-auth-provider.interface.ts
 interface AdminAuthProvider {
-  inviteUserByEmail(email: string, redirectTo: string): Promise<AuthProviderResult<void>>;
+  inviteUserByEmail(email: string, redirectTo: string): Promise<void>;
 }
 ```
 
@@ -445,8 +491,8 @@ admin/src/server/contexts/auth/
 │   │   ├── auth-user.ts
 │   │   ├── auth-session.ts
 │   │   └── supabase-auth-user.ts
-│   ├── types/
-│   │   └── result.ts                    # AuthProviderResult, AuthErrorCode
+│   ├── errors/
+│   │   └── auth-error.ts                # AuthError, AuthErrorCode, AUTH_ERROR_MESSAGES
 │   ├── services/
 │   │   └── role-validator.ts
 │   └── repositories/


### PR DESCRIPTION
## Summary

- authコンテキストを4レイヤー構造（presentation / application / domain / infrastructure）にリファクタリングするための設計ドキュメントを追加
- 移行順序（domain → infrastructure → application → presentation）と各レイヤーの責務を明確化
- 後方互換性を維持しつつ段階的に移行するための手順を記載

## Test plan

- [ ] ドキュメントの内容がadmin-architecture-guide.mdのルールと整合していることを確認
- [ ] 移行手順の妥当性をレビュー

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 認証コンテキストの四層（プレゼンテーション、アプリケーション、ドメイン、インフラ）移行設計を追加。各レイヤーの責務、段階的移行手順（ドメイン→インフラ→アプリ→プレゼン）、増分ロールアウトと検証ポイントを明記。旧機能から新ユースケースへのマッピング、互換性やミドルウェア考慮、中央集約的なエラー処理方針（AuthError とユーザー向けメッセージ）、移行後の成果物一覧を詳細化。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->