### PR TITLE
fix: アカウント設定ページのスタイル修正と日本語化

### DIFF
--- a/admin/src/app/(public)/auth/setup/page.tsx
+++ b/admin/src/app/(public)/auth/setup/page.tsx
@@ -25,15 +25,14 @@ export default async function SetupPage({ searchParams }: SetupPageProps) {
   if (fromInvite) {
     // This is an invited user who needs to set up their password
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+      <div className="min-h-screen flex items-center justify-center bg-background py-12 px-4 sm:px-6 lg:px-8">
         <div className="max-w-md w-full space-y-8">
           <div>
-            <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
-              Complete your account setup
+            <h2 className="mt-6 text-center text-3xl font-extrabold text-foreground">
+              アカウント設定
             </h2>
-            <p className="mt-2 text-center text-sm text-gray-600">
-              You&apos;ve been invited to join Poli Money Alpha. Please set up your password to
-              continue.
+            <p className="mt-2 text-center text-sm text-muted-foreground">
+              「みらいまる見え政治資金」に招待されました。パスワードを設定して利用を開始してください。
             </p>
           </div>
           <SetupForm userEmail={user.email} setupPasswordAction={setupPassword} />


### PR DESCRIPTION
## Summary
- アカウント設定ページ（`/auth/setup?from=invite`）の背景色を他のページと統一
- テキストカラーをテーマ変数（`text-foreground` / `text-muted-foreground`）に変更
- メッセージを日本語化し、サービス名を「みらいまる見え政治資金」に更新

## Test plan
- [ ] `/auth/setup?from=invite` ページにアクセスし、背景色が他のページと統一されていることを確認
- [ ] テキストが読みやすいカラーで表示されることを確認
- [ ] 日本語メッセージが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **スタイル**
  * アカウント設定画面のテーマカラーを更新しました。背景色とテキスト色が統一されたデザイントークンに変更されました。

* **ローカライゼーション**
  * 招待ユーザーのアカウント設定画面を日本語に対応しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->