### PR TITLE
docs: Donor CSV取り込み設計の既存Donor照合をバッチクエリに最適化

### DIFF
--- a/docs/20251230_0154_donor一括CSV取り込みプレビュー詳細設計.md
+++ b/docs/20251230_0154_donor一括CSV取り込みプレビュー詳細設計.md
@@ -484,7 +484,7 @@ export class PreviewDonorCsvUsecase {
 
   /**
    * 既存 Donor との照合を行う
-   * N+1 問題を回避するため、ユニークな組み合わせのみを検索し、結果をマップして返す
+   * N+1 問題を回避するため、ユニークな組み合わせを抽出し、1回のクエリで一括検索する
    */
   private async enrichWithMatchingDonors(
     rows: PreviewDonorCsvRow[],
@@ -500,20 +500,14 @@ export class PreviewDonorCsvUsecase {
       }
     }
 
-    // ユニークな組み合わせごとに Donor を検索
-    // 注: ユニークな組み合わせ数 K は行数 N よりも十分小さいことが期待される
-    // （同一寄付者が複数回寄付するケースが多いため）
-    // K が大きい場合はバッチクエリ対応を検討（実装段階で判断）
-    const donorMap = new Map<string, Donor | null>();
-    for (const [key, { name, address, donorType }] of searchKeys) {
-      const donor = await this.donorRepository.findByNameAddressAndType(name, address, donorType);
-      donorMap.set(key, donor);
-    }
+    // 1回のクエリで一括検索
+    const uniqueCriteria = [...searchKeys.values()];
+    const donors = await this.donorRepository.findByMatchCriteriaBatch(uniqueCriteria);
 
-    // 将来的な最適化案:
-    // searchKeys が大きい場合（例: 100以上）は、
-    // findByNameAddressAndTypeBatch(criteria: Array<{name, address, donorType}>)
-    // を実装して一括クエリ化することを検討
+    // 検索結果を Map に変換（O(1) ルックアップ用）
+    const donorMap = new Map(
+      donors.map((d) => [`${d.name}|${d.address ?? ""}|${d.donorType}`, d]),
+    );
 
     // 各行に検索結果を紐付け
     return rows.map((row) => {
@@ -543,7 +537,32 @@ export class PreviewDonorCsvUsecase {
 - DB接続エラー: 例外をスローし、Presentation層でリトライを促すメッセージを表示
 - 部分成功: 対応しない（全体成功または全体失敗）
 
-### 5.2 リポジトリ拡張（ITransactionWithDonorRepository）
+### 5.2 リポジトリ拡張（IDonorRepository）
+
+**追加メソッド**:
+
+```typescript
+// admin/src/server/contexts/report/domain/repositories/donor-repository.interface.ts
+
+export interface IDonorRepository {
+  // ... 既存メソッド
+
+  /**
+   * 複数の (name, address, donorType) 条件で既存 Donor を一括検索
+   *
+   * 同一人物判定に使用。政治資金報告書では同一寄付者の寄付を合算して
+   * 5万円以上かを判定する必要があるため、既存Donorとの照合が重要。
+   *
+   * @param criteria 検索条件の配列
+   * @returns 条件に一致した Donor の配列（一致しない条件は結果に含まれない）
+   */
+  findByMatchCriteriaBatch(
+    criteria: Array<{ name: string; address: string | null; donorType: DonorType }>
+  ): Promise<Donor[]>;
+}
+```
+
+### 5.3 リポジトリ拡張（ITransactionWithDonorRepository）
 
 **追加メソッド**:
 
@@ -564,7 +583,43 @@ export interface ITransactionWithDonorRepository {
 }
 ```
 
-#### 実装方針
+#### IDonorRepository 実装方針
+
+```typescript
+// admin/src/server/contexts/report/infrastructure/repositories/donor-repository.ts
+
+async findByMatchCriteriaBatch(
+  criteria: Array<{ name: string; address: string | null; donorType: DonorType }>
+): Promise<Donor[]> {
+  if (criteria.length === 0) return [];
+
+  // PostgreSQL のタプル比較で一括検索（1クエリ）
+  // WHERE (name, COALESCE(address, ''), donor_type) IN ((...), (...), ...)
+  const donors = await this.prisma.$queryRaw<Donor[]>`
+    SELECT * FROM donor
+    WHERE (name, COALESCE(address, ''), donor_type) IN (
+      ${Prisma.join(
+        criteria.map(c =>
+          Prisma.sql`(${c.name}, ${c.address ?? ''}, ${c.donorType})`
+        )
+      )}
+    )
+  `;
+  return donors;
+}
+```
+
+**パフォーマンス考慮**:
+- K 回の個別クエリではなく、1 回の IN 句クエリで一括取得
+- 1000行制限の制約下で、タプル比較は PostgreSQL で効率的に処理可能
+- `(name, address, donor_type)` の複合インデックスがあるとより効率的（なくても動作する）
+
+**将来の最適化案**:
+- 同一人物判定の精度向上が必要になった場合、match_hash カラムを導入して
+  ハッシュベースの検索に切り替えることを検討
+- その場合、正規化ロジック（trim + 全角半角統一）はリポジトリ実装の内部詳細として扱う
+
+#### ITransactionWithDonorRepository 実装方針
 
 ```typescript
 // admin/src/server/contexts/report/infrastructure/repositories/transaction-with-donor-repository.ts
@@ -804,6 +859,8 @@ admin/src/client/components/donor-csv-import/
 
 | パス | 変更内容 |
 |-----|---------|
+| `report/domain/repositories/donor-repository.interface.ts` | `findByMatchCriteriaBatch` メソッド追加 |
+| `report/infrastructure/repositories/donor-repository.ts` | 上記メソッドの実装（タプル比較で1クエリ） |
 | `report/domain/repositories/transaction-with-donor-repository.interface.ts` | `findByTransactionNosForDonorCsv` メソッド追加 |
 | `report/infrastructure/repositories/transaction-with-donor-repository.ts` | 上記メソッドの実装 |
 


### PR DESCRIPTION
## 目的

実装者がDonor CSV取り込み機能を実装する際に、N+1問題を回避した効率的な実装ができるようにするため。

## Summary

- 既存Donor照合のK回ループクエリを1回のIN句クエリに変更
- `findByMatchCriteriaBatch` メソッドを `IDonorRepository` に追加
- PostgreSQLタプル比較による一括検索の実装方針を記載
- 将来の最適化案（match_hashカラム）をコメントで追記

## 変更の背景

当初の設計では、CSV内のユニークな `(name, address, donorType)` の組み合わせ K 個に対して K 回の個別クエリを実行していた。これをタプル比較 `WHERE (name, COALESCE(address, ''), donor_type) IN (...)` による1回のクエリに最適化。

## Test plan

- [ ] ドキュメントの内容を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 改善

* **改善**
  * ドナー一括CSV取り込みプレビュー機能における寄付者データマッチング処理の効率を向上させました
  * 取引情報と寄付者データの検索処理を強化しました

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->