### PR TITLE
chore: remove deprecated baseUrl option from tsconfig.json

### DIFF
--- a/admin/tsconfig.json
+++ b/admin/tsconfig.json
@@ -18,7 +18,6 @@
         "name": "next"
       }
     ],
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "@/shared/*": ["../shared/*"]

--- a/webapp/tsconfig.json
+++ b/webapp/tsconfig.json
@@ -18,7 +18,6 @@
         "name": "next"
       }
     ],
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "@/shared/*": ["../shared/*"]


### PR DESCRIPTION
## Summary

- admin/webapp両方のtsconfig.jsonから非推奨の`baseUrl`オプションを削除

## 目的

TypeScript 7.0で削除予定の非推奨オプション（`baseUrl`）による警告を解消するため。

TypeScript 5.0以降、`paths`オプションは`baseUrl`なしで動作するようになったため、`baseUrl`は不要になりました。

## Test plan

- [x] `pnpm typecheck` が通ることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * TypeScript設定ファイルを更新し、インポート解決の設定を最適化しました。

---

注：このリリースは主に内部の構成変更です。エンドユーザーに対する直接的な影響はありません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->