### PR TITLE
chore: GitHub Actions の commit SHA pinning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
           
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
           cache: 'pnpm'
@@ -49,7 +49,7 @@ jobs:
         run: pnpm --filter webapp run type-check
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./admin/coverage/lcov.info,./webapp/coverage/lcov.info


### PR DESCRIPTION
# chore: GitHub Actions の commit SHA pinning

## Summary

GitHub Actions のサプライチェーンセキュリティ強化のため、すべての Actions を tag 参照から commit SHA 参照に変更しました。

変更内容:
- `actions/checkout@v4` → `@34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.1)
- `pnpm/action-setup@v4` → `@41ff72655975bd51cab0327fa583b6e92b6d3061` (v4.2.0)
- `actions/setup-node@v4` → `@49933ea5288caeca8642d1e84afbd3f7d6820020` (v4.4.0)
- `codecov/codecov-action@v5` → `@671740ac38dd9b0130fbe1cec585b89eea48d3de` (v5.5.2)

各行にはコメントで元のバージョン番号を記載し、可読性を維持しています。

Closes #905

## Review & Testing Checklist for Human

- [ ] 各 SHA が正しいバージョンを指しているか確認（GitHub API で `gh api repos/{owner}/{repo}/git/ref/tags/{tag}` を使用して検証可能）
- [ ] CI が正常に動作することを確認（このPRのCI結果で検証）

### Notes

- SHA は GitHub API を使用して取得しました
- `pnpm/action-setup@v4` は annotated tag のため、tag object から commit SHA を解決しています
- Link to Devin run: https://app.devin.ai/sessions/636397050b89457c8aff331dbaf6843e
- Requested by: jun.ito@team-mir.ai (@jujunjun110)