### PR TITLE
docs: 認証関連ファイル配置の整理設計書を追加

### DIFF
--- a/docs/20251231_0008_認証関連ファイル配置の整理設計.md
+++ b/docs/20251231_0008_認証関連ファイル配置の整理設計.md
@@ -1,0 +1,145 @@
+# 認証関連ファイル配置の整理設計
+
+## 背景
+
+以下のファイルが `app/(public)` 配下に配置されているが、アーキテクチャ上の配置として適切かどうかを検討する。
+
+- `admin/src/app/(public)/login/actions.ts`
+- `admin/src/app/(public)/auth/callback/route.ts`
+
+## 現状の分析
+
+### 現在のファイル構成
+
+```
+admin/src/
+├── app/(public)/
+│   ├── login/
+│   │   ├── page.tsx                  # ログインページ
+│   │   ├── actions.ts                # ← 問題のファイル (1)
+│   │   └── InviteTokenHandler.tsx    # 招待トークン処理コンポーネント
+│   └── auth/
+│       ├── callback/
+│       │   └── route.ts              # ← 問題のファイル (2)
+│       └── setup/
+│           └── page.tsx              # パスワード設定ページ
+└── server/contexts/auth/presentation/actions/
+    ├── complete-invite-session.ts    # 招待セッション完了アクション（実処理）
+    ├── exchange-code-for-session.ts  # OAuth コールバック処理（実処理）
+    ├── login.ts                      # ログインアクション
+    ├── logout.ts                     # ログアウトアクション
+    └── setup-password.ts             # パスワード設定アクション
+```
+
+### 各ファイルの役割
+
+#### `app/(public)/login/actions.ts`
+
+```typescript
+"use server";
+import { completeInviteSession as completeInviteSessionAction } from "@/server/contexts/auth/presentation/actions/complete-invite-session";
+
+export async function completeInviteSession(
+  accessToken: string,
+  refreshToken: string,
+): Promise<{ ok: boolean; error?: string }> {
+  return completeInviteSessionAction(accessToken, refreshToken);
+}
+```
+
+**現状**: `presentation/actions/complete-invite-session.ts` の薄いラッパー。`InviteTokenHandler.tsx` から呼び出される。
+
+#### `app/(public)/auth/callback/route.ts`
+
+```typescript
+import "server-only";
+import { exchangeCodeForSession } from "@/server/contexts/auth/presentation/actions/exchange-code-for-session";
+
+export async function GET(request: Request) {
+  const code = searchParams.get("code");
+  const result = await exchangeCodeForSession(code);
+  // リダイレクト処理
+}
+```
+
+**現状**: OAuth コールバックを受け取り、`presentation/actions/exchange-code-for-session.ts` を呼び出してリダイレクトする Route Handler。
+
+## 問題点
+
+### 1. `login/actions.ts` の冗長性
+
+- 単なる re-export ラッパーであり、存在意義が薄い
+- `InviteTokenHandler.tsx` から直接 `presentation/actions/complete-invite-session.ts` を呼び出せばよい
+
+### 2. `auth/callback/route.ts` の配置
+
+Route Handler はページルーティングに必須であり、`app/` 配下に配置すること自体は正しい。ただし、処理ロジックは `presentation/actions/` に移譲済みであり、Route Handler としての役割（リクエスト受付・リダイレクト）のみを担っている。
+
+## 設計方針
+
+### 方針1: `login/actions.ts` を削除
+
+`login/actions.ts` は単なるラッパーであり、削除して直接 import に置き換える。
+
+**変更内容**:
+
+1. `login/actions.ts` を削除
+2. `InviteTokenHandler.tsx` の import を変更
+
+```diff
+- import { completeInviteSession } from "@/app/(public)/login/actions";
++ import { completeInviteSession } from "@/server/contexts/auth/presentation/actions/complete-invite-session";
+```
+
+### 方針2: `auth/callback/route.ts` を `app/api/` 配下へ移動
+
+現在のプロジェクトでは Route Handler は `app/api/` 配下に配置する慣習がある。
+
+```
+admin/src/app/api/
+├── export-report/route.ts
+├── transactions/route.ts
+└── balance-snapshots/route.ts
+```
+
+`auth/callback/route.ts` も同様に `app/api/auth/callback/route.ts` へ移動する。
+
+**変更内容**:
+
+1. `app/(public)/auth/callback/route.ts` を `app/api/auth/callback/route.ts` へ移動
+2. `app/(public)/auth/callback/` ディレクトリを削除
+
+**注意**: Supabase の OAuth コールバック URL の設定も変更が必要（`/auth/callback` → `/api/auth/callback`）
+
+## 変更ファイル一覧
+
+| ファイル | 変更内容 |
+|---|---|
+| `admin/src/app/(public)/login/actions.ts` | 削除 |
+| `admin/src/app/(public)/login/InviteTokenHandler.tsx` | import パスを変更 |
+| `admin/src/app/(public)/auth/callback/route.ts` | `app/api/auth/callback/route.ts` へ移動 |
+
+## 環境設定の変更
+
+Supabase Dashboard で OAuth の Redirect URL を更新する必要がある:
+
+- 変更前: `https://{domain}/auth/callback`
+- 変更後: `https://{domain}/api/auth/callback`
+
+## 設計判断の根拠
+
+### admin-architecture-guide.md との整合性
+
+- **loaders/actions の配置**: ガイドでは `server/contexts/{コンテキスト}/presentation/actions/` に Server Actions を配置すると定めている。`complete-invite-session.ts` は既にこの配置に従っている。
+- **app/ 配下の役割**: `app/` 配下はルーティングのみを担い、ビジネスロジックは `server/` 配下に配置する方針に合致。
+
+### 依存ルールとの整合性
+
+クライアント層（UI）からの依存ルール（ガイド 3.2.1）により、`Client → Presentation` の依存は許可されている。
+
+```
+✓ 許可される依存:
+  - Client → Presentation（actions/schemas/typesの呼び出し・型参照）
+```
+
+`InviteTokenHandler.tsx` から `presentation/actions/complete-invite-session.ts` を直接呼び出すことはこのルールに準拠している。


### PR DESCRIPTION
## Summary

- `app/(public)/login/actions.ts` と `auth/callback/route.ts` の配置問題を分析
- `login/actions.ts` は冗長なラッパーのため削除する方針
- `auth/callback/route.ts` は `app/api/auth/callback/` へ移動する方針

## 設計内容

詳細は [docs/20251231_0008_認証関連ファイル配置の整理設計.md](docs/20251231_0008_認証関連ファイル配置の整理設計.md) を参照。

## Test plan

- [ ] 設計内容をレビュー

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * 認証関連ファイルの構成を整理し、APIルートの配置を統一しました。Supabase OAuthのリダイレクト先URLを更新する必要があります。

* **Refactor**
  * 認証処理の実装をより効率的に再構成し、サーバー処理の集約化を進めました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->