### PR TITLE
chore: 未使用コード警告を解消

### DIFF
--- a/admin/src/server/contexts/data-import/presentation/types/index.ts
+++ b/admin/src/server/contexts/data-import/presentation/types/index.ts
@@ -5,13 +5,7 @@
  */
 
 // CSVプレビュー関連
-export type {
-  PreviewMfCsvInput,
-  PreviewMfCsvResult,
-} from "@/server/contexts/data-import/application/usecases/preview-mf-csv-usecase";
+export type { PreviewMfCsvResult } from "@/server/contexts/data-import/application/usecases/preview-mf-csv-usecase";
 
 // トランザクション取得関連
-export type {
-  GetTransactionsParams,
-  GetTransactionsResult,
-} from "@/server/contexts/data-import/application/usecases/get-transactions-usecase";
+export type { GetTransactionsResult } from "@/server/contexts/data-import/application/usecases/get-transactions-usecase";

--- a/biome.json
+++ b/biome.json
@@ -54,5 +54,17 @@
         }
       }
     }
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["admin/src/client/components/ui/**/*", "webapp/src/client/components/ui/**/*"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "noUnusedVariables": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/knip.json
+++ b/knip.json
@@ -18,7 +18,8 @@
         "src/app/**/route.ts",
         "src/app/**/not-found.tsx"
       ],
-      "project": ["src/**/*.{ts,tsx}"]
+      "project": ["src/**/*.{ts,tsx}"],
+      "ignore": ["src/client/components/ui/**/*"]
     },
     "admin": {
       "entry": [
@@ -26,7 +27,8 @@
         "src/app/**/layout.tsx",
         "src/app/**/route.ts"
       ],
-      "project": ["src/**/*.{ts,tsx}"]
+      "project": ["src/**/*.{ts,tsx}"],
+      "ignore": ["src/client/components/ui/**/*"]
     }
   }
 }


### PR DESCRIPTION
## 概要

lint (biome) と knip で未使用コード警告が出ていた問題を解消。

## 変更内容

### biome.json
- `admin/src/client/components/ui/**/*` と `webapp/src/client/components/ui/**/*` に対して `noUnusedVariables` を無効化
- shadcn/ui コンポーネントは将来使う可能性のある未使用コンポーネント（`CardFooter`、`DialogClose` など）を含むため、他の lint ルールは適用しつつ未使用変数チェックのみ除外

### knip.json
- 同ディレクトリを knip の検査対象から除外

### admin/src/server/contexts/data-import/presentation/types/index.ts
- 未使用の型 `PreviewMfCsvInput`、`GetTransactionsParams` を削除（アプリ固有のコードなので削除が適切）

## テスト

- `pnpm run lint` ✅
- `pnpm knip` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他の変更**
  * データインポート機能の内部API表面を調整しました。一部の内部型の公開エクスポートが削除されているため、既存コード実装への影響の確認をお願いします。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->