### PR TITLE
fix: remove counterpart from personnel-costs seed data

### DIFF
--- a/prisma/seeds/transactions.ts
+++ b/prisma/seeds/transactions.ts
@@ -510,7 +510,6 @@ const data: TransactionSeedData[] = [
     creditAmount: '250000',
     description: '事務職員給与',
     categoryKey: 'personnel-costs',
-    counterpartName: '事務　太郎',
     friendlyCategory: '人件費',
   },
   // SYUUSHI07_15: 政治活動費の支出（KUBUN1: 組織活動費）


### PR DESCRIPTION
## Summary

Fixes #940 - Seed data was failing because it tried to assign a counterpart to a transaction with `categoryKey: 'personnel-costs'`.

The DB trigger `validate_transaction_counterpart` only allows counterparts for specific expense categories, and `personnel-costs` is not in the allowed list. This caused the seed to fail with:
```
Counterpart cannot be assigned to this expense transaction category: personnel-costs
```

The fix removes the `counterpartName` field from the personnel-costs seed entry.

## Review & Testing Checklist for Human

- [ ] Run `pnpm db:seed` locally to verify the seed completes successfully
- [ ] Verify no other seed entries have similar counterpart assignment issues

### Notes

- Link to Devin run: https://app.devin.ai/sessions/ddeb0071916843aebcea6ea17cdd2656
- Requested by: jun.ito@team-mir.ai (@jujunjun110)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 特定の取引レコード（T2025-0034：経常経費の支出・事務所費）の相手先情報フィールドを削除しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->