### PR TITLE
fix: 取引先紐付けページのページング不具合を修正

### DIFF
--- a/admin/src/client/components/counterpart-assignment/CounterpartAssignmentClient.tsx
+++ b/admin/src/client/components/counterpart-assignment/CounterpartAssignmentClient.tsx
@@ -133,8 +133,10 @@ export function CounterpartAssignmentClient({
       "counterpartRequired",
       String(params.counterpartRequired ?? counterpartRequiredOnly),
     );
-    if (params.category ?? categoryKey) {
-      searchParams.set("category", params.category ?? categoryKey);
+    const categoryForUrl = params.category ?? categoryKey;
+    const normalizedCategory = categoryForUrl === ALL_CATEGORIES_VALUE ? "" : categoryForUrl;
+    if (normalizedCategory) {
+      searchParams.set("category", normalizedCategory);
     }
     if (params.search ?? searchQuery) {
       searchParams.set("search", params.search ?? searchQuery);
@@ -159,15 +161,10 @@ export function CounterpartAssignmentClient({
       setCounterpartRequiredOnly(changes.counterpartRequiredOnly);
     }
 
-    const categoryForUrl =
-      (changes.categoryKey ?? categoryKey) === ALL_CATEGORIES_VALUE
-        ? ""
-        : (changes.categoryKey ?? categoryKey);
-
     startTransition(() => {
       router.push(
         buildUrl({
-          category: categoryForUrl,
+          category: changes.categoryKey ?? categoryKey,
           search: changes.searchQuery ?? searchQuery,
           unassigned: changes.unassignedOnly ?? unassignedOnly,
           counterpartRequired: changes.counterpartRequiredOnly ?? counterpartRequiredOnly,


### PR DESCRIPTION
# fix: 取引先紐付けページのページング不具合を修正

## Summary

`/assign/counterparts` ページでページングの2ページ目以降に遷移すると0件になる問題を修正しました。

**原因**: UIで「すべてのカテゴリ」を表す `"__all__"` という値が、ページ遷移時にそのままURLパラメータとしてサーバーに渡され、存在しないカテゴリでフィルタリングされていました。

**修正内容**: `buildUrl` 関数内で `"__all__"` を空文字に変換する処理を追加し、すべてのURL生成で一貫した動作を保証するようにしました。これにより `handleFilterChange` 内の冗長な変換処理も削除できました。

設計ドキュメント: `docs/20251231_0019_取引先紐付けページのページング不具合修正.md`

## Review & Testing Checklist for Human

- [ ] 「すべてのカテゴリ」選択時にページ遷移（2ページ目以降）しても正常にトランザクションが表示されることを確認
- [ ] 特定のカテゴリ選択時にページ遷移しても正常に表示されることを確認
- [ ] ソート変更・組織変更・年度変更時にカテゴリフィルタが維持されることを確認
- [ ] URLパラメータに `category=__all__` が含まれないことを確認

**推奨テスト手順**:
1. `/assign/counterparts` にアクセス
2. カテゴリを「すべてのカテゴリ」のままにして2ページ目に遷移 → トランザクションが表示されることを確認
3. URLに `category=__all__` が含まれていないことを確認

### Notes

- Link to Devin run: https://app.devin.ai/sessions/6f6a7aac8d83422fb065296678b30922
- Requested by: jun.ito@team-mir.ai (@jujunjun110)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * カテゴリーフィルター機能の内部処理を改善しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->