### PR TITLE
docs: 月別収支グラフの欠損月表示対応の設計書を追加

### DIFF
--- a/docs/20260102_0037_月別収支グラフの欠損月表示対応.md
+++ b/docs/20260102_0037_月別収支グラフの欠損月表示対応.md
@@ -1,0 +1,124 @@
+# 月別収支グラフの欠損月表示対応
+
+## 目的
+
+**ユーザー（市民）が、データのない月があっても年間を通じた収支の推移を正確に把握できるようにするため**
+
+現在のグラフはデータがある月のみを表示するため、例えば「1月, 3月, 5月」のようにデータのない月はスキップされる。これにより、閲覧者は「2月と4月に取引がなかったのか、それとも表示が省略されているだけなのか」が分からず、正確な時系列推移を把握しづらい状況になっている。
+
+## 関連Issue
+
+- https://github.com/team-mirai/marumie/issues/804
+
+## 現状分析
+
+### 現在のデータフロー
+
+```
+PrismaTransactionRepository.getMonthlyAggregation()
+  ├─ SQL: 収入データ GROUP BY 年月
+  ├─ SQL: 支出データ GROUP BY 年月
+  └─ Map で統合して yearMonth でソート
+      ↓
+  GetMonthlyTransactionAggregationUsecase
+      ↓
+  loadTopPageData()
+      ↓
+  MonthlyTrendsSection → MonthlyChart
+```
+
+### 問題点
+
+- Repository層のSQLクエリで `GROUP BY` を使用しており、データがある月のみが返される
+- マッピング処理でもデータが存在しない月は補完されない
+- 結果として、グラフには実データがある月のみが表示される
+
+### 関連ファイル
+
+| ファイル | 役割 |
+|---------|------|
+| [webapp/src/server/repositories/prisma-transaction.repository.ts](webapp/src/server/repositories/prisma-transaction.repository.ts) | データベースから月別集計を取得 |
+| [webapp/src/server/usecases/get-monthly-transaction-aggregation-usecase.ts](webapp/src/server/usecases/get-monthly-transaction-aggregation-usecase.ts) | Usecase層 |
+| [webapp/src/client/components/top-page/features/charts/MonthlyChart.tsx](webapp/src/client/components/top-page/features/charts/MonthlyChart.tsx) | グラフ表示コンポーネント |
+
+## 設計方針
+
+### 実装箇所の選択
+
+欠損月を補完する処理の実装箇所として、以下の選択肢がある：
+
+| 箇所 | メリット | デメリット |
+|------|----------|------------|
+| **Repository層** | DBに近い位置で完結 | Repository は純粋なデータ取得に留めるべき |
+| **Usecase層** ✅ | ビジネスロジックとして適切 | - |
+| **フロントエンド** | 表示に近い位置 | データ整形をクライアントで行うべきでない |
+
+**Usecase層で補完処理を実装する**ことを推奨する。Repository層は純粋なデータ取得に専念し、「会計年度の全月を表示する」というビジネス要件はUsecase層で対応する。
+
+### 補完ロジック
+
+1. 会計年度（`financialYear`）に対応する12ヶ月分の yearMonth リストを生成
+2. Repository から取得した実データを Map 化
+3. 12ヶ月すべてについて、データがあれば使用、なければ `{ income: 0, expense: 0 }` で補完
+
+### データ構造
+
+変更なし。既存の `MonthlyAggregation` インターフェースをそのまま使用：
+
+```typescript
+interface MonthlyAggregation {
+  yearMonth: string;  // "YYYY-MM"
+  income: number;
+  expense: number;
+}
+```
+
+## 実装詳細
+
+### 1. Usecase層の修正
+
+**ファイル:** `webapp/src/server/usecases/get-monthly-transaction-aggregation-usecase.ts`
+
+`execute()` メソッド内で、Repository から取得したデータに対して12ヶ月分の補完処理を追加する。
+
+**補完処理のロジック：**
+
+1. 会計年度から12ヶ月分の `yearMonth` 配列を生成
+   - 例: `financialYear = 2025` → `["2025-01", "2025-02", ..., "2025-12"]`
+2. 取得したデータを `yearMonth` をキーとする Map に変換
+3. 12ヶ月分をループし、データがない月は `{ yearMonth, income: 0, expense: 0 }` で補完
+4. ソート済みの配列として返却
+
+### 2. 補完用ヘルパー関数
+
+月配列生成のロジックは Usecase 内にプライベート関数として実装する。
+
+```
+generateYearMonths(financialYear: number): string[]
+// 出力例: ["2025-01", "2025-02", ..., "2025-12"]
+```
+
+### 3. グラフコンポーネント
+
+変更不要。既に `yearMonth` をカテゴリとして使用しており、12ヶ月分のデータが渡されれば正しく表示される。
+
+## 影響範囲
+
+- `get-monthly-transaction-aggregation-usecase.ts` の修正のみ
+- Repository層、グラフコンポーネント、ローダー層は変更不要
+- 既存のテストがあれば、12ヶ月分のデータが返ることを期待するように更新が必要
+
+## テスト観点
+
+1. **データがない月の補完**
+   - 例: 1月、3月のみデータがある場合 → 12ヶ月すべてが返される
+   - 補完された月は `income: 0, expense: 0`
+
+2. **全月にデータがある場合**
+   - 既存の動作と同じ結果になること
+
+3. **データが全くない場合**
+   - 12ヶ月すべてが `income: 0, expense: 0` で返される
+
+4. **月の順序**
+   - 1月から12月まで正しい順序でソートされていること


### PR DESCRIPTION
## Summary

- Issue #804 「月々の収支について、レコードのない月にも線グラフを表示するようにする」に対応する設計ドキュメントを追加
- Usecase層で12ヶ月分の欠損月補完処理を実装する方針を策定

## 目的

ユーザー（市民）が、データのない月があっても年間を通じた収支の推移を正確に把握できるようにするため

## Test plan

- [ ] 設計内容のレビュー
- [ ] 実装方針の承認

Closes #804

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * 月別収支グラフの欠損月表示対応に関する設計ドキュメントを追加しました。今後、グラフに12ヶ月分のデータが確実に表示されるようになります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->