### PR TITLE
refactor: 月別集計リポジトリのドメインロジックをドメイン層に移行

### DIFF
--- a/webapp/src/server/contexts/public-finance/application/usecases/get-monthly-aggregation-usecase.ts
+++ b/webapp/src/server/contexts/public-finance/application/usecases/get-monthly-aggregation-usecase.ts
@@ -1,6 +1,9 @@
 import "server-only";
 
-import type { MonthlyAggregation } from "@/server/contexts/public-finance/domain/models/monthly-aggregation";
+import {
+  type MonthlyAggregation,
+  aggregateFromTotals,
+} from "@/server/contexts/public-finance/domain/models/monthly-aggregation";
 import type { IMonthlyAggregationRepository } from "@/server/contexts/public-finance/domain/repositories/monthly-aggregation-repository.interface";
 import type { IPoliticalOrganizationRepository } from "@/server/contexts/public-finance/domain/repositories/political-organization-repository.interface";
 
@@ -16,8 +19,8 @@ export interface GetMonthlyAggregationResult {
 /**
  * 月別収支集計を取得するユースケース
  *
- * ITransactionRepository への依存を IMonthlyAggregationRepository に変更し、
- * Interface Segregation Principle を適用。
+ * リポジトリから収入・支出の生データを取得し、
+ * ドメインモデルでマージ・ソートを行う。
  */
 export class GetMonthlyAggregationUsecase {
   constructor(
@@ -38,10 +41,19 @@ export class GetMonthlyAggregationUsecase {
       }
 
       const organizationIds = politicalOrganizations.map((org) => org.id);
-      const monthlyData = await this.monthlyAggregationRepository.getByOrganizationIds(
-        organizationIds,
-        params.financialYear,
-      );
+
+      const [incomeData, expenseData] = await Promise.all([
+        this.monthlyAggregationRepository.getIncomeByOrganizationIds(
+          organizationIds,
+          params.financialYear,
+        ),
+        this.monthlyAggregationRepository.getExpenseByOrganizationIds(
+          organizationIds,
+          params.financialYear,
+        ),
+      ]);
+
+      const monthlyData = aggregateFromTotals(incomeData, expenseData);
 
       return { monthlyData };
     } catch (error) {

--- a/webapp/src/server/contexts/public-finance/domain/models/monthly-aggregation.ts
+++ b/webapp/src/server/contexts/public-finance/domain/models/monthly-aggregation.ts
@@ -1,8 +1,10 @@
+import type { MonthlyTransactionTotal } from "./monthly-transaction-total";
+
 /**
  * MonthlyAggregation ドメインモデル
  *
  * 月別の収支集計データを表現する。
- * ドメインロジックがほぼないため、型定義とバリデーション関数のみを提供する。
+ * 収入・支出データのマージ、yearMonthフォーマット変換、ソートのドメインロジックを提供する。
  */
 
 /**
@@ -31,4 +33,56 @@ export function isValidYearMonthFormat(yearMonth: string): boolean {
  */
 export function calculateBalance(aggregation: MonthlyAggregation): number {
   return aggregation.income - aggregation.expense;
+}
+
+/**
+ * 年と月から yearMonth フォーマット文字列を生成する
+ * @param year 年
+ * @param month 月
+ * @returns "YYYY-MM" 形式の文字列
+ */
+function formatYearMonth(year: number, month: number): string {
+  return `${year}-${month.toString().padStart(2, "0")}`;
+}
+
+/**
+ * 収入・支出データをマージして MonthlyAggregation[] を生成する
+ *
+ * - 年月でグルーピング
+ * - yearMonth フォーマット変換
+ * - yearMonth でソート
+ *
+ * @param incomeData 収入の月別合計データ
+ * @param expenseData 支出の月別合計データ
+ * @returns マージ・ソート済みの月別収支集計データ
+ */
+export function aggregateFromTotals(
+  incomeData: MonthlyTransactionTotal[],
+  expenseData: MonthlyTransactionTotal[],
+): MonthlyAggregation[] {
+  const monthlyMap = new Map<string, MonthlyAggregation>();
+
+  for (const item of incomeData) {
+    const yearMonth = formatYearMonth(item.year, item.month);
+    if (!monthlyMap.has(yearMonth)) {
+      monthlyMap.set(yearMonth, { yearMonth, income: 0, expense: 0 });
+    }
+    const existing = monthlyMap.get(yearMonth);
+    if (existing) {
+      existing.income = item.totalAmount;
+    }
+  }
+
+  for (const item of expenseData) {
+    const yearMonth = formatYearMonth(item.year, item.month);
+    if (!monthlyMap.has(yearMonth)) {
+      monthlyMap.set(yearMonth, { yearMonth, income: 0, expense: 0 });
+    }
+    const existing = monthlyMap.get(yearMonth);
+    if (existing) {
+      existing.expense = item.totalAmount;
+    }
+  }
+
+  return Array.from(monthlyMap.values()).sort((a, b) => a.yearMonth.localeCompare(b.yearMonth));
 }

--- a/webapp/src/server/contexts/public-finance/domain/models/monthly-transaction-total.ts
+++ b/webapp/src/server/contexts/public-finance/domain/models/monthly-transaction-total.ts
@@ -1,0 +1,16 @@
+/**
+ * MonthlyTransactionTotal ドメインモデル
+ *
+ * SQLから返される月別合計を表す型。
+ * リポジトリ層からドメイン層へのデータ転送に使用する。
+ */
+
+/**
+ * 月別取引合計データ
+ * SQLの GROUP BY ... SUM() の結果を表現する
+ */
+export interface MonthlyTransactionTotal {
+  year: number;
+  month: number;
+  totalAmount: number;
+}

--- a/webapp/src/server/contexts/public-finance/domain/repositories/monthly-aggregation-repository.interface.ts
+++ b/webapp/src/server/contexts/public-finance/domain/repositories/monthly-aggregation-repository.interface.ts
@@ -1,20 +1,34 @@
-import type { MonthlyAggregation } from "@/server/contexts/public-finance/domain/models/monthly-aggregation";
+import type { MonthlyTransactionTotal } from "@/server/contexts/public-finance/domain/models/monthly-transaction-total";
 
 /**
  * 月別収支集計リポジトリインターフェース
  *
  * Interface Segregation Principle に基づき、
  * ITransactionRepository から月次集計機能を分離したインターフェース。
+ *
+ * 収入・支出を別々に取得するメソッドを提供し、
+ * マージ・ソートのドメインロジックはドメイン層に委譲する。
  */
 export interface IMonthlyAggregationRepository {
   /**
-   * 指定された組織IDと会計年度の月別収支集計を取得する
+   * 指定された組織IDと会計年度の月別収入合計を取得する
    * @param organizationIds 政治団体ID配列
    * @param financialYear 会計年度
-   * @returns 月別収支集計データの配列
+   * @returns 月別収入合計データの配列
    */
-  getByOrganizationIds(
+  getIncomeByOrganizationIds(
     organizationIds: string[],
     financialYear: number,
-  ): Promise<MonthlyAggregation[]>;
+  ): Promise<MonthlyTransactionTotal[]>;
+
+  /**
+   * 指定された組織IDと会計年度の月別支出合計を取得する
+   * @param organizationIds 政治団体ID配列
+   * @param financialYear 会計年度
+   * @returns 月別支出合計データの配列
+   */
+  getExpenseByOrganizationIds(
+    organizationIds: string[],
+    financialYear: number,
+  ): Promise<MonthlyTransactionTotal[]>;
 }

--- a/webapp/src/server/contexts/public-finance/infrastructure/repositories/prisma-monthly-aggregation.repository.ts
+++ b/webapp/src/server/contexts/public-finance/infrastructure/repositories/prisma-monthly-aggregation.repository.ts
@@ -1,79 +1,71 @@
 import "server-only";
 
 import { Prisma, type PrismaClient } from "@prisma/client";
-import type { MonthlyAggregation } from "@/server/contexts/public-finance/domain/models/monthly-aggregation";
+import type { MonthlyTransactionTotal } from "@/server/contexts/public-finance/domain/models/monthly-transaction-total";
 import type { IMonthlyAggregationRepository } from "@/server/contexts/public-finance/domain/repositories/monthly-aggregation-repository.interface";
 
 /**
  * Prisma を使用した月別収支集計リポジトリ実装
+ *
+ * SQLでの GROUP BY ... SUM() による集計のみを行い、
+ * マージ・ソートのドメインロジックはドメイン層に委譲する。
  */
 export class PrismaMonthlyAggregationRepository implements IMonthlyAggregationRepository {
   constructor(private prisma: PrismaClient) {}
 
-  async getByOrganizationIds(
+  async getIncomeByOrganizationIds(
     organizationIds: string[],
     financialYear: number,
-  ): Promise<MonthlyAggregation[]> {
+  ): Promise<MonthlyTransactionTotal[]> {
     const organizationIdsBigInt = organizationIds.map((id) => BigInt(id));
 
-    const [incomeResults, expenseResults] = await Promise.all([
-      this.prisma.$queryRaw<Array<{ year: bigint; month: bigint; total_amount: number }>>`
-        SELECT
-          EXTRACT(YEAR FROM transaction_date) as year,
-          EXTRACT(MONTH FROM transaction_date) as month,
-          SUM(credit_amount) as total_amount
-        FROM transactions
-        WHERE political_organization_id IN (${Prisma.join(organizationIdsBigInt)})
-          AND financial_year = ${financialYear}
-          AND transaction_type = 'income'
-        GROUP BY EXTRACT(YEAR FROM transaction_date), EXTRACT(MONTH FROM transaction_date)
-        ORDER BY year, month
-      `,
-      this.prisma.$queryRaw<Array<{ year: bigint; month: bigint; total_amount: number }>>`
-        SELECT
-          EXTRACT(YEAR FROM transaction_date) as year,
-          EXTRACT(MONTH FROM transaction_date) as month,
-          SUM(debit_amount) as total_amount
-        FROM transactions
-        WHERE political_organization_id IN (${Prisma.join(organizationIdsBigInt)})
-          AND financial_year = ${financialYear}
-          AND transaction_type = 'expense'
-        GROUP BY EXTRACT(YEAR FROM transaction_date), EXTRACT(MONTH FROM transaction_date)
-        ORDER BY year, month
-      `,
-    ]);
+    const results = await this.prisma.$queryRaw<
+      Array<{ year: bigint; month: bigint; total_amount: number }>
+    >`
+      SELECT
+        EXTRACT(YEAR FROM transaction_date) as year,
+        EXTRACT(MONTH FROM transaction_date) as month,
+        SUM(credit_amount) as total_amount
+      FROM transactions
+      WHERE political_organization_id IN (${Prisma.join(organizationIdsBigInt)})
+        AND financial_year = ${financialYear}
+        AND transaction_type = 'income'
+      GROUP BY EXTRACT(YEAR FROM transaction_date), EXTRACT(MONTH FROM transaction_date)
+      ORDER BY year, month
+    `;
 
-    // 年月別のマップを作成
-    const monthlyMap = new Map<string, { yearMonth: string; income: number; expense: number }>();
+    return results.map((item) => ({
+      year: Number(item.year),
+      month: Number(item.month),
+      totalAmount: Number(item.total_amount),
+    }));
+  }
 
-    // 収入データを追加
-    for (const item of incomeResults) {
-      const year = Number(item.year);
-      const month = Number(item.month);
-      const yearMonth = `${year}-${month.toString().padStart(2, "0")}`;
-      if (!monthlyMap.has(yearMonth)) {
-        monthlyMap.set(yearMonth, { yearMonth, income: 0, expense: 0 });
-      }
-      const existing = monthlyMap.get(yearMonth);
-      if (existing) {
-        existing.income = Number(item.total_amount);
-      }
-    }
+  async getExpenseByOrganizationIds(
+    organizationIds: string[],
+    financialYear: number,
+  ): Promise<MonthlyTransactionTotal[]> {
+    const organizationIdsBigInt = organizationIds.map((id) => BigInt(id));
 
-    // 支出データを追加
-    for (const item of expenseResults) {
-      const year = Number(item.year);
-      const month = Number(item.month);
-      const yearMonth = `${year}-${month.toString().padStart(2, "0")}`;
-      if (!monthlyMap.has(yearMonth)) {
-        monthlyMap.set(yearMonth, { yearMonth, income: 0, expense: 0 });
-      }
-      const existing = monthlyMap.get(yearMonth);
-      if (existing) {
-        existing.expense = Number(item.total_amount);
-      }
-    }
+    const results = await this.prisma.$queryRaw<
+      Array<{ year: bigint; month: bigint; total_amount: number }>
+    >`
+      SELECT
+        EXTRACT(YEAR FROM transaction_date) as year,
+        EXTRACT(MONTH FROM transaction_date) as month,
+        SUM(debit_amount) as total_amount
+      FROM transactions
+      WHERE political_organization_id IN (${Prisma.join(organizationIdsBigInt)})
+        AND financial_year = ${financialYear}
+        AND transaction_type = 'expense'
+      GROUP BY EXTRACT(YEAR FROM transaction_date), EXTRACT(MONTH FROM transaction_date)
+      ORDER BY year, month
+    `;
 
-    return Array.from(monthlyMap.values()).sort((a, b) => a.yearMonth.localeCompare(b.yearMonth));
+    return results.map((item) => ({
+      year: Number(item.year),
+      month: Number(item.month),
+      totalAmount: Number(item.total_amount),
+    }));
   }
 }

--- a/webapp/tests/server/contexts/public-finance/domain/models/monthly-aggregation.test.ts
+++ b/webapp/tests/server/contexts/public-finance/domain/models/monthly-aggregation.test.ts
@@ -1,8 +1,10 @@
 import {
   isValidYearMonthFormat,
   calculateBalance,
+  aggregateFromTotals,
   type MonthlyAggregation,
 } from "@/server/contexts/public-finance/domain/models/monthly-aggregation";
+import type { MonthlyTransactionTotal } from "@/server/contexts/public-finance/domain/models/monthly-transaction-total";
 
 describe("MonthlyAggregation domain model", () => {
   describe("isValidYearMonthFormat", () => {
@@ -63,6 +65,141 @@ describe("MonthlyAggregation domain model", () => {
         expense: 0,
       };
       expect(calculateBalance(aggregation)).toBe(0);
+    });
+  });
+
+  describe("aggregateFromTotals", () => {
+    it("should merge income and expense data for the same month", () => {
+      const incomeData: MonthlyTransactionTotal[] = [
+        { year: 2025, month: 1, totalAmount: 1000000 },
+        { year: 2025, month: 2, totalAmount: 800000 },
+      ];
+      const expenseData: MonthlyTransactionTotal[] = [
+        { year: 2025, month: 1, totalAmount: 500000 },
+        { year: 2025, month: 2, totalAmount: 600000 },
+      ];
+
+      const result = aggregateFromTotals(incomeData, expenseData);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        yearMonth: "2025-01",
+        income: 1000000,
+        expense: 500000,
+      });
+      expect(result[1]).toEqual({
+        yearMonth: "2025-02",
+        income: 800000,
+        expense: 600000,
+      });
+    });
+
+    it("should handle months with only income data", () => {
+      const incomeData: MonthlyTransactionTotal[] = [
+        { year: 2025, month: 1, totalAmount: 1000000 },
+        { year: 2025, month: 3, totalAmount: 500000 },
+      ];
+      const expenseData: MonthlyTransactionTotal[] = [
+        { year: 2025, month: 1, totalAmount: 300000 },
+      ];
+
+      const result = aggregateFromTotals(incomeData, expenseData);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        yearMonth: "2025-01",
+        income: 1000000,
+        expense: 300000,
+      });
+      expect(result[1]).toEqual({
+        yearMonth: "2025-03",
+        income: 500000,
+        expense: 0,
+      });
+    });
+
+    it("should handle months with only expense data", () => {
+      const incomeData: MonthlyTransactionTotal[] = [
+        { year: 2025, month: 1, totalAmount: 1000000 },
+      ];
+      const expenseData: MonthlyTransactionTotal[] = [
+        { year: 2025, month: 1, totalAmount: 300000 },
+        { year: 2025, month: 2, totalAmount: 200000 },
+      ];
+
+      const result = aggregateFromTotals(incomeData, expenseData);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        yearMonth: "2025-01",
+        income: 1000000,
+        expense: 300000,
+      });
+      expect(result[1]).toEqual({
+        yearMonth: "2025-02",
+        income: 0,
+        expense: 200000,
+      });
+    });
+
+    it("should sort results by yearMonth", () => {
+      const incomeData: MonthlyTransactionTotal[] = [
+        { year: 2025, month: 3, totalAmount: 300000 },
+        { year: 2025, month: 1, totalAmount: 100000 },
+      ];
+      const expenseData: MonthlyTransactionTotal[] = [
+        { year: 2025, month: 2, totalAmount: 200000 },
+      ];
+
+      const result = aggregateFromTotals(incomeData, expenseData);
+
+      expect(result).toHaveLength(3);
+      expect(result[0].yearMonth).toBe("2025-01");
+      expect(result[1].yearMonth).toBe("2025-02");
+      expect(result[2].yearMonth).toBe("2025-03");
+    });
+
+    it("should format yearMonth with zero-padded month", () => {
+      const incomeData: MonthlyTransactionTotal[] = [
+        { year: 2025, month: 1, totalAmount: 100000 },
+        { year: 2025, month: 12, totalAmount: 1200000 },
+      ];
+      const expenseData: MonthlyTransactionTotal[] = [];
+
+      const result = aggregateFromTotals(incomeData, expenseData);
+
+      expect(result[0].yearMonth).toBe("2025-01");
+      expect(result[1].yearMonth).toBe("2025-12");
+    });
+
+    it("should handle empty income and expense data", () => {
+      const result = aggregateFromTotals([], []);
+      expect(result).toEqual([]);
+    });
+
+    it("should handle data spanning multiple years", () => {
+      const incomeData: MonthlyTransactionTotal[] = [
+        { year: 2024, month: 12, totalAmount: 500000 },
+        { year: 2025, month: 1, totalAmount: 600000 },
+      ];
+      const expenseData: MonthlyTransactionTotal[] = [
+        { year: 2024, month: 12, totalAmount: 200000 },
+        { year: 2025, month: 1, totalAmount: 300000 },
+      ];
+
+      const result = aggregateFromTotals(incomeData, expenseData);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        yearMonth: "2024-12",
+        income: 500000,
+        expense: 200000,
+      });
+      expect(result[1]).toEqual({
+        yearMonth: "2025-01",
+        income: 600000,
+        expense: 300000,
+      });
     });
   });
 });


### PR DESCRIPTION
# refactor: 月別集計リポジトリのドメインロジックをドメイン層に移行

## Summary

設計ドキュメント `docs/20260102_0954_月別集計リポジトリのドメインロジック移行設計.md` に従い、`PrismaMonthlyAggregationRepository` に埋め込まれていたドメインロジック（収入・支出データのマージ、yearMonthフォーマット変換、ソート）をドメイン層に移行しました。

**変更内容:**
- `MonthlyTransactionTotal` ドメインモデルを新規作成（SQLの生データを表現）
- `MonthlyAggregation` に `aggregateFromTotals()` 関数を追加
- `IMonthlyAggregationRepository` を `getIncomeByOrganizationIds` / `getExpenseByOrganizationIds` に分割
- リポジトリ実装からマージ・ソート処理を削除し、SQLの結果をそのまま返すように変更
- Usecaseでドメインモデルを使用して集計を実行

**期待される効果:**
- `aggregateFromTotals` は純粋関数としてユニットテスト可能
- リポジトリはデータ取得のみ、ロジックはドメイン層という責務分離
- Usecaseのシグネチャは不変（外部APIへの影響なし）

## Review & Testing Checklist for Human

- [ ] `aggregateFromTotals` のマージロジックが元の実装と同等か確認（特に同一月の収入・支出が正しくマージされるか）
- [ ] 月別トレンドチャートの表示が正常に動作するか実際のUIで確認

### Test Plan
1. ローカル環境で `pnpm supabase:start` → `pnpm dev` を実行
2. webapp (http://localhost:3000) で政治団体ページにアクセス
3. 月別トレンドチャート（MonthlyTrendsSection）が正しく表示されることを確認

### Notes
- Link to Devin run: https://app.devin.ai/sessions/10847d1c69694453b1152232bcd87e2c
- Requested by: jun.ito@team-mir.ai (@jujunjun110)