### PR TITLE
fix: SelectItemに空文字列のvalueを使用しないよう修正

### DIFF
--- a/admin/src/client/components/donors/DonorMasterClient.tsx
+++ b/admin/src/client/components/donors/DonorMasterClient.tsx
@@ -17,6 +17,8 @@ import {
   SelectValue,
 } from "@/client/components/ui";
 
+const ALL_TYPES_VALUE = "all" as const;
+
 interface DonorMasterClientProps {
   initialDonors: DonorWithUsage[];
   total: number;
@@ -37,7 +39,9 @@ export function DonorMasterClient({
   const router = useRouter();
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [searchInput, setSearchInput] = useState(searchQuery ?? "");
-  const [selectedType, setSelectedType] = useState<DonorType | "">(donorType ?? "");
+  const [selectedType, setSelectedType] = useState<DonorType | typeof ALL_TYPES_VALUE>(
+    donorType ?? ALL_TYPES_VALUE,
+  );
 
   const totalPages = Math.ceil(total / perPage);
 
@@ -58,21 +62,23 @@ export function DonorMasterClient({
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
+    const typeParam = selectedType === ALL_TYPES_VALUE ? undefined : selectedType;
     router.push(
       buildUrl({
         q: searchInput.trim(),
-        type: selectedType || undefined,
+        type: typeParam,
         page: "1",
       }),
     );
   };
 
-  const handleTypeChange = (newType: DonorType | "") => {
+  const handleTypeChange = (newType: DonorType | typeof ALL_TYPES_VALUE) => {
     setSelectedType(newType);
+    const typeParam = newType === ALL_TYPES_VALUE ? undefined : newType;
     router.push(
       buildUrl({
         q: searchQuery,
-        type: newType || undefined,
+        type: typeParam,
         page: "1",
       }),
     );
@@ -90,7 +96,7 @@ export function DonorMasterClient({
 
   const handleClear = () => {
     setSearchInput("");
-    setSelectedType("");
+    setSelectedType(ALL_TYPES_VALUE);
     router.push("/donors");
   };
 
@@ -119,13 +125,13 @@ export function DonorMasterClient({
           />
           <Select
             value={selectedType}
-            onValueChange={(value) => handleTypeChange(value as DonorType | "")}
+            onValueChange={(value) => handleTypeChange(value as DonorType | typeof ALL_TYPES_VALUE)}
           >
             <SelectTrigger className="w-[160px]" aria-label="寄付者種別でフィルタ">
               <SelectValue placeholder="すべての種別" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="">すべての種別</SelectItem>
+              <SelectItem value={ALL_TYPES_VALUE}>すべての種別</SelectItem>
               {VALID_DONOR_TYPES.map((type) => (
                 <SelectItem key={type} value={type}>
                   {DONOR_TYPE_LABELS[type]}


### PR DESCRIPTION
## Summary
- 寄付者マスタページ（/donors）でRadix UI SelectのSelectItemに空文字列を渡していたことによるエラーを修正
- 「すべての種別」オプションのvalueを空文字列から`"all"`に変更
- 内部で`"all"`を`undefined`に変換してURLパラメータを構築

## Test plan
- [ ] http://localhost:3001/donors でエラーが発生しないことを確認
- [ ] 種別フィルタで「すべての種別」を選択した際に正常に動作すること
- [ ] 各種別（個人、団体）でフィルタが正常に動作すること
- [ ] クリアボタンでフィルタがリセットされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * ドナータイプフィルターの「すべてのタイプ」オプションの処理を改善しました。フィルター選択時のURL生成ロジックを最適化し、より正確なフィルタリング動作を実現しています。

* **Refactor**
  * フィルターリセット機能と型フィルター選択ロジックの内部構造を改善しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->