### PR TITLE
test(admin): E2Eテスト作成 - ユーザー情報ページ

### DIFF
--- a/admin/e2e/tests/user-info.spec.ts
+++ b/admin/e2e/tests/user-info.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("ユーザー情報", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto("/login");
+		await page.getByLabel("Email").fill("foo@example.com");
+		await page.getByLabel("Password").fill("foo@example.com");
+		await page.getByRole("button", { name: "ログイン" }).click();
+		await expect(page).toHaveURL("/");
+	});
+
+	test.describe("読み込み", () => {
+		test("ユーザー情報ページが正常に表示される", async ({ page }) => {
+			await page.goto("/user-info");
+
+			await expect(page.getByRole("heading", { name: "ユーザー情報" })).toBeVisible();
+		});
+
+		test("ログイン中のユーザーのメールアドレスが表示される", async ({ page }) => {
+			await page.goto("/user-info");
+
+			await expect(page.getByText("foo@example.com")).toBeVisible();
+		});
+
+		test("ロール情報が表示される", async ({ page }) => {
+			await page.goto("/user-info");
+
+			await expect(page.getByText("ロール:")).toBeVisible();
+		});
+
+		test("作成日が表示される", async ({ page }) => {
+			await page.goto("/user-info");
+
+			await expect(page.getByText("作成日:")).toBeVisible();
+		});
+	});
+});

--- a/admin/playwright.config.ts
+++ b/admin/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   ],
   webServer: {
     command: process.env.CI ? "pnpm start --port 3001" : "pnpm dev",
-    url: "http://localhost:3001",
+    url: "http://localhost:3001/login",
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,
   },


### PR DESCRIPTION
## Summary

Issue #1003 に対応し、admin管理画面のユーザー情報ページ（`/user-info`）のE2Eテストを作成しました。

**追加したテスト:**
- ユーザー情報ページが正常に表示される
- ログイン中のユーザーのメールアドレスが表示される
- ロール情報が表示される
- 作成日が表示される

**Playwright設定の修正:**
- 健全性チェックURLを `/` から `/login` に変更（認証不要ページを使用することでタイムアウトを回避）

## Review & Testing Checklist for Human

- [ ] Playwright設定変更（`/login`への変更）が既存のE2Eテストに影響を与えていないか確認（ローカルで `pnpm test:e2e` を実行）
- [ ] テストのセレクタが適切か確認（`getByText("ロール:")` などの部分一致が将来のUI変更で壊れる可能性）

### テスト実行方法
```bash
cd admin
pnpm test:e2e --grep "ユーザー情報"
```

### Notes

- ローカルでの動作確認済み（4テスト全てパス）
- 既存の政治団体管理テストも引き続きパスすることを確認済み

Link to Devin run: https://app.devin.ai/sessions/1effe6ea0e344397aad04c5b24a47273
Requested by: jun.ito@team-mir.ai (@jujunjun110)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * ユーザー情報ページのエンドツーエンドテストスイートを追加しました。

* **その他**
  * テスト環境の構成を更新しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->