### PR TITLE
docs: 取引先紐付けページのページング不具合修正の設計書を追加

### DIFF
--- a/docs/20251231_0019_取引先紐付けページのページング不具合修正.md
+++ b/docs/20251231_0019_取引先紐付けページのページング不具合修正.md
@@ -1,0 +1,167 @@
+# 取引先紐付けページのページング不具合修正
+
+## 概要
+
+`/assign/counterparts` ページでページングの2ページ目に遷移すると0件になる問題の調査結果と改善案。
+
+## 問題の概要
+
+- **現象**: 取引先紐付け管理ページで、ページングの2ページ目に遷移すると取引が0件になる
+- **期待動作**: 2ページ目以降も正常にトランザクションが表示される
+
+## 原因分析
+
+### 問題のあるコードフロー
+
+1. **クライアント側のカテゴリ状態管理**
+
+   `CounterpartAssignmentClient.tsx` の69-70行目:
+   ```typescript
+   const [categoryKey, setCategoryKey] = useState(
+     initialFilters.categoryKey || ALL_CATEGORIES_VALUE,  // "__all__"
+   );
+   ```
+
+   サーバーから `categoryKey: ""` が渡された場合、クライアント側では `"__all__"` として扱う。
+
+2. **buildUrl関数のカテゴリ処理**
+
+   `CounterpartAssignmentClient.tsx` の136-138行目:
+   ```typescript
+   if (params.category ?? categoryKey) {
+     searchParams.set("category", params.category ?? categoryKey);
+   }
+   ```
+
+   `params.category` が未指定の場合、現在の `categoryKey` (= `"__all__"`) がそのままURLに設定される。
+
+3. **ページ変更時の処理**
+
+   `CounterpartAssignmentClient.tsx` の209-213行目:
+   ```typescript
+   const handlePageChange = (newPage: number) => {
+     startTransition(() => {
+       router.push(buildUrl({ page: newPage }));
+     });
+   };
+   ```
+
+   ページ変更時は `category` パラメータを明示的に渡しておらず、`buildUrl` 内で現在の `categoryKey` がそのまま使用される。
+
+4. **フィルタ変更時との不整合**
+
+   `CounterpartAssignmentClient.tsx` の162-177行目:
+   ```typescript
+   const handleFilterChange = (changes: Partial<CounterpartAssignmentFilterValues>) => {
+     // ...
+     const categoryForUrl =
+       (changes.categoryKey ?? categoryKey) === ALL_CATEGORIES_VALUE
+         ? ""  // フィルタ変更時は "__all__" を空文字に変換している
+         : (changes.categoryKey ?? categoryKey);
+
+     startTransition(() => {
+       router.push(
+         buildUrl({
+           category: categoryForUrl,  // 変換後の値を明示的に渡す
+           // ...
+         }),
+       );
+     });
+   };
+   ```
+
+5. **サーバー側での処理**
+
+   `page.tsx` の82行目:
+   ```typescript
+   const categoryKey = params.category || "";
+   ```
+
+   URLパラメータの `category=__all__` はそのまま `"__all__"` として受け取られる。
+
+6. **リポジトリでのフィルタリング**
+
+   `prisma-report-transaction.repository.ts` の729-731行目:
+   ```typescript
+   if (categoryKey) {
+     conditions.push({ categoryKey });
+   }
+   ```
+
+   `"__all__"` というカテゴリキーで検索が行われるが、実際のトランザクションにはそのようなカテゴリは存在しないため、0件になる。
+
+### 根本原因
+
+`"__all__"` はUIでの「すべてのカテゴリ」を表す擬似的な値だが、この値がページ遷移時にサーバーに渡されてしまい、実際のデータベースクエリで不正なフィルタ条件として使用されてしまう。
+
+`handleFilterChange` では正しく空文字に変換しているが、`handlePageChange` や `handleSortChange` 、`handleOrganizationChange` 、`handleYearChange` ではこの変換が行われていない。
+
+## 改善案
+
+### 方針
+
+`buildUrl` 関数内で一貫して `"__all__"` を空文字に変換する。これにより、どのアクション（フィルタ変更、ページ変更、ソート変更など）からURLを構築しても、正しいパラメータが生成される。
+
+### 修正箇所
+
+**ファイル**: `admin/src/client/components/counterpart-assignment/CounterpartAssignmentClient.tsx`
+
+**修正内容**: `buildUrl` 関数内でカテゴリの変換処理を行う
+
+現在のコード（136-138行目）:
+```typescript
+if (params.category ?? categoryKey) {
+  searchParams.set("category", params.category ?? categoryKey);
+}
+```
+
+修正後:
+```typescript
+const categoryForUrl = params.category ?? categoryKey;
+const normalizedCategory = categoryForUrl === ALL_CATEGORIES_VALUE ? "" : categoryForUrl;
+if (normalizedCategory) {
+  searchParams.set("category", normalizedCategory);
+}
+```
+
+### 追加の確認事項
+
+修正後は `handleFilterChange` 内のカテゴリ変換処理（162-165行目）が冗長になるため、削除を検討する:
+
+```typescript
+// この変換処理は buildUrl 内で行うため不要になる
+const categoryForUrl =
+  (changes.categoryKey ?? categoryKey) === ALL_CATEGORIES_VALUE
+    ? ""
+    : (changes.categoryKey ?? categoryKey);
+```
+
+簡潔に:
+```typescript
+startTransition(() => {
+  router.push(
+    buildUrl({
+      category: changes.categoryKey ?? categoryKey,
+      // ...
+    }),
+  );
+});
+```
+
+## 影響範囲
+
+- `handlePageChange`: ページ変更時のURL生成
+- `handleSortChange`: ソート変更時のURL生成
+- `handleOrganizationChange`: 組織変更時のURL生成
+- `handleYearChange`: 年度変更時のURL生成
+- `handleFilterChange`: フィルタ変更時のURL生成（冗長な変換処理の削除）
+
+すべて `buildUrl` 関数を経由するため、`buildUrl` の修正で一括対応できる。
+
+## テスト観点
+
+1. 「すべてのカテゴリ」選択時にページ遷移しても正常に表示される
+2. 特定のカテゴリ選択時にページ遷移しても正常に表示される
+3. ソート変更時にカテゴリフィルタが維持される
+4. 組織・年度変更時にカテゴリフィルタが維持される
+5. URLパラメータに `category=__all__` が含まれないこと


### PR DESCRIPTION
## Summary

- `/assign/counterparts` ページでページングの2ページ目に遷移すると0件になる問題を調査
- 原因: クライアント側の擬似値 `"__all__"` がサーバーに渡され、不正なフィルタ条件として使用されていた
- 改善案: `buildUrl` 関数内で `"__all__"` を空文字に変換する処理を追加

## Test plan

- [ ] 設計書の内容をレビュー
- [ ] 改善案の妥当性を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * 取引先紐付けページのページング不具合に関する修正内容と改善方針をドキュメント化しました。複数ページ選択時のフィルタリング機能の改善について詳細を記載しています。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->