### PR TITLE
docs: Playwright E2Eテスト導入設計ドキュメントを追加

### DIFF
--- a/docs/20260102_1047_Playwright_E2Eテスト導入設計.md
+++ b/docs/20260102_1047_Playwright_E2Eテスト導入設計.md
@@ -1,0 +1,231 @@
+# Playwright E2Eテスト導入設計（admin）
+
+## 目的
+
+**開発者が、参照漏れやページ表示のリグレッションに気づかずにリリースしてしまう状態を解消するため。**
+
+具体的には以下を検証可能にする：
+- ログイン・認証フローが正常に動作すること
+- 各ページが正しく表示されること（参照漏れによる500エラーがないこと）
+- Seedデータに基づく期待値が画面上に表示されること（合計金額など）
+
+---
+
+## スコープ
+
+### 対象
+- admin アプリ（`http://localhost:3001`）
+
+### 今回のスコープ外
+- webapp アプリ（将来的に同様の構成で追加可能）
+
+---
+
+## テスト方針
+
+### 1. テストの種類
+
+| テスト種別 | 目的 | 例 |
+|-----------|------|-----|
+| Smoke Test | 全ページが500エラーなく表示されること | 各ページへのアクセス確認 |
+| 認証テスト | ログイン/ログアウトが正常に動作すること | foo@example.comでログイン成功 |
+| データ表示テスト | Seedデータに基づく値が表示されること | 取引一覧の合計金額が一致 |
+
+### 2. テスト実行環境
+
+```
+[Playwright] → [Next.js dev server (localhost:3001)]
+                        ↓
+              [Supabase (localhost:54321)]
+                        ↓
+              [PostgreSQL + Seed Data]
+```
+
+- ローカル開発環境のSupabase + Seedデータを使用
+- テスト前に `pnpm db:reset` でデータを初期化
+
+### 3. 認証の扱い
+
+Playwrightの `storageState` を使用して認証状態を保持：
+
+1. `setup` プロジェクトでログインを実行
+2. 認証Cookie/LocalStorageを `.auth/user.json` に保存
+3. 他のテストは保存された認証状態を再利用
+
+---
+
+## ディレクトリ構成
+
+```
+admin/
+├── e2e/
+│   ├── tests/
+│   │   ├── auth.setup.ts      # 認証セットアップ（ログイン）
+│   │   ├── smoke.spec.ts      # 全ページのSmoke Test
+│   │   ├── login.spec.ts      # ログイン機能のテスト
+│   │   └── transactions.spec.ts  # 取引ページのデータ表示テスト
+│   ├── fixtures/
+│   │   └── test-base.ts       # カスタムfixtureの定義
+│   └── .auth/                 # 認証状態の保存先（.gitignore）
+├── playwright.config.ts       # Playwright設定
+└── package.json               # playwright依存追加
+```
+
+---
+
+## テスト対象ページ
+
+現在のadminアプリのページ構成に基づく：
+
+### 認証不要（public）
+| パス | 説明 |
+|------|------|
+| `/login` | ログインページ |
+| `/forgot-password` | パスワードリセット |
+| `/auth/setup` | 初期設定 |
+| `/auth/reset-password` | パスワード再設定 |
+
+### 認証必要（auth）
+| パス | 説明 | データ検証対象 |
+|------|------|---------------|
+| `/` | ダッシュボード | - |
+| `/transactions` | 取引一覧 | 取引件数、合計金額 |
+| `/balance-snapshots` | 残高登録 | - |
+| `/counterparts` | 取引先一覧 | 取引先件数 |
+| `/counterparts/[id]` | 取引先詳細 | - |
+| `/donors` | 寄付者一覧 | - |
+| `/political-organizations` | 政治団体一覧 | 団体名表示 |
+| `/political-organizations/new` | 政治団体新規作成 | - |
+| `/political-organizations/[orgId]` | 政治団体詳細 | - |
+| `/political-organizations/[orgId]/report-profile` | 報告書プロファイル | - |
+| `/upload-csv` | CSVアップロード | - |
+| `/assign/counterparts` | 取引先割り当て | - |
+| `/assign/donors` | 寄付者割り当て | - |
+| `/export-report` | レポート出力 | - |
+| `/export-report/[orgId]/[year]` | レポート出力（年次） | - |
+| `/users` | ユーザー一覧 | - |
+| `/user-info` | ユーザー情報 | - |
+
+---
+
+## Seedデータを用いた検証
+
+### 検証可能なデータ例（`prisma/seeds/`より）
+
+| データ | Seed内容 | 検証内容 |
+|--------|----------|----------|
+| ユーザー | foo@example.com (admin), bar@example.com (user) | ログイン成功確認 |
+| 取引 | 複数の収入・支出データ | 取引一覧に表示、合計金額の一致 |
+| 政治団体 | サンプル党本部など | 団体名の表示確認 |
+
+---
+
+## 設定ファイル
+
+### playwright.config.ts の主要設定
+
+| 設定項目 | 値 | 説明 |
+|----------|-----|------|
+| baseURL | `http://localhost:3001` | adminのベースURL |
+| testDir | `./e2e/tests` | テストファイルの配置場所 |
+| webServer | `pnpm dev:admin` | テスト前に自動起動 |
+| projects | setup, chromium | 認証セットアップ + ブラウザテスト |
+| retries | 2 (CI時) | 不安定なテストへの対応 |
+| use.trace | `on-first-retry` | 失敗時のデバッグ用トレース |
+
+### webServerオプション
+
+```
+webServer: {
+  command: 'pnpm dev:admin',
+  url: 'http://localhost:3001',
+  reuseExistingServer: !process.env.CI,
+  timeout: 120 * 1000,
+}
+```
+
+- ローカル: 既存サーバーを再利用
+- CI: 新規サーバーを起動
+
+---
+
+## package.json への追加
+
+### 依存パッケージ
+- `@playwright/test`: E2Eテストフレームワーク
+
+### npm scripts
+| コマンド | 説明 |
+|----------|------|
+| `test:e2e` | E2Eテスト実行（ヘッドレス） |
+| `test:e2e:ui` | PlaywrightのUI モードで実行（デバッグ用） |
+| `test:e2e:headed` | ブラウザを表示して実行 |
+
+---
+
+## CI/CD統合
+
+### GitHub Actions の追加ジョブ
+
+E2Eテストは既存のユニットテストとは別ジョブとして追加する：
+
+1. Supabaseのセットアップ（supabase-cliを使用）
+2. データベースマイグレーション + Seed投入
+3. adminアプリのビルド・起動
+4. Playwrightテスト実行
+
+### 依存サービス
+
+```yaml
+services:
+  # Supabase CLIを使用してローカルと同様の環境を構築
+```
+
+### 成果物の保存
+- テストレポート（HTML）
+- 失敗時のスクリーンショット
+- トレースファイル
+
+---
+
+## ローカル開発時の実行フロー
+
+```bash
+# 1. 開発環境の準備（初回のみ）
+pnpm dev:setup
+
+# 2. データベースの初期化（テスト前）
+pnpm db:reset
+
+# 3. E2Eテストの実行
+cd admin
+pnpm test:e2e        # ヘッドレスで実行
+pnpm test:e2e:ui     # UIモードで実行（デバッグ時推奨）
+```
+
+---
+
+## 今後の拡張（参考）
+
+webapp への展開時は同様の構成で追加可能：
+
+```
+webapp/
+├── e2e/
+│   ├── tests/
+│   └── .auth/
+└── playwright.config.ts
+```
+
+---
+
+## チェックリスト
+
+実装時に確認すべき項目：
+
+- [ ] `@playwright/test` がadminのdevDependenciesに追加されている
+- [ ] `playwright.config.ts` がadminディレクトリに存在する
+- [ ] `e2e/tests/` にテストファイルが配置されている
+- [ ] `.gitignore` に `.auth/` と `playwright-report/` が追加されている
+- [ ] `pnpm test:e2e` コマンドが動作する
+- [ ] CI用のワークフローが追加されている


### PR DESCRIPTION
## 目的

**開発者が、参照漏れやページ表示のリグレッションに気づかずにリリースしてしまう状態を解消するため。**

## 概要

adminアプリにPlaywright E2Eテストを導入するための設計ドキュメントです。

### テストの種類
- **Smoke Test**: 全ページが500エラーなく表示されること
- **認証テスト**: ログイン/ログアウトが正常動作すること
- **データ表示テスト**: Seedデータに基づく値が画面に表示されること

### 主な設計ポイント
- `admin/e2e/tests/` にテストファイルを配置
- Playwrightの `storageState` で認証状態を保持・再利用
- `pnpm test:e2e` で実行
- GitHub ActionsにE2E用ジョブを追加

## Test plan

- [ ] 設計ドキュメントの内容をレビュー
- [ ] 設計が承認されたら実装に着手

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * E2Eテスト導入設計に関するドキュメントを追加しました。テスト戦略、環境構築手順、CI/CD統合についての詳細な設計仕様を記載しています。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->