### PR TITLE
docs: 取引一覧DDDリファクタリング設計（Phase 4）

### DIFF
--- a/docs/20260102_1034_取引一覧DDDリファクタリング設計.md
+++ b/docs/20260102_1034_取引一覧DDDリファクタリング設計.md
@@ -1,0 +1,251 @@
+# 取引一覧 DDD リファクタリング設計（Phase 4）
+
+## 目的
+
+**開発者が**、取引一覧機能のコードを理解・変更しやすくするため。
+
+現状の課題:
+- `utils/transaction-converter.ts` にドメインロジック（Transaction → DisplayTransaction 変換）が配置されている
+- UseCase が utils の関数に依存しており、レイヤー構造が不明確
+
+---
+
+## 現状分析
+
+### 対象コード
+
+| ファイル | 役割 |
+|---|---|
+| `server/usecases/get-transactions-by-slug-usecase.ts` | ページネーション付き取引一覧取得 |
+| `server/usecases/get-all-transactions-by-slug-usecase.ts` | 全件取引取得（CSV出力用） |
+| `server/utils/transaction-converter.ts` | Transaction → DisplayTransaction 変換 |
+| `types/display-transaction.ts` | DisplayTransaction 型定義 |
+
+### 現状のデータフロー
+
+```
+Loader
+  → UseCase
+      → ITransactionRepository.findWithPagination()
+      → convertToDisplayTransactions() ← utils/transaction-converter.ts
+  → DisplayTransaction[]
+```
+
+### 変換ロジックの責務
+
+`transaction-converter.ts` には以下のロジックがある:
+
+1. **年月フォーマット**: `transaction_date` から `"YYYY.MM"` 形式の `yearmonth` を生成
+2. **アカウント判定**: `transaction_type` に基づき `debit_account` or `credit_account` を選択
+3. **カテゴリマッピング**: `PL_CATEGORIES` を参照して `category`, `subcategory`, `shortLabel` を取得
+4. **金額計算**: `absAmount`（絶対値）と `amount`（支出時はマイナス）を計算
+5. **offset警告**: `offset_income`/`offset_expense` が渡された場合に警告を出力
+
+---
+
+## リファクタリング方針
+
+### ドメインモデル: DisplayTransaction
+
+`DisplayTransaction` は「表示用取引データ」を表すドメインモデルとして位置づける。
+
+- **型定義**: `contexts/public-finance/domain/models/display-transaction.ts`
+- **変換ロジック**: 同ファイル内の純粋関数として実装
+- **外部依存なし**: `PL_CATEGORIES` の参照は許容（shared からの import）
+
+**ドメインサービスは不要**: 単一エンティティ（Transaction）から単一エンティティ（DisplayTransaction）への変換であり、複数エンティティにまたがるロジックではないため。
+
+### リポジトリ: Interface Segregation
+
+現在の `ITransactionRepository` から取引一覧取得に必要なメソッドのみを持つインターフェースを分離する。
+
+```
+ITransactionListRepository
+  - findWithPagination()
+  - findAll()
+  - getLastUpdatedAt()
+```
+
+既存の `PrismaTransactionRepository` がこのインターフェースを実装する形とし、実装クラスは増やさない。
+
+---
+
+## 新規ファイル構成
+
+```
+webapp/src/server/contexts/public-finance/
+├── domain/
+│   ├── models/
+│   │   └── display-transaction.ts     # 新規: 型定義 + 変換関数
+│   └── repositories/
+│       └── transaction-list-repository.interface.ts  # 新規
+├── application/
+│   └── usecases/
+│       ├── get-transactions-by-slug-usecase.ts      # 移動
+│       └── get-all-transactions-by-slug-usecase.ts  # 移動
+└── infrastructure/
+    └── repositories/
+        # 既存の PrismaTransactionRepository に ITransactionListRepository を実装させる
+```
+
+---
+
+## 実装詳細
+
+### 1. ドメインモデル: display-transaction.ts
+
+```typescript
+// webapp/src/server/contexts/public-finance/domain/models/display-transaction.ts
+
+/**
+ * 表示用取引タイプ（offset系は除外）
+ */
+export type DisplayTransactionType = "income" | "expense";
+
+/**
+ * 表示用取引データ
+ */
+export interface DisplayTransaction {
+  id: string;
+  date: Date;
+  yearmonth: string;
+  transactionType: DisplayTransactionType;
+  category: string;
+  subcategory?: string;
+  account: string;
+  label: string;
+  shortLabel: string;
+  friendly_category: string;
+  absAmount: number;
+  amount: number;
+}
+
+// 変換関数群（純粋関数）
+// - formatYearMonth(date: Date): string
+// - getAccountFromTransaction(transaction: Transaction): string
+// - calculateDisplayAmount(transaction: Transaction): { absAmount: number; amount: number }
+// - convertToDisplayTransaction(transaction: Transaction): DisplayTransaction
+// - convertToDisplayTransactions(transactions: Transaction[]): DisplayTransaction[]
+```
+
+### 2. リポジトリインターフェース: transaction-list-repository.interface.ts
+
+```typescript
+// webapp/src/server/contexts/public-finance/domain/repositories/transaction-list-repository.interface.ts
+
+import type { Transaction } from "@/shared/models/transaction";
+import type { TransactionFilters } from "@/types/transaction-filters";
+
+export interface PaginatedResult<T> {
+  items: T[];
+  total: number;
+  page: number;
+  perPage: number;
+  totalPages: number;
+}
+
+export interface PaginationOptions {
+  page: number;
+  perPage: number;
+  sortBy?: "date" | "amount";
+  order?: "asc" | "desc";
+}
+
+export interface SortOptions {
+  sortBy?: "date" | "amount";
+  order?: "asc" | "desc";
+}
+
+/**
+ * 取引一覧取得用リポジトリインターフェース
+ * Interface Segregation Principle に基づき分離
+ */
+export interface ITransactionListRepository {
+  findWithPagination(
+    filters?: TransactionFilters,
+    pagination?: PaginationOptions,
+  ): Promise<PaginatedResult<Transaction>>;
+
+  findAll(
+    filters?: TransactionFilters,
+    sortOptions?: SortOptions,
+  ): Promise<Transaction[]>;
+
+  getLastUpdatedAt(): Promise<Date | null>;
+}
+```
+
+### 3. UseCase の移動と更新
+
+**移動元**: `server/usecases/get-transactions-by-slug-usecase.ts`
+**移動先**: `contexts/public-finance/application/usecases/get-transactions-by-slug-usecase.ts`
+
+変更点:
+- import パスを contexts 配下のドメインモデルに変更
+- `ITransactionRepository` を `ITransactionListRepository` に変更
+- `convertToDisplayTransactions` を `domain/models/display-transaction.ts` から import
+
+### 4. 既存 PrismaTransactionRepository の更新
+
+`ITransactionListRepository` を追加で実装する:
+
+```typescript
+export class PrismaTransactionRepository
+  implements ITransactionRepository, ITransactionListRepository {
+  // 既存実装を維持
+}
+```
+
+---
+
+## テスト計画
+
+### 移行するテスト
+
+| 現在のパス | 移行先 |
+|---|---|
+| `tests/server/utils/transaction-converter.test.ts` | `tests/server/contexts/public-finance/domain/models/display-transaction.test.ts` |
+| `tests/server/usecases/get-transactions-by-slug-usecase.test.ts` | `tests/server/contexts/public-finance/application/usecases/get-transactions-by-slug-usecase.test.ts` |
+
+### 新規テスト
+
+- `ITransactionListRepository` のモックを使用した UseCase テスト
+
+---
+
+## Loader の更新
+
+既存の Loader ファイルは位置を変えず、import パスのみ更新:
+
+```typescript
+// server/loaders/load-transactions-page-data.ts
+
+// Before
+import { GetTransactionsBySlugUsecase } from "@/server/usecases/get-transactions-by-slug-usecase";
+
+// After
+import { GetTransactionsBySlugUsecase } from "@/server/contexts/public-finance/application/usecases/get-transactions-by-slug-usecase";
+```
+
+---
+
+## 削除対象
+
+リファクタリング完了後に削除:
+
+- `server/utils/transaction-converter.ts`
+- `server/usecases/get-transactions-by-slug-usecase.ts`
+- `server/usecases/get-all-transactions-by-slug-usecase.ts`
+- `types/display-transaction.ts`（domain/models に統合）
+- `tests/server/utils/transaction-converter.test.ts`
+
+---
+
+## チェックリスト
+
+- [ ] 既存のテストが通ること
+- [ ] import パスがすべて `@/` から始まる絶対パスであること
+- [ ] `server-only` が適切なファイルに含まれていること
+- [ ] ドメインモデルが外部依存（Prisma等）を持たないこと
+- [ ] Loader が UseCase のみを呼び出していること
+- [ ] `PL_CATEGORIES` への依存は shared からの import であること


### PR DESCRIPTION
## 目的

開発者が、取引一覧機能のコードを理解・変更しやすくするため。

## 概要

webapp DDD リファクタリング Phase 4（取引一覧）の設計ドキュメントを追加。

### 設計のポイント

- `utils/transaction-converter.ts` の変換ロジックを `domain/models/display-transaction.ts` に移動
- `ITransactionRepository` から `ITransactionListRepository` を分離（Interface Segregation）
- UseCase を contexts 配下に移動
- ドメインサービスは不要（単一エンティティの変換のみ）

### 追加ドキュメント

- `docs/20260102_1034_取引一覧DDDリファクタリング設計.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * 取引一覧機能の内部構造を改善し、より堅牢で保守性の高いアーキテクチャに統一しました。ユーザーの操作性に変わりはありません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->