### PR TITLE
fix: DependabotのautoマージをCI完了後に実行するよう修正

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,8 +1,10 @@
 name: Dependabot Auto-merge
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
 
 permissions:
   contents: write
@@ -11,16 +13,30 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: |
+      github.event.workflow_run.actor.login == 'dependabot[bot]' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
 
     steps:
+      - name: Get PR number
+        id: pr
+        run: |
+          PR_NUMBER=$(gh run view ${{ github.event.workflow_run.id }} --repo ${{ github.repository }} --json pullRequests --jq '.pullRequests[0].number')
+          echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Fetch Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v2
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Enable auto-merge for patch and minor updates
+      - name: Merge PR for patch and minor updates
         if: |
           steps.metadata.outputs.update-type != 'version-update:semver-major' &&
           !(
@@ -32,7 +48,6 @@ jobs:
               contains(steps.metadata.outputs.dependency-names, '@nivo/')
             )
           )
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: gh pr merge --squash "${{ steps.pr.outputs.number }}"
         env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 目的

DependabotのPRがCIの結果を待たずにマージされてしまう問題を解消するため。

## 問題

- `pull_request` イベントでは auto-merge ワークフローとCIが並行実行される
- ブランチ保護ルールが設定されていない場合、CIが完了する前にマージが実行される
- 例: https://github.com/team-mirai/marumie/pull/950 はCI失敗にもかかわらずマージされた

## 変更内容

- トリガーを `pull_request` から `workflow_run` に変更
- CIワークフローが成功した場合のみマージを実行
- `--auto` フラグを削除し、CI成功確認後に即座にマージ

## テスト

- 次回のDependabot PRで動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)