### PR TITLE
docs: add error handling rules with ValidationError pattern to admin-architecture-guide

### DIFF
--- a/docs/admin-architecture-guide.md
+++ b/docs/admin-architecture-guide.md
@@ -267,16 +267,15 @@ export const Password = {
 
 #### 6.3.2 拡張エラー型とエラーコードの定義
 
-Domain層でバリデーションエラーを扱う場合は、`ValidationError`/`ValidationResult`/`ValidationErrorCode` を定義する。
+Domain層でエラーを扱う場合は、拡張エラー型とエラーコードを定義する。
 
-**配置場所**: `contexts/{コンテキスト名}/domain/types/validation.ts`
+**配置場所**: `contexts/{コンテキスト名}/domain/types/`
 
 **リファレンス実装**: `contexts/report/domain/types/validation.ts`
 
 **原則**:
-- `ValidationError`: `path`（エラー箇所）、`code`（エラーコード）、`message`（日本語メッセージ）、`severity`（"error" | "warning"）を持つ
-- `ValidationResult`: `isValid`、`errors`（致命的問題）、`warnings`（確認が必要な問題）を持つ
-- `ValidationErrorCode`: `as const` で型安全に定義。大文字スネークケース（例: `REQUIRED`, `INVALID_FORMAT`）
+- エラー型は `path`（エラー箇所）、`code`（エラーコード）、`message`（日本語メッセージ）、`severity`（"error" | "warning"）を持つ
+- エラーコードは `as const` で型安全に定義。大文字スネークケース（例: `REQUIRED`, `INVALID_FORMAT`）
 - コンテキスト固有のコードには接頭辞を付ける（例: `REPORT_MISSING_COUNTERPART`）
 
 #### 6.3.3 error と warning の使い分け


### PR DESCRIPTION
## Summary

`docs/admin-architecture-guide.md` のセクション 6.3 エラーハンドリングを拡張し、`admin/src/server/contexts/report/domain/types/validation.ts` のパターンに基づいた拡張エラー型とエラーコードの定義ルールを追加しました。

追加した内容:
- **6.3.1**: レイヤー別エラーハンドリング方針
- **6.3.2**: 拡張エラー型とエラーコードの定義（原則のみ、リファレンス実装への参照）
- **6.3.3**: error と warning の使い分け基準

## Updates since last revision

レビューフィードバックに基づき、ドキュメントを簡潔化しました：
- 冗長なコード例を削除し、原則のみに絞った記述に変更
- リファレンス実装（`contexts/report/domain/types/validation.ts`）への参照を追加
- AIがコンテキストを消費しすぎないよう、端的な記述に統一

## Review & Testing Checklist for Human

- [ ] 原則の記述が既存の `validation.ts` のパターンと整合しているか確認
- [ ] リファレンス実装パス（`contexts/report/domain/types/validation.ts`）が正しいか確認

### Notes

- ドキュメントのみの変更のため、ランタイムへの影響はありません
- Link to Devin run: https://app.devin.ai/sessions/1a77389008354564b45d9693784b3ac0
- Requested by: jun.ito@team-mir.ai (@jujunjun110)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * 層別エラーハンドリング戦略を追加し、Presentation/Application/Domain/Infrastructureの役割を明確化しました。
  * 拡張ドメインエラーの型定義と標準化された大文字エラーコードのフレームワークを導入しました。
  * エラーと警告の使い分け、伝播フロー、表示変換パターンを明確化しました。
  * ローダー/アクションのキャッシュ挙動と横断的なキャッシュ無効化方針を強化しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->