### PR TITLE
fix: 月次収支グラフでデータがない月も表示するように修正

### DIFF
--- a/webapp/src/server/contexts/public-finance/application/usecases/get-monthly-aggregation-usecase.ts
+++ b/webapp/src/server/contexts/public-finance/application/usecases/get-monthly-aggregation-usecase.ts
@@ -53,7 +53,7 @@ export class GetMonthlyAggregationUsecase {
         ),
       ]);
 
-      const monthlyData = aggregateFromTotals(incomeData, expenseData);
+      const monthlyData = aggregateFromTotals(incomeData, expenseData, params.financialYear);
 
       return { monthlyData };
     } catch (error) {

--- a/webapp/src/server/contexts/public-finance/domain/models/monthly-aggregation.ts
+++ b/webapp/src/server/contexts/public-finance/domain/models/monthly-aggregation.ts
@@ -48,36 +48,41 @@ function formatYearMonth(year: number, month: number): string {
 /**
  * 収入・支出データをマージして MonthlyAggregation[] を生成する
  *
+ * - 会計年度の全12ヶ月分のデータを生成（データがない月は収支0として補完）
  * - 年月でグルーピング
  * - yearMonth フォーマット変換
  * - yearMonth でソート
  *
  * @param incomeData 収入の月別合計データ
  * @param expenseData 支出の月別合計データ
- * @returns マージ・ソート済みの月別収支集計データ
+ * @param financialYear 会計年度（指定した年の1月〜12月の全月データを生成）
+ * @returns マージ・ソート済みの月別収支集計データ（12ヶ月分）
  */
 export function aggregateFromTotals(
   incomeData: MonthlyTransactionTotal[],
   expenseData: MonthlyTransactionTotal[],
+  financialYear: number,
 ): MonthlyAggregation[] {
   const monthlyMap = new Map<string, MonthlyAggregation>();
 
+  // 会計年度の全12ヶ月分を初期化（データがない月も収支0として含める）
+  for (let month = 1; month <= 12; month++) {
+    const yearMonth = formatYearMonth(financialYear, month);
+    monthlyMap.set(yearMonth, { yearMonth, income: 0, expense: 0 });
+  }
+
+  // 収入データをマージ
   for (const item of incomeData) {
     const yearMonth = formatYearMonth(item.year, item.month);
-    if (!monthlyMap.has(yearMonth)) {
-      monthlyMap.set(yearMonth, { yearMonth, income: 0, expense: 0 });
-    }
     const existing = monthlyMap.get(yearMonth);
     if (existing) {
       existing.income = item.totalAmount;
     }
   }
 
+  // 支出データをマージ
   for (const item of expenseData) {
     const yearMonth = formatYearMonth(item.year, item.month);
-    if (!monthlyMap.has(yearMonth)) {
-      monthlyMap.set(yearMonth, { yearMonth, income: 0, expense: 0 });
-    }
     const existing = monthlyMap.get(yearMonth);
     if (existing) {
       existing.expense = item.totalAmount;

--- a/webapp/tests/server/usecases/get-monthly-aggregation-usecase.test.ts
+++ b/webapp/tests/server/usecases/get-monthly-aggregation-usecase.test.ts
@@ -51,11 +51,28 @@ describe("GetMonthlyAggregationUsecase", () => {
       financialYear: 2025,
     });
 
-    expect(result.monthlyData).toHaveLength(3);
+    // 全12ヶ月分が返される
+    expect(result.monthlyData).toHaveLength(12);
     expect(result.monthlyData[0]).toEqual({
       yearMonth: "2025-01",
       income: 1000000,
       expense: 500000,
+    });
+    expect(result.monthlyData[1]).toEqual({
+      yearMonth: "2025-02",
+      income: 800000,
+      expense: 600000,
+    });
+    expect(result.monthlyData[2]).toEqual({
+      yearMonth: "2025-03",
+      income: 1200000,
+      expense: 400000,
+    });
+    // データがない月は収支0
+    expect(result.monthlyData[3]).toEqual({
+      yearMonth: "2025-04",
+      income: 0,
+      expense: 0,
     });
     expect(mockPoliticalOrganizationRepository.findBySlugs).toHaveBeenCalledWith(["test-org"]);
     expect(mockMonthlyAggregationRepository.getIncomeByOrganizationIds).toHaveBeenCalledWith(
@@ -106,7 +123,13 @@ describe("GetMonthlyAggregationUsecase", () => {
       financialYear: 2025,
     });
 
-    expect(result.monthlyData).toHaveLength(1);
+    // 全12ヶ月分が返される
+    expect(result.monthlyData).toHaveLength(12);
+    expect(result.monthlyData[0]).toEqual({
+      yearMonth: "2025-01",
+      income: 2000000,
+      expense: 1000000,
+    });
     expect(mockMonthlyAggregationRepository.getIncomeByOrganizationIds).toHaveBeenCalledWith(
       ["1", "2"],
       2025,
@@ -135,7 +158,14 @@ describe("GetMonthlyAggregationUsecase", () => {
       financialYear: 2025,
     });
 
-    expect(result.monthlyData).toEqual([]);
+    // 全12ヶ月分が収支0で返される
+    expect(result.monthlyData).toHaveLength(12);
+    for (const item of result.monthlyData) {
+      expect(item.income).toBe(0);
+      expect(item.expense).toBe(0);
+    }
+    expect(result.monthlyData[0].yearMonth).toBe("2025-01");
+    expect(result.monthlyData[11].yearMonth).toBe("2025-12");
   });
 
   it("should handle different financial years", async () => {
@@ -162,7 +192,19 @@ describe("GetMonthlyAggregationUsecase", () => {
       financialYear: 2024,
     });
 
-    expect(result.monthlyData).toHaveLength(1);
+    // 全12ヶ月分が返される
+    expect(result.monthlyData).toHaveLength(12);
+    expect(result.monthlyData[3]).toEqual({
+      yearMonth: "2024-04",
+      income: 500000,
+      expense: 300000,
+    });
+    // データがない月は収支0
+    expect(result.monthlyData[0]).toEqual({
+      yearMonth: "2024-01",
+      income: 0,
+      expense: 0,
+    });
     expect(mockMonthlyAggregationRepository.getIncomeByOrganizationIds).toHaveBeenCalledWith(
       ["1"],
       2024,


### PR DESCRIPTION
## 目的

ユーザーが月次収支グラフを見たときに、レコードがない月（10月、11月など）が表示されないと収支の推移が分かりにくい状態を解消するため。

## 変更内容

- `aggregateFromTotals` 関数に `financialYear` パラメータを追加
- 会計年度の全12ヶ月分のデータを生成するように変更
- データがない月は `income: 0, expense: 0` として補完

## 変更ファイル

- `webapp/src/server/contexts/public-finance/domain/models/monthly-aggregation.ts`
- `webapp/src/server/contexts/public-finance/application/usecases/get-monthly-aggregation-usecase.ts`
- テストファイル（2ファイル）

## テスト計画

- [x] 全12ヶ月分が返されることを確認するテスト追加
- [x] データがない月は収支0で補完されることを確認するテスト追加
- [x] 既存テストが通ること

Closes #804

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 月別収支集計の会計年度ごとの処理を改善。指定した会計年度の全12ヶ月データを確実に取得できるようになりました。データが存在しない月は自動的に収支0として補完されます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->