### PR TITLE
feat(webapp): E2Eテストの仕組みを導入

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,6 +200,9 @@ importers:
         specifier: 19.1.4
         version: 19.1.4(react@19.1.4)
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.57.0
+        version: 1.57.0
       '@tailwindcss/postcss':
         specifier: ^4.1.12
         version: 4.1.13

--- a/webapp/e2e/tests/privacy.spec.ts
+++ b/webapp/e2e/tests/privacy.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("プライバシーポリシーページ", () => {
+	test("プライバシーポリシーページが正常に表示される", async ({ page }) => {
+		const response = await page.goto("/privacy");
+
+		expect(response?.status()).toBe(200);
+		await expect(page).toHaveTitle(/みらい まる見え政治資金/);
+	});
+});

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -15,6 +15,7 @@
     "react-dom": "19.1.4"
   },
   "devDependencies": {
+    "@playwright/test": "^1.57.0",
     "@tailwindcss/postcss": "^4.1.12",
     "@types/jest": "^29.5.14",
     "@types/node": "^20",
@@ -27,6 +28,7 @@
     "typescript": "^5"
   },
   "scripts": {
+    "postinstall": "pnpm exec playwright install chromium",
     "dev": "next dev --turbopack",
     "build": "cd ../ && prisma generate && prisma migrate deploy && cd webapp && next build",
     "start": "next start",
@@ -35,6 +37,9 @@
     "format": "biome check --write .",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui --ui-host=0.0.0.0",
+    "test:e2e:headed": "playwright test --headed"
   }
 }

--- a/webapp/playwright.config.ts
+++ b/webapp/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e/tests",
+  outputDir: "./e2e/.output/test-results",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: [["html", { outputFolder: "./e2e/.output/report" }]],
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: process.env.CI ? "pnpm start --port 3000" : "pnpm dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+});


### PR DESCRIPTION
## Summary

管理画面(admin)のE2Eテスト構成を参考に、webappにもPlaywrightを使用したE2Eテストの仕組みを導入しました。

**変更内容:**
- `playwright.config.ts` を追加（adminと同様の構成、ポートは3000を使用）
- プライバシーポリシーページ(`/privacy`)の基本的なE2Eテストを追加
- `package.json` にPlaywright依存関係とE2Eテスト用スクリプトを追加

## Review & Testing Checklist for Human

- [ ] **CIでE2Eテストが実行されるか確認** - webappのE2Eテストを実行するためのCI設定が必要な可能性があります。adminのCI設定を参考に追加が必要かもしれません
- [ ] **ローカルでのテスト実行** - DATABASE_URLが設定された環境で `cd webapp && pnpm run test:e2e` を実行し、テストがパスすることを確認してください
- [ ] **postinstallスクリプトの影響確認** - `pnpm install` 時にChromiumがインストールされるようになります

### Notes

ローカルでのE2Eテスト実行はDATABASE_URLが必要なため（Headerコンポーネントがorganizationsをロードするため）、ローカルでの動作確認はできていません。CIでデータベースが設定されている環境での実行を想定しています。

---
**Link to Devin run:** https://app.devin.ai/sessions/0d868730ef474a96baebb0589ae97937
**Requested by:** jun.ito@team-mir.ai (@jujunjun110)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * Privacy Policyページのエンドツーエンドテストを追加しました。
  * テスト実行環境をセットアップしました。
  * テスト実行用の新しいコマンドを追加しました（test:e2e、test:e2e:ui、test:e2e:headed）。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->