### PR TITLE
docs: パスワードリセット機能の設計ドキュメントを追加

### DIFF
--- a/docs/20251231_0959_パスワードリセット機能設計.md
+++ b/docs/20251231_0959_パスワードリセット機能設計.md
@@ -1,0 +1,450 @@
+# パスワードリセット機能設計
+
+## 概要
+
+admin アプリケーションに「パスワードを忘れた場合」のフローを追加する。
+
+## 現状
+
+- ログイン: `/login` でメール/パスワード認証
+- 招待フロー: 管理者が招待 → メールリンク → `/auth/setup?from=invite` でパスワード設定
+- パスワードリセット: **未実装**
+
+## フロー設計
+
+```
+[ログイン画面]
+    │
+    ├─ 「パスワードを忘れた場合」リンクをクリック
+    ▼
+[パスワードリセット申請画面] /forgot-password
+    │
+    ├─ メールアドレスを入力して送信
+    │  └─ Supabase Auth の resetPasswordForEmail() を呼び出し
+    ▼
+[送信完了画面] /forgot-password?sent=true
+    │
+    ├─ 「メールを送信しました」メッセージ表示
+    │
+    ▼
+[ユーザーがメールのリンクをクリック]
+    │
+    ├─ Supabase が発行したリンク（type=recovery）
+    │  └─ リダイレクト先: /login#type=recovery&access_token=...&refresh_token=...
+    ▼
+[ログイン画面でトークン処理]
+    │
+    ├─ RecoveryTokenHandler がハッシュを検出
+    │  └─ トークンでセッションを確立
+    ▼
+[パスワード再設定画面] /auth/reset-password
+    │
+    ├─ 新しいパスワードを入力
+    │  └─ updateUser({ password }) を呼び出し
+    ▼
+[リセット完了 → ホーム画面へリダイレクト]
+```
+
+## 画面設計
+
+### 1. ログイン画面の変更
+
+パスワード入力欄の下に「パスワードを忘れた場合」リンクを追加。
+
+```
+┌─────────────────────────────────────┐
+│           ログイン                  │
+├─────────────────────────────────────┤
+│ Email                               │
+│ ┌─────────────────────────────────┐ │
+│ │                                 │ │
+│ └─────────────────────────────────┘ │
+│                                     │
+│ Password                            │
+│ ┌─────────────────────────────────┐ │
+│ │                                 │ │
+│ └─────────────────────────────────┘ │
+│                                     │
+│ パスワードを忘れた場合 ← 追加       │
+│                                     │
+│ ┌─────────────────────────────────┐ │
+│ │         ログイン                │ │
+│ └─────────────────────────────────┘ │
+└─────────────────────────────────────┘
+```
+
+### 2. パスワードリセット申請画面 `/forgot-password`
+
+```
+┌─────────────────────────────────────┐
+│     パスワードをリセット            │
+│                                     │
+│  登録されているメールアドレスに     │
+│  リセット用のリンクを送信します。   │
+├─────────────────────────────────────┤
+│ Email                               │
+│ ┌─────────────────────────────────┐ │
+│ │                                 │ │
+│ └─────────────────────────────────┘ │
+│                                     │
+│ ┌─────────────────────────────────┐ │
+│ │       リセットメールを送信      │ │
+│ └─────────────────────────────────┘ │
+│                                     │
+│ ログイン画面に戻る                  │
+└─────────────────────────────────────┘
+```
+
+### 3. 送信完了画面 `/forgot-password?sent=true`
+
+```
+┌─────────────────────────────────────┐
+│     メールを送信しました            │
+│                                     │
+│  パスワードリセット用のリンクを     │
+│  メールで送信しました。             │
+│                                     │
+│  メールが届かない場合は、迷惑       │
+│  メールフォルダをご確認ください。   │
+│                                     │
+│ ┌─────────────────────────────────┐ │
+│ │      ログイン画面に戻る         │ │
+│ └─────────────────────────────────┘ │
+└─────────────────────────────────────┘
+```
+
+### 4. パスワード再設定画面 `/auth/reset-password`
+
+```
+┌─────────────────────────────────────┐
+│     新しいパスワードを設定          │
+│                                     │
+│  account@example.com                │
+├─────────────────────────────────────┤
+│ パスワード                          │
+│ ┌─────────────────────────────────┐ │
+│ │                                 │ │
+│ └─────────────────────────────────┘ │
+│                                     │
+│ パスワード（確認）                  │
+│ ┌─────────────────────────────────┐ │
+│ │                                 │ │
+│ └─────────────────────────────────┘ │
+│                                     │
+│ ┌─────────────────────────────────┐ │
+│ │        パスワードを変更         │ │
+│ └─────────────────────────────────┘ │
+└─────────────────────────────────────┘
+```
+
+## 実装詳細
+
+### ディレクトリ構成（追加・変更箇所）
+
+```
+admin/src/
+├── app/(public)/
+│   ├── login/
+│   │   ├── page.tsx                    # 変更: リンク追加
+│   │   ├── LoginForm.tsx → 移動先は client/components/auth/
+│   │   ├── InviteTokenHandler.tsx      # 既存
+│   │   └── RecoveryTokenHandler.tsx    # 新規: recovery トークン処理
+│   ├── forgot-password/
+│   │   └── page.tsx                    # 新規: リセット申請画面
+│   └── auth/
+│       ├── setup/
+│       │   └── page.tsx                # 既存
+│       └── reset-password/
+│           └── page.tsx                # 新規: パスワード再設定画面
+├── client/components/auth/
+│   ├── LoginForm.tsx                   # 変更: forgotPasswordHref props 追加
+│   ├── SetupForm.tsx                   # 既存（再設定画面でも再利用可能）
+│   ├── ForgotPasswordForm.tsx          # 新規
+│   └── RecoveryTokenHandler.tsx        # 新規
+└── server/contexts/auth/
+    ├── presentation/
+    │   └── actions/
+    │       ├── request-password-reset.ts    # 新規
+    │       └── reset-password.ts            # 新規
+    ├── application/
+    │   └── usecases/
+    │       ├── request-password-reset-usecase.ts  # 新規
+    │       └── reset-password-usecase.ts          # 新規
+    ├── domain/
+    │   ├── providers/
+    │   │   └── auth-provider.interface.ts  # 変更: resetPasswordForEmail 追加
+    │   └── errors/
+    │       └── auth-error.ts               # 変更: RESET_EMAIL_FAILED 追加
+    └── infrastructure/
+        └── supabase/
+            └── supabase-auth-provider.ts   # 変更: resetPasswordForEmail 実装
+```
+
+### Domain 層
+
+#### AuthProvider インターフェース拡張
+
+```typescript
+// auth-provider.interface.ts に追加
+interface AuthProvider {
+  // ... 既存メソッド
+
+  /**
+   * パスワードリセットメールを送信
+   * @throws {AuthError} RESET_EMAIL_FAILED - 送信失敗
+   * @throws {AuthError} NETWORK_ERROR - ネットワークエラー
+   */
+  resetPasswordForEmail(email: string, redirectTo: string): Promise<void>;
+}
+```
+
+#### エラーコード追加
+
+```typescript
+// auth-error.ts に追加
+export type AuthErrorCode =
+  | // ... 既存
+  | "RESET_EMAIL_FAILED"; // パスワードリセットメール送信失敗
+
+export const AUTH_ERROR_MESSAGES: Record<AuthErrorCode, string> = {
+  // ... 既存
+  RESET_EMAIL_FAILED: "パスワードリセットメールの送信に失敗しました",
+};
+```
+
+### Infrastructure 層
+
+#### SupabaseAuthProvider 拡張
+
+`resetPasswordForEmail` メソッドを追加。Supabase Auth の `resetPasswordForEmail()` を呼び出す。
+
+### Application 層
+
+#### RequestPasswordResetUsecase
+
+- 入力: email
+- 処理: `authProvider.resetPasswordForEmail(email, redirectTo)` を呼び出し
+- redirectTo: `${process.env.NEXT_PUBLIC_APP_URL}/login` (ハッシュでトークンが付与される)
+
+#### ResetPasswordUsecase
+
+- 入力: password
+- 処理: `authProvider.updateUser({ password })` を呼び出し
+- 既存の `SetupPasswordUsecase` と同様の処理
+
+### Presentation 層
+
+#### requestPasswordReset アクション
+
+- FormData から email を取得
+- `RequestPasswordResetUsecase` を実行
+- 成功時: `/forgot-password?sent=true` にリダイレクト
+- 失敗時: エラーメッセージ付きでリダイレクト
+
+#### resetPassword アクション
+
+- password を受け取り
+- `ResetPasswordUsecase` を実行
+- 成功時: `{ ok: true }` を返却
+- 失敗時: `{ ok: false, error: "..." }` を返却
+
+### Client 層
+
+#### RecoveryTokenHandler
+
+`InviteTokenHandler` と同様の構造で、`type=recovery` のトークンを処理。
+
+1. URL ハッシュから `type`, `access_token`, `refresh_token` を取得
+2. `type === "recovery"` の場合、セッションを確立
+3. `/auth/reset-password` にリダイレクト
+
+#### ForgotPasswordForm
+
+メールアドレス入力フォーム。`requestPasswordReset` アクションを呼び出す。
+
+#### LoginForm 変更
+
+`forgotPasswordHref` props を追加し、リンクを表示。
+
+### ページコンポーネント
+
+#### /forgot-password
+
+- `sent` クエリパラメータの有無で表示を切り替え
+- 送信前: `ForgotPasswordForm` を表示
+- 送信後: 完了メッセージを表示
+
+#### /auth/reset-password
+
+- `getCurrentUser()` でユーザー取得（セッション確立済み前提）
+- 未認証なら `/login` にリダイレクト
+- 認証済みなら `SetupForm` を表示（props を調整して再利用）
+
+## セキュリティ考慮事項
+
+### メールアドレスの存在確認を漏らさない
+
+リセット申請時、メールアドレスが登録されていなくても同じ「送信しました」メッセージを表示する。これにより、攻撃者がメールアドレスの存在を確認できないようにする。
+
+Supabase Auth はデフォルトでこの挙動をサポートしている。
+
+### トークンの有効期限
+
+Supabase Auth のデフォルト設定に従う（通常1時間）。Supabase ダッシュボードで変更可能。
+
+### レート制限
+
+Supabase Auth が自動的にレート制限を適用する。追加の実装は不要。
+
+## Supabase 設定
+
+### メールテンプレート
+
+Supabase ダッシュボード → Authentication → Email Templates → Reset Password でカスタマイズ可能。
+
+デフォルトテンプレートでも動作するが、日本語化する場合は以下を設定:
+
+```
+件名: パスワードリセットのご案内
+
+本文:
+パスワードリセットのリクエストを受け付けました。
+
+以下のリンクをクリックして、新しいパスワードを設定してください。
+
+{{ .ConfirmationURL }}
+
+このリクエストに心当たりがない場合は、このメールを無視してください。
+```
+
+### リダイレクト URL の設定
+
+Supabase ダッシュボード → Authentication → URL Configuration → Redirect URLs に以下を追加:
+
+- 本番: `https://admin.example.com/login`
+- 開発: `http://localhost:3001/login`
+
+## 既存コードとの整合性
+
+### SetupForm の再利用
+
+`/auth/reset-password` では既存の `SetupForm` コンポーネントを再利用する。
+
+変更点:
+- タイトルを props で受け取れるように変更（「アカウント設定」→「パスワードを変更」）
+- アクション関数の型は同じなので互換性あり
+
+### InviteTokenHandler との共存
+
+ログイン画面で `InviteTokenHandler` と `RecoveryTokenHandler` を両方配置。それぞれ異なる `type` パラメータで判別するため、競合しない。
+
+## 付録: パスワードバリデーションのドメイン化
+
+### 背景
+
+現在、パスワードバリデーションロジックが以下の2箇所に重複している:
+
+1. `SetupForm.tsx`（クライアント）: `password.length < 6`
+2. `SetupPasswordUsecase`（サーバー）: `password.length < 6`
+
+今後パスワードルールを厳しくする予定があり、変更時に両方を修正する必要があるため、ドメインモデルとして一元化する。
+
+### 追加ファイル
+
+```
+admin/src/server/contexts/auth/domain/models/password.ts  # 新規
+```
+
+### Password ドメインモデル設計
+
+`interface + const` パターン（自動マージ）を採用する。
+
+```typescript
+// admin/src/server/contexts/auth/domain/models/password.ts
+
+/**
+ * パスワードバリデーション結果
+ */
+export interface PasswordValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+/**
+ * パスワードのドメインモデル（型定義）
+ */
+export interface Password {
+  value: string;
+}
+
+/** パスワードの最小文字数 */
+const MIN_LENGTH = 6;
+
+/**
+ * Password のドメインロジック
+ */
+export const Password = {
+  MIN_LENGTH,
+
+  /**
+   * パスワードが要件を満たしているか検証
+   * @param password 検証するパスワード
+   * @returns バリデーション結果
+   */
+  validate(password: string): PasswordValidationResult {
+    if (!password || password.length < MIN_LENGTH) {
+      return {
+        valid: false,
+        error: `パスワードは${MIN_LENGTH}文字以上で設定してください`,
+      };
+    }
+
+    return { valid: true };
+  },
+};
+```
+
+### 変更箇所
+
+#### 1. SetupPasswordUsecase（サーバー）
+
+```typescript
+// 変更前
+if (!password || password.length < 6) {
+  throw new AuthError("WEAK_PASSWORD", "Password must be at least 6 characters");
+}
+
+// 変更後
+import { Password } from "@/server/contexts/auth/domain/models/password";
+
+const validation = Password.validate(password);
+if (!validation.valid) {
+  throw new AuthError("WEAK_PASSWORD", validation.error ?? "Invalid password");
+}
+```
+
+#### 2. SetupForm.tsx（クライアント）
+
+```typescript
+// 変更前
+if (password.length < 6) {
+  setError("パスワードは6文字以上で設定してください");
+  return;
+}
+
+// 変更後
+import { Password } from "@/server/contexts/auth/domain/models/password";
+
+const validation = Password.validate(password);
+if (!validation.valid) {
+  setError(validation.error ?? "パスワードが要件を満たしていません");
+  return;
+}
+```
+
+### アーキテクチャガイドとの整合性
+
+- Client → Domain（models の型参照のみ）は許可されている
+- `Password` は純粋な関数のみで構成され、`server-only` を含まないためクライアントから参照可能
+- 単一エンティティのロジックなので Domain Model に配置
+- `interface + const` パターンで他のドメインモデル（`ReportData` 等）と統一


### PR DESCRIPTION
## Summary
- admin アプリケーションに「パスワードを忘れた場合」フローを追加するための設計ドキュメント
- Supabase Auth の `resetPasswordForEmail()` を活用したパスワードリセット機能
- パスワードバリデーションをドメインモデル（`Password`）として一元化する設計

## 設計内容
- フロー: ログイン画面 → パスワードリセット申請 → メール送信 → リンククリック → パスワード再設定
- 新規画面: `/forgot-password`（申請）、`/auth/reset-password`（再設定）
- 既存コード再利用: `SetupForm`、`InviteTokenHandler` と同様のパターン

## Test plan
- [ ] 設計ドキュメントのレビュー
- [ ] アーキテクチャガイドとの整合性確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * パスワードリセット機能の包括的な設計ドキュメントを追加。ユーザーエクスペリエンス、UI画面設計、メールベースのリセットフロー、トークン処理、セキュリティ考慮事項を含む実装仕様を提供。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->