### PR TITLE
test(admin): E2Eテスト作成 - ダッシュボードページ #999

### DIFF
--- a/admin/e2e/tests/dashboard.spec.ts
+++ b/admin/e2e/tests/dashboard.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("ダッシュボード", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto("/login");
+		await page.getByLabel("Email").fill("foo@example.com");
+		await page.getByLabel("Password").fill("foo@example.com");
+		await page.getByRole("button", { name: "ログイン" }).click();
+		await expect(page).toHaveURL("/");
+	});
+
+	test.describe("読み込み", () => {
+		test("ログイン後にダッシュボードが正常に表示される", async ({ page }) => {
+			await expect(page.getByRole("heading", { name: "Welcome" })).toBeVisible();
+		});
+
+		test("Welcomeメッセージが表示される", async ({ page }) => {
+			await expect(page.getByText("Use the left navigation to manage data.")).toBeVisible();
+		});
+	});
+});


### PR DESCRIPTION
## Summary

admin管理画面のダッシュボードページ（`/`）に対するE2Eテストを追加しました。

Issue #999 の要件に従い、以下のテストを実装:
- ログイン後にダッシュボードが正常に表示されるテスト
- Welcomeメッセージが表示されるテスト

既存の `political-organizations.spec.ts` のログインパターンを参考に、`.claude/commands/e2e.md` のルールに従ったセレクタ（`getByRole`, `getByLabel`, `getByText`）を使用しています。

## Review & Testing Checklist for Human

- [ ] CIのE2Eテストが正常にパスすることを確認
- [ ] `h1` 要素が `heading` ロールとして正しく認識されているか確認（`getByRole("heading", { name: "Welcome" })`）

### 推奨テスト手順
```bash
cd admin && pnpm test:e2e --grep "ダッシュボード"
```

### Notes
- Closes #999
- Link to Devin run: https://app.devin.ai/sessions/1b6604799cb94429bb88bb616a92e2c7
- Requested by: jun.ito@team-mir.ai (@jujunjun110)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## テスト

* **テスト**
  * ダッシュボード機能のエンドツーエンド自動テストを追加しました。ログイン認証、ダッシュボード画面の表示、ウェルカムメッセージと案内テキストの確認が含まれます。これにより、ユーザーの操作フローが正常に機能していることを継続的に検証できます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->