### PR TITLE
chore: CI改善 - ジョブ並列化、knip追加、ビルドチェック、キャッシュ強化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,53 +5,172 @@ on:
     paths:
       - 'admin/**'
       - 'webapp/**'
+      - 'packages/**'
+      - 'prisma/**'
       - '.dependency-cruiser.cjs'
+      - 'pnpm-lock.yaml'
   pull_request:
     paths:
       - 'admin/**'
       - 'webapp/**'
+      - 'packages/**'
+      - 'prisma/**'
       - '.dependency-cruiser.cjs'
+      - 'pnpm-lock.yaml'
 
 jobs:
-  lint-and-test:
+  admin:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-          
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'pnpm'
-          
+
+      - name: Cache Prisma client
+        uses: actions/cache@v4
+        with:
+          path: node_modules/.prisma
+          key: ${{ runner.os }}-prisma-${{ hashFiles('prisma/schema.prisma') }}
+          restore-keys: |
+            ${{ runner.os }}-prisma-
+
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: admin/.next/cache
+          key: ${{ runner.os }}-nextjs-admin-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('admin/**/*.ts', 'admin/**/*.tsx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-admin-${{ hashFiles('pnpm-lock.yaml') }}-
+            ${{ runner.os }}-nextjs-admin-
+
       - name: Install dependencies
         run: pnpm install
-        
+
       - name: Run lint for admin
         run: pnpm --filter admin run lint
-        
+
       - name: Run tests for admin with coverage
         run: pnpm --filter admin run test:coverage
-        
+
       - name: Run type check for admin
         run: pnpm --filter admin run type-check
 
       - name: Check dependency rules for admin
         run: pnpm depcruise
 
+      - name: Build admin
+        run: pnpm build:admin
+
+      - name: Upload admin coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: admin-coverage
+          path: admin/coverage/lcov.info
+
+  webapp:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Cache Prisma client
+        uses: actions/cache@v4
+        with:
+          path: node_modules/.prisma
+          key: ${{ runner.os }}-prisma-${{ hashFiles('prisma/schema.prisma') }}
+          restore-keys: |
+            ${{ runner.os }}-prisma-
+
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: webapp/.next/cache
+          key: ${{ runner.os }}-nextjs-webapp-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('webapp/**/*.ts', 'webapp/**/*.tsx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-webapp-${{ hashFiles('pnpm-lock.yaml') }}-
+            ${{ runner.os }}-nextjs-webapp-
+
+      - name: Install dependencies
+        run: pnpm install
+
       - name: Run lint for webapp
         run: pnpm --filter webapp run lint
-        
+
       - name: Run tests for webapp with coverage
         run: pnpm --filter webapp run test:coverage
-        
+
       - name: Run type check for webapp
         run: pnpm --filter webapp run type-check
+
+      - name: Build webapp
+        run: pnpm build:webapp
+
+      - name: Upload webapp coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: webapp-coverage
+          path: webapp/coverage/lcov.info
+
+  knip:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Check unused code
+        run: pnpm knip
+
+  coverage:
+    runs-on: ubuntu-latest
+    needs: [admin, webapp]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download admin coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: admin-coverage
+          path: admin/coverage
+
+      - name: Download webapp coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: webapp-coverage
+          path: webapp/coverage
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
## 目的

開発者がCI完了を待つ時間を短縮し、コード品質の問題を早期に検出できるようにするため。

## 変更内容

### 1. ジョブ並列化
- `admin`, `webapp`, `knip` ジョブを独立して並列実行
- `coverage` ジョブは両アプリ完了後にCodecovへアップロード

```
┌─────────┐  ┌─────────┐  ┌──────┐
│  admin  │  │ webapp  │  │ knip │
└────┬────┘  └────┬────┘  └──────┘
     │            │
     └─────┬──────┘
           ▼
      ┌──────────┐
      │ coverage │
      └──────────┘
```

### 2. knip追加
- 未使用コード検出をCIで自動チェック

### 3. ビルドチェック追加
- `pnpm build:admin` / `pnpm build:webapp` を各ジョブで実行
- 本番ビルドの破損を早期検出

### 4. キャッシュ強化
- Prisma client (`node_modules/.prisma`) をキャッシュ
- Next.js build cache (`.next/cache`) をキャッシュ

### 5. トリガーパス拡張
- `packages/**`, `prisma/**`, `pnpm-lock.yaml` を追加

## Test plan

- [ ] PRのCIが正常に完了すること
- [ ] admin, webapp, knipジョブが並列実行されること
- [ ] coverageジョブがadmin/webapp完了後に実行されること
- [ ] Dependabot PRで自動マージが引き続き動作すること（次回のDependabot PRで確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)