### PR TITLE
test(admin): 取引先マスタページのE2Eテストを追加

### DIFF
--- a/admin/e2e/tests/counterparts.spec.ts
+++ b/admin/e2e/tests/counterparts.spec.ts
@@ -1,0 +1,114 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("取引先マスタ管理", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto("/login");
+		await page.getByLabel("Email").fill("foo@example.com");
+		await page.getByLabel("Password").fill("foo@example.com");
+		await page.getByRole("button", { name: "ログイン" }).click();
+		await expect(page).toHaveURL("/");
+	});
+
+	test.describe("読み込み", () => {
+		test("取引先マスタページが正常に表示される", async ({ page }) => {
+			await page.goto("/counterparts");
+
+			await expect(page.getByRole("heading", { name: "取引先マスタ管理" })).toBeVisible();
+			await expect(page.getByRole("button", { name: "新規作成" })).toBeVisible();
+		});
+
+		test("シードデータの取引先が一覧に表示される", async ({ page }) => {
+			await page.goto("/counterparts");
+
+			await expect(page.getByRole("link", { name: "寄附　太郎" })).toBeVisible();
+			await expect(page.getByRole("link", { name: "東京電力株式会社" })).toBeVisible();
+		});
+
+		test("検索フォームが表示される", async ({ page }) => {
+			await page.goto("/counterparts");
+
+			await expect(
+				page.getByLabel("取引先を名前または住所で検索")
+			).toBeVisible();
+			await expect(page.getByRole("button", { name: "検索" })).toBeVisible();
+		});
+
+		test("テーブルヘッダーが正しく表示される", async ({ page }) => {
+			await page.goto("/counterparts");
+
+			await expect(page.getByRole("columnheader", { name: "名前" })).toBeVisible();
+			await expect(page.getByRole("columnheader", { name: "住所" })).toBeVisible();
+			await expect(page.getByRole("columnheader", { name: "使用数" })).toBeVisible();
+			await expect(page.getByRole("columnheader", { name: "操作" })).toBeVisible();
+		});
+
+		test("取引先の件数が表示される", async ({ page }) => {
+			await page.goto("/counterparts");
+
+			await expect(page.getByText(/\d+件の取引先/)).toBeVisible();
+		});
+	});
+
+	test.describe("書き込み", () => {
+		test("新規取引先を作成できる", async ({ page }) => {
+			await page.goto("/counterparts");
+
+			await page.getByRole("button", { name: "新規作成" }).click();
+
+			await expect(page.getByRole("heading", { name: "新規取引先作成" })).toBeVisible();
+
+			const uniqueName = `テスト取引先 ${Date.now()}`;
+			const postalCode = "123-4567";
+			const address = "東京都テスト区テスト町1-2-3";
+
+			// ダイアログ内のフォームフィールドを特定するため、getByRole('textbox')を使用
+			await page.getByRole("textbox", { name: /^名前/ }).fill(uniqueName);
+			await page.getByRole("textbox", { name: "郵便番号" }).fill(postalCode);
+			await page.getByRole("textbox", { name: "住所" }).fill(address);
+
+			await page.getByRole("button", { name: "作成" }).click();
+
+			await expect(page.getByRole("link", { name: uniqueName })).toBeVisible();
+		});
+
+		test("検索機能が正常に動作する", async ({ page }) => {
+			await page.goto("/counterparts");
+
+			await expect(page.getByRole("link", { name: "東京電力株式会社" })).toBeVisible();
+			await expect(page.getByRole("link", { name: "寄附　太郎" })).toBeVisible();
+
+			await page.getByLabel("取引先を名前または住所で検索").fill("東京電力");
+			await page.getByRole("button", { name: "検索" }).click();
+
+			// URLエンコードされた日本語を確認
+			await expect(page).toHaveURL(/q=/);
+			await expect(page.getByRole("link", { name: "東京電力株式会社" })).toBeVisible();
+			await expect(page.getByRole("link", { name: "寄附　太郎" })).not.toBeVisible();
+		});
+
+		test("検索をクリアできる", async ({ page }) => {
+			await page.goto("/counterparts?q=東京電力");
+
+			await expect(page.getByRole("button", { name: "クリア" })).toBeVisible();
+			await page.getByRole("button", { name: "クリア" }).click();
+
+			await expect(page).toHaveURL("/counterparts");
+			await expect(page.getByRole("link", { name: "寄附　太郎" })).toBeVisible();
+		});
+
+		test("名前が空の場合は作成ボタンが無効になる", async ({ page }) => {
+			await page.goto("/counterparts");
+
+			await page.getByRole("button", { name: "新規作成" }).click();
+
+			await expect(page.getByRole("heading", { name: "新規取引先作成" })).toBeVisible();
+
+			const createButton = page.getByRole("button", { name: "作成" });
+			await expect(createButton).toBeDisabled();
+
+			// ダイアログ内のフォームフィールドを特定するため、getByRole('textbox')を使用
+			await page.getByRole("textbox", { name: /^名前/ }).fill("テスト");
+			await expect(createButton).toBeEnabled();
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Issue #1001 に対応し、admin管理画面の取引先マスタページ（`/counterparts`）に対するE2Eテストを追加しました。

**読み込みテスト（5件）:**
- ページが正常に表示される
- シードデータの取引先が一覧に表示される
- 検索フォームが表示される
- テーブルヘッダーが正しく表示される
- 取引先の件数が表示される

**書き込みテスト（4件）:**
- 新規取引先を作成できる（ダイアログから作成）
- 検索機能が正常に動作する
- 検索をクリアできる
- 名前が空の場合は作成ボタンが無効になる

ローカルで全9テストがパスすることを確認済みです。

## Review & Testing Checklist for Human

- [ ] CIでE2Eテストが正常にパスするか確認（ローカルでは19.8秒で全9テスト成功）
- [ ] `getByRole("textbox", { name: /^名前/ })` のセレクタが適切か確認（検索フォームとダイアログ内フォームの両方に「名前」が含まれるため、正規表現で区別）
- [ ] ページネーションテストが含まれていない点について確認（シードデータが45件でperPage=50のため、ページネーションUIが表示されない）

**推奨テスト手順:**
1. `pnpm supabase:start` でSupabaseを起動
2. `pnpm db:migrate && pnpm db:seed` でDBをセットアップ
3. `cd admin && pnpm test:e2e --grep "取引先"` でテスト実行

### Notes

- `.claude/commands/e2e.md` のルールに従い、`getByRole`, `getByLabel`, `getByText` を優先して使用
- 既存の `political-organizations.spec.ts` のパターンを参考に実装
- 検索URLの確認は日本語がURLエンコードされるため `/q=/` のみで確認

---
**Link to Devin run:** https://app.devin.ai/sessions/bb07a008bdcf4645bc550c3f5b34f8a4
**Requested by:** jun.ito@team-mir.ai (@jujunjun110)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * 取引先マスタ管理画面の包括的なエンドツーエンドテストスイートを追加しました。ページの表示、検索、新規作成、フォーム検証などの動作確認を強化しています。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->