### PR TITLE
docs: 月別集計リポジトリのドメインロジック移行設計を追加

### DIFF
--- a/docs/20260102_0954_月別集計リポジトリのドメインロジック移行設計.md
+++ b/docs/20260102_0954_月別集計リポジトリのドメインロジック移行設計.md
@@ -1,0 +1,123 @@
+# 月別集計リポジトリのドメインロジック移行設計
+
+## 目的
+
+開発者がリポジトリ層のロジックをテストしづらい状態を解消するため。
+
+現状、`PrismaMonthlyAggregationRepository` にドメインロジック（収入・支出データのマージ、ソート）が埋め込まれており、単体テストが困難になっている。
+
+## 対象ファイル
+
+`webapp/src/server/contexts/public-finance/infrastructure/repositories/prisma-monthly-aggregation.repository.ts`
+
+## 現状の問題
+
+リポジトリ内に以下のロジックが埋め込まれている：
+
+1. **収入・支出のマージ処理** (L46-75)
+   - 収入データと支出データを年月別のMapにマージ
+   - yearMonth フォーマット変換
+
+2. **ソート処理** (L77)
+   - yearMonth でソート
+
+これらはドメインロジックであり、リポジトリに置くべきではない（`docs/admin-architecture-guide.md` 参照）。
+
+**許容する処理**: SQLでの `GROUP BY ... SUM()` による集計はパフォーマンス上の理由から許容する。
+
+## 設計方針
+
+### 変更概要
+
+| 層 | 責務 |
+|---|---|
+| Infrastructure（リポジトリ） | SQLで収入・支出それぞれの月別合計を取得（GROUP BY SUM） |
+| Domain（モデル） | 収入・支出データのマージ、yearMonthフォーマット変換、ソート |
+| Application（Usecase） | リポジトリから生データ取得 → ドメインモデルで集計 |
+
+### 1. 新しいドメインモデルの導入
+
+**MonthlyTransactionTotal** - SQLから返される月別合計を表す型
+
+```typescript
+// domain/models/monthly-transaction-total.ts
+export interface MonthlyTransactionTotal {
+  year: number;
+  month: number;
+  totalAmount: number;
+}
+```
+
+### 2. リポジトリインターフェースの変更
+
+収入・支出を別々に取得するメソッドに分割。
+
+```typescript
+// domain/repositories/monthly-aggregation-repository.interface.ts
+export interface IMonthlyAggregationRepository {
+  getIncomeByOrganizationIds(
+    organizationIds: string[],
+    financialYear: number
+  ): Promise<MonthlyTransactionTotal[]>;
+
+  getExpenseByOrganizationIds(
+    organizationIds: string[],
+    financialYear: number
+  ): Promise<MonthlyTransactionTotal[]>;
+}
+```
+
+### 3. ドメインモデルに集計ロジックを移動
+
+```typescript
+// domain/models/monthly-aggregation.ts
+export const MonthlyAggregation = {
+  /**
+   * 収入・支出データをマージして MonthlyAggregation[] を生成
+   * - 年月でグルーピング
+   * - yearMonth フォーマット変換
+   * - ソート
+   */
+  aggregateFromTotals(
+    incomeData: MonthlyTransactionTotal[],
+    expenseData: MonthlyTransactionTotal[]
+  ): MonthlyAggregation[];
+};
+```
+
+### 4. リポジトリ実装の簡素化
+
+マージ・ソート処理を削除し、SQLの結果をそのまま返す。
+
+### 5. Usecaseでの組み立て
+
+```typescript
+// application/usecases/get-monthly-aggregation-usecase.ts
+async execute(params) {
+  // リポジトリから生データ取得
+  const [incomeData, expenseData] = await Promise.all([
+    this.repository.getIncomeByOrganizationIds(orgIds, year),
+    this.repository.getExpenseByOrganizationIds(orgIds, year),
+  ]);
+
+  // ドメインモデルで集計
+  const monthlyData = MonthlyAggregation.aggregateFromTotals(incomeData, expenseData);
+  return { monthlyData };
+}
+```
+
+## ファイル変更一覧
+
+| ファイル | 変更内容 |
+|----------|----------|
+| `domain/models/monthly-transaction-total.ts` | 新規作成 |
+| `domain/models/monthly-aggregation.ts` | `aggregateFromTotals` 追加 |
+| `domain/repositories/monthly-aggregation-repository.interface.ts` | メソッド分割 |
+| `infrastructure/repositories/prisma-monthly-aggregation.repository.ts` | マージ・ソート処理削除 |
+| `application/usecases/get-monthly-aggregation-usecase.ts` | ドメインモデル呼び出し追加 |
+
+## 期待される効果
+
+- **テスタビリティ向上**: `MonthlyAggregation.aggregateFromTotals` は純粋関数としてユニットテスト可能
+- **責務分離**: リポジトリはデータ取得のみ、ロジックはドメイン層
+- **Usecaseシグネチャ不変**: 外部APIは変わらない


### PR DESCRIPTION
## 目的

開発者がリポジトリ層のロジックをテストしづらい状態を解消するため。

## 概要

`PrismaMonthlyAggregationRepository` に埋め込まれているドメインロジック（収入・支出データのマージ、ソート）をドメイン層に移行する設計ドキュメントを追加。

## 設計方針

- SQLでの `GROUP BY SUM` による集計は許容（パフォーマンス考慮）
- リポジトリは収入・支出を別々に取得するメソッドに分割
- マージ処理・ソート処理はドメインモデル `MonthlyAggregation.aggregateFromTotals` に移動
- Usecaseのシグネチャは変更なし

## Test plan

- [ ] 設計ドキュメントの内容を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 月別の財務集計データ取得機能を追加しました
  * トランザクション検索にフィルタリングとページネーション機能を追加しました

* **バグ修正**
  * デフォルト組織が存在しない場合のナビゲーションを改善しました

* **リファクタリング**
  * ドメイン駆動設計に基づいて月別集計ロジックを再構成しました
  * リポジトリインターフェースを再編成しました

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->