### PR TITLE
feat(admin): add E2E tests for transactions list page

### DIFF
--- a/admin/e2e/tests/transactions.spec.ts
+++ b/admin/e2e/tests/transactions.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("取引一覧", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto("/login");
+		await page.getByLabel("Email").fill("foo@example.com");
+		await page.getByLabel("Password").fill("foo@example.com");
+		await page.getByRole("button", { name: "ログイン" }).click();
+		await expect(page).toHaveURL("/");
+	});
+
+	test.describe("読み込み", () => {
+		test("取引一覧ページが正常に表示される", async ({ page }) => {
+			await page.goto("/transactions");
+
+			await expect(page.getByRole("heading", { name: "取引一覧" })).toBeVisible();
+			await expect(page.getByRole("combobox")).toBeVisible();
+		});
+
+		test("政治団体セレクターが表示される", async ({ page }) => {
+			await page.goto("/transactions");
+
+			const selector = page.getByRole("combobox");
+			await expect(selector).toBeVisible();
+
+			await selector.click();
+			await expect(page.getByRole("option", { name: "サンプル党" })).toBeVisible();
+		});
+
+		test("シードデータの取引が一覧に表示される", async ({ page }) => {
+			await page.goto("/transactions");
+
+			await expect(page.getByRole("heading", { name: "取引一覧" })).toBeVisible();
+
+			await page.waitForSelector("table");
+
+			const table = page.locator("table");
+			await expect(table).toBeVisible();
+
+			await expect(table.getByRole("columnheader", { name: "取引日" })).toBeVisible();
+			await expect(table.getByRole("columnheader", { name: "政治団体" })).toBeVisible();
+			await expect(table.getByRole("columnheader", { name: "借方勘定科目" })).toBeVisible();
+			await expect(table.getByRole("columnheader", { name: "借方金額" })).toBeVisible();
+			await expect(table.getByRole("columnheader", { name: "貸方勘定科目" })).toBeVisible();
+			await expect(table.getByRole("columnheader", { name: "貸方金額" })).toBeVisible();
+			await expect(table.getByRole("columnheader", { name: "種別" })).toBeVisible();
+			await expect(table.getByRole("columnheader", { name: "カテゴリ" })).toBeVisible();
+
+			const rows = table.locator("tbody tr");
+			await expect(rows).not.toHaveCount(0);
+		});
+
+		test("ページネーションが機能する", async ({ page }) => {
+			await page.goto("/transactions");
+
+			await page.waitForSelector("table");
+
+			const paginationInfo = page.getByText(/全 \d+ 件中/);
+			await expect(paginationInfo).toBeVisible();
+
+			const pagination = page.locator("nav[aria-label='pagination']");
+			if (await pagination.isVisible()) {
+				const nextButton = pagination.getByRole("link", { name: /次/ });
+				if (await nextButton.isVisible()) {
+					await nextButton.click();
+					await expect(page).toHaveURL(/page=2/);
+				}
+			}
+		});
+	});
+});


### PR DESCRIPTION
# feat(admin): add E2E tests for transactions list page

## Summary

Adds E2E tests for the admin `/transactions` page as requested in issue #1000. The test file includes 4 load tests covering:

1. **Page displays correctly** - Verifies the "取引一覧" heading and combobox selector are visible
2. **Political organization selector works** - Verifies the combobox displays and shows "サンプル党" option when clicked
3. **Seed data transactions display** - Verifies the table renders with correct column headers and contains transaction rows
4. **Pagination info displays** - Verifies pagination information text is visible

Tests follow the existing patterns from `political-organizations.spec.ts` and the E2E guidelines in `.claude/commands/e2e.md`.

## Review & Testing Checklist for Human

- [ ] Verify CI E2E tests pass (tests were verified locally with `CI=true pnpm test:e2e --grep "取引"`)
- [ ] Confirm the 4 test cases adequately cover the requirements from issue #1000
- [ ] Check that selectors (`getByRole("combobox")`, `getByRole("heading")`, etc.) are robust and follow E2E guidelines

**Recommended test plan:**
1. Run `cd admin && pnpm test:e2e --grep "取引"` locally to verify tests pass
2. Review the test file to ensure it matches the existing test patterns

### Notes

Closes #1000

**Link to Devin run:** https://app.devin.ai/sessions/3194642042954adc83391e52badba3ae
**Requested by:** jun.ito@team-mir.ai (@jujunjun110)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * 取引一覧ページの自動テストスイートを追加。ページロード検証、データテーブルの表示確認、ページネーション動作の検証を含みます。品質保証を強化しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->