### PR TITLE
docs: 貸借対照表DDDリファクタリング設計（Phase 2）

### DIFF
--- a/docs/20260102_1001_貸借対照表DDDリファクタリング設計.md
+++ b/docs/20260102_1001_貸借対照表DDDリファクタリング設計.md
@@ -187,17 +187,39 @@ export interface IBalanceSheetRepository {
 
 admin の `prisma-report-transaction.repository.ts` と同様に、`shared/accounting/account-category.ts` をSSOTとして参照する。
 
-現在の実装では `creditAccount` / `debitAccount` フィールド（勘定科目名）を使用しているため、`PL_CATEGORIES` のキー（日本語の勘定科目名）を定数化する。
+##### categoryKey と creditAccount / debitAccount の関係
+
+Transactionテーブルには以下の2系統のフィールドがある：
+
+| フィールド | 値の形式 | 例 | 用途 |
+|-----------|---------|-----|------|
+| `creditAccount` / `debitAccount` | 日本語の勘定科目名 | "借入金", "普通預金" | 複式簿記の貸方/借方勘定 |
+| `categoryKey` | 英語キー | "loans", "utilities" | UIカテゴリ表示用 |
+
+`PL_CATEGORIES` の構造：
+```typescript
+"借入金": {           // ← キー = 日本語科目名 = creditAccount/debitAccount に格納される値
+  key: "loans",       // ← categoryKey に格納される値
+  category: "借入金",
+  type: "income"
+}
+```
+
+##### 定数定義
 
 ```typescript
 // infrastructure/repositories/prisma-balance-sheet.repository.ts
 
 import { PL_CATEGORIES, BS_CATEGORIES } from "@/shared/accounting/account-category";
 
-// 勘定科目名定数（shared/accounting/account-category.ts のキーを参照）
-// PL_CATEGORIESのキーは日本語の勘定科目名そのもの
+// 勘定科目名定数（PL_CATEGORIESのキーから取得）
+// creditAccount / debitAccount でのクエリに使用
 const ACCOUNT_NAMES = {
-  LOAN: "借入金" as const,  // PL_CATEGORIESのキーと一致
+  // Object.keys(PL_CATEGORIES) から "借入金" を取得する形で参照
+  // ただし TypeScript の型安全性のため、明示的に定義
+  LOAN: Object.keys(PL_CATEGORIES).find(
+    (key) => PL_CATEGORIES[key].key === "loans"
+  ) as string,  // → "借入金"
 } as const;
 
 // 負債勘定リスト（BS_CATEGORIESから抽出）
@@ -207,7 +229,10 @@ const LIABILITY_ACCOUNTS = Object.keys(BS_CATEGORIES).filter(
 // 結果: ["未払金/未払費用"]
 ```
 
-**補足**: `PL_CATEGORIES` のキーは日本語の勘定科目名であり、これが `creditAccount` / `debitAccount` に格納される値と一致する。`BS_CATEGORIES` も同様に日本語キーを使用している。
+**設計判断**:
+- `PL_CATEGORIES` の英語キー（`key` プロパティ）から逆引きして日本語科目名を取得
+- これにより、英語キーをSSOTとして、日本語科目名のハードコーディングを回避
+- `BS_CATEGORIES` は日本語キーのみ持つため、`Object.keys()` で直接取得
 
 #### リポジトリ実装
 


### PR DESCRIPTION
## Summary

- 開発者が貸借対照表のビジネスロジックをテストしづらい状態を解消するための設計ドキュメント
- webapp DDDリファクタリングのPhase 2として、貸借対照表機能のドメインモデル化を設計
- `categoryKey` と `creditAccount`/`debitAccount` の関係を明確化し、SSOT参照方針を策定

## Test plan

- [ ] 設計ドキュメントのレビュー
- [ ] admin-architecture-guide.md との整合性確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 貸借対照表機能の内部アーキテクチャを再構成しました。コード構造を改善し、長期的な保守性と拡張性を向上させました。ユーザーの操作や機能に変更はありません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->