### PR TITLE
fix: CIの重複実行を解消

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,6 @@
 name: CI
 
 on:
-  push:
-    paths:
-      - 'admin/**'
-      - 'webapp/**'
-      - 'packages/**'
-      - 'prisma/**'
-      - '.dependency-cruiser.cjs'
-      - 'pnpm-lock.yaml'
   pull_request:
     paths:
       - 'admin/**'


### PR DESCRIPTION
## 目的

開発者がPRを作成・更新するたびにCIが2回実行される無駄を解消するため。

## 変更内容

- CIワークフローから `push` トリガーを削除
- `pull_request` トリガーのみを残す

## 背景

`push` と `pull_request` の両方がトリガーに設定されていたため、PRを作成すると同じCIが2回実行されていた。

`pull_request` イベントはデフォルトで `synchronize` アクティビティにも反応するため、PRへの追加プッシュ時もCIは問題なく実行される。

## Test plan

- [x] PRを作成してCIが1回だけ実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)