### PR TITLE
feat: Dependabot設定を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,96 @@
+version: 2
+updates:
+  # ルートのpackage.json
+  # dependencies: @prisma/client, @supabase/supabase-js, dotenv
+  # devDependencies: @biomejs/biome, concurrently, dependency-cruiser, dotenv-cli,
+  #                  knip, lint-staged, prisma, simple-git-hooks, supabase, tsx, typescript
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    groups:
+      prisma:
+        patterns:
+          - "prisma"
+          - "@prisma/client"
+      supabase:
+        patterns:
+          - "@supabase/supabase-js"
+          - "supabase"
+      dev-dependencies:
+        dependency-type: "development"
+
+  # admin
+  # dependencies: @ai-sdk/anthropic, @prisma/client, @radix-ui/*, @supabase/ssr,
+  #               @supabase/supabase-js, @tanstack/react-table, @vercel/speed-insights,
+  #               ai, class-variance-authority, clsx, iconv-lite, lucide-react, next,
+  #               react, react-dom, sonner, tailwind-merge, xmlbuilder2, zod
+  # devDependencies: @tailwindcss/postcss, @types/*, jest, postcss, tailwindcss, ts-jest, typescript
+  - package-ecosystem: "npm"
+    directory: "/admin"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    groups:
+      radix-ui:
+        patterns:
+          - "@radix-ui/*"
+      tanstack:
+        patterns:
+          - "@tanstack/react-table"
+      ai-sdk:
+        patterns:
+          - "@ai-sdk/*"
+          - "ai"
+      supabase:
+        patterns:
+          - "@supabase/*"
+      next-react:
+        patterns:
+          - "next"
+          - "react"
+          - "react-dom"
+      dev-dependencies:
+        dependency-type: "development"
+
+  # webapp
+  # dependencies: @next/third-parties, @nivo/sankey, @prisma/client, @vercel/speed-insights,
+  #               apexcharts, critters, next, react, react-apexcharts, react-dom
+  # devDependencies: @tailwindcss/postcss, @types/*, jest, postcss, tailwindcss, ts-jest, typescript
+  - package-ecosystem: "npm"
+    directory: "/webapp"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    groups:
+      charts:
+        patterns:
+          - "apexcharts"
+          - "react-apexcharts"
+          - "@nivo/*"
+      next-react:
+        patterns:
+          - "next"
+          - "react"
+          - "react-dom"
+      dev-dependencies:
+        dependency-type: "development"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,38 @@
+name: Dependabot Auto-merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for patch and minor updates
+        if: |
+          steps.metadata.outputs.update-type != 'version-update:semver-major' &&
+          !(
+            steps.metadata.outputs.directory == '/webapp' &&
+            steps.metadata.outputs.update-type == 'version-update:semver-minor' &&
+            (
+              contains(steps.metadata.outputs.dependency-names, 'apexcharts') ||
+              contains(steps.metadata.outputs.dependency-names, 'react-apexcharts') ||
+              contains(steps.metadata.outputs.dependency-names, '@nivo/')
+            )
+          )
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

[設計ドキュメント](https://github.com/team-mirai/marumie/blob/develop/docs/20260101_2220_Dependabot%E5%B0%8E%E5%85%A5%E8%A8%AD%E8%A8%88.md)に従い、Dependabot設定を追加しました。

**追加ファイル:**
- `.github/dependabot.yml` - 依存パッケージの自動更新PR作成設定
- `.github/workflows/dependabot-auto-merge.yml` - patch/minor更新の自動マージワークフロー

**設定内容:**
- 週1回（土曜9:00 JST）にPR作成
- root, admin, webapp, GitHub Actionsの4つのエコシステムを監視
- 関連パッケージをグループ化（prisma, supabase, radix-ui, charts等）
- major更新は手動レビュー必須
- webappのチャートライブラリ（apexcharts, @nivo/*）はminor以上も手動レビュー

## Review & Testing Checklist for Human

- [ ] **リポジトリ設定**: Settings → General → Pull Requests → 「Allow auto-merge」が有効になっているか確認
- [ ] **自動マージ条件**: `dependabot-auto-merge.yml`の`contains()`による`@nivo/`パターンマッチが意図通り動作するか確認（部分一致で正しく検出されるか）
- [ ] **スケジュール確認**: 土曜9:00 JSTで問題ないか

### Notes

- 実際にDependabotがPRを作成するのは次の土曜日以降になります
- 自動マージが動作するには、CIが通る必要があります（Branch protectionが設定されている場合）

---
Link to Devin run: https://app.devin.ai/sessions/00a4b39f89b54721bbc072f9adcb745f
Requested by: jun.ito@team-mir.ai (@jujunjun110)