### PR TITLE
fix: 一括紐付けUIを常に表示し、未選択時はdisabledにする

### DIFF
--- a/admin/src/client/components/counterpart-assignment/CounterpartAssignmentClient.tsx
+++ b/admin/src/client/components/counterpart-assignment/CounterpartAssignmentClient.tsx
@@ -281,19 +281,28 @@ export function CounterpartAssignmentClient({
           {isPending && <div className="text-muted-foreground text-sm">読み込み中...</div>}
         </div>
 
-        {selectedTransactions.length > 0 && (
-          <div className="flex items-center gap-4 mb-4 p-3 bg-secondary/30 border border-border rounded-lg">
-            <span className="text-white text-sm">
-              選択中: <span className="font-medium">{selectedTransactions.length}件</span>
-            </span>
-            <Button type="button" size="sm" onClick={handleBulkAssignClick}>
-              一括紐付け
-            </Button>
-            <Button type="button" variant="ghost" size="sm" onClick={() => setRowSelection({})}>
-              選択解除
-            </Button>
-          </div>
-        )}
+        <div className="flex items-center gap-4 mb-4 p-3 bg-secondary/30 border border-border rounded-lg">
+          <span className="text-white text-sm">
+            選択中: <span className="font-medium">{selectedTransactions.length}件</span>
+          </span>
+          <Button
+            type="button"
+            size="sm"
+            onClick={handleBulkAssignClick}
+            disabled={selectedTransactions.length === 0}
+          >
+            一括紐付け
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => setRowSelection({})}
+            disabled={selectedTransactions.length === 0}
+          >
+            選択解除
+          </Button>
+        </div>
 
         <TransactionWithCounterpartTable
           transactions={initialTransactions}

--- a/admin/src/client/components/donor-assignment/DonorAssignmentClient.tsx
+++ b/admin/src/client/components/donor-assignment/DonorAssignmentClient.tsx
@@ -256,19 +256,28 @@ export function DonorAssignmentClient({
           {isPending && <div className="text-muted-foreground text-sm">読み込み中...</div>}
         </div>
 
-        {selectedTransactions.length > 0 && (
-          <div className="flex items-center gap-4 mb-4 p-3 bg-secondary/30 border border-border rounded-lg">
-            <span className="text-white text-sm">
-              選択中: <span className="font-medium">{selectedTransactions.length}件</span>
-            </span>
-            <Button type="button" size="sm" onClick={handleBulkAssignClick}>
-              一括紐付け
-            </Button>
-            <Button type="button" variant="ghost" size="sm" onClick={() => setRowSelection({})}>
-              選択解除
-            </Button>
-          </div>
-        )}
+        <div className="flex items-center gap-4 mb-4 p-3 bg-secondary/30 border border-border rounded-lg">
+          <span className="text-white text-sm">
+            選択中: <span className="font-medium">{selectedTransactions.length}件</span>
+          </span>
+          <Button
+            type="button"
+            size="sm"
+            onClick={handleBulkAssignClick}
+            disabled={selectedTransactions.length === 0}
+          >
+            一括紐付け
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => setRowSelection({})}
+            disabled={selectedTransactions.length === 0}
+          >
+            選択解除
+          </Button>
+        </div>
 
         <TransactionWithDonorTable
           transactions={initialTransactions}


### PR DESCRIPTION
## Summary

管理画面の取引相手紐付け画面（/assign/counterparts）と寄附相手紐付け画面（/assign/donors）において、一括紐付けUIがチェック後にのみ表示されていたのを、常に表示するように変更しました。未選択時はボタンをdisabledにすることで、レイアウト崩れを防ぎます。

**変更内容:**
- `CounterpartAssignmentClient.tsx`: 条件付きレンダリング（`selectedTransactions.length > 0 && ...`）を削除し、代わりにボタンに`disabled={selectedTransactions.length === 0}`を追加
- `DonorAssignmentClient.tsx`: 同様の変更

## Review & Testing Checklist for Human

- [ ] /assign/counterparts ページで一括紐付けUIが初期表示時から見えることを確認
- [ ] /assign/donors ページで一括紐付けUIが初期表示時から見えることを確認
- [ ] 未選択時にボタンがdisabled状態（グレーアウト等）で表示されることを確認
- [ ] チェックボックスで項目を選択するとボタンが有効になることを確認

**推奨テスト手順:**
1. 管理画面にログイン
2. /assign/counterparts にアクセス → 一括紐付けUIが表示されていてボタンがdisabledであることを確認
3. いくつかの取引をチェック → ボタンが有効になることを確認
4. 一括紐付けボタンをクリック → 正常に動作することを確認
5. /assign/donors でも同様に確認

### Notes

- Link to Devin run: https://app.devin.ai/sessions/d11c3b2480614c1a8cfbb947cdf9adf2
- Requested by: jun.ito@team-mir.ai (@jujunjun110)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Style**
  * 一括操作パネルが常に表示されるようになりました。トランザクションが選択されていない場合、操作ボタンが無効になります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->