### PR TITLE
fix: 人件費のcategoryKeyを修正し組織活動費データを追加

### DIFF
--- a/prisma/seeds/transactions.ts
+++ b/prisma/seeds/transactions.ts
@@ -515,7 +515,7 @@ const data: TransactionSeedData[] = [
   },
   // SYUUSHI07_15: 政治活動費の支出（KUBUN1: 組織活動費）
   {
-    transactionNo: 'T2025-0060',
+    transactionNo: 'T2025-0061',
     transactionDate: '2025-03-15',
     transactionType: 'expense',
     debitAccount: '組織活動費',


### PR DESCRIPTION
## Summary

- 人件費のseedデータで`categoryKey`が`organizational-activities`になっていたのを`personnel-costs`に修正
- これにより人件費がシート15（その15）ではなく、シート13（総括表）にのみ出力されるようになる
- シート15用の組織活動費テストデータを追加

### Updates since last revision
- `transactionNo`を`T2025-0060`から`T2025-0061`に変更（702行目の既存エントリとの重複を解消）

## Review & Testing Checklist for Human

- [ ] `transactionNo: 'T2025-0061'`が他のエントリと重複していないことを確認
- [ ] `pnpm -F admin db:seed`でseedデータを再投入し、エラーなく完了することを確認
- [ ] XMLエクスポートでシート15に人件費が出力されないことを確認
- [ ] シート13（総括表）に人件費の合計が出力されることを確認

### Notes

- Link to Devin run: https://app.devin.ai/sessions/eebf1dc1a2c947fd92dc8501523e8ab6
- Requested by: jun.ito@team-mir.ai (@jujunjun110)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **保守**
  * 取引サンプルデータを更新しました。既存サンプルの勘定科目分類を修正し、2025年分の新しいサンプル取引を追加しました。システムの公開インターフェースや動作には変更ありません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->