### PR TITLE
docs: 寄付者CSVインポート確定フェーズの設計ドキュメントを追加

### DIFF
--- a/docs/20260102_2322_寄付者CSVインポート確定フェーズ設計.md
+++ b/docs/20260102_2322_寄付者CSVインポート確定フェーズ設計.md
@@ -19,7 +19,7 @@
 │  1. ユーザーが「インポート実行」ボタンをクリック                      │
 │  2. クライアントからサーバーアクションを呼び出し                      │
 │     - 再度CSV内容をパース＆バリデーション                            │
-│     - 全行がvalidかを確認                                          │
+│     - valid行のみを抽出                                            │
 │  3. Donorの作成または既存Donor検索                                  │
 │     - matchingDonor がある行: 既存Donorを使用                       │
 │     - matchingDonor がない行: 新規Donor作成                         │
@@ -102,7 +102,8 @@ client/components/donor-csv-import/
 
 サーバーアクションとして以下を実行：
 
-1. リクエストの受け取り（File, politicalOrganizationId）
+1. リクエストの受け取り（csvContent: string, politicalOrganizationId: string）
+   - **注意**: File オブジェクトはサーバーアクションでシリアライズ不可のため、クライアント側で `file.text()` により string に変換してから渡す
 2. ImportDonorCsvUsecase の呼び出し
 3. 成功時: `revalidatePath("/import/donors")` でキャッシュ無効化
 4. エラーハンドリング: ユーザーフレンドリーなメッセージに変換
@@ -137,11 +138,12 @@ interface ImportDonorCsvOutput {
 1. PreviewDonorCsvUsecase と同様のパース＆バリデーション
 2. valid行が0件の場合は例外をスロー
 3. valid行のみを抽出してインポート対象とする
-4. 新規Donorの一括作成
+4. 同一 transaction_no の重複解決（後勝ち）
+5. 新規Donorの一括作成
    - matchingDonor がない行を抽出
    - 重複を除去（同一CSV内で同じ name + address + donorType がある場合）
    - IDonorRepository.create() で作成
-5. TransactionDonorの一括紐付け
+6. TransactionDonorの一括紐付け
    - ITransactionDonorRepository.replaceMany() を使用
    - 既存の紐付けは置換される
 
@@ -153,12 +155,27 @@ interface ImportDonorCsvOutput {
 - IDonorRepository
 - ITransactionDonorRepository
 
-### 4.3 Client層（DonorCsvImportClient.tsx / DonorCsvPreview.tsx）
+### 4.3 Domain層
+
+本機能で使用するドメインモデルとドメインサービスは、既存の実装を再利用する。
+
+**使用するドメインモデル:**
+- `Donor`: 寄付者エンティティ（name + address + donorType で同一人物を識別）
+- `PreviewDonorCsvRow`: CSVプレビュー行の値オブジェクト（status, errors, matchingDonor を保持）
+
+**ドメイン不変条件:**
+- Donor の一意性: name + address + donorType の組み合わせで一意
+- TransactionDonor: 1つの Transaction に対して1つの Donor のみ紐付け可能
+
+**ドメインサービス（既存を再利用）:**
+- `DonorCsvValidator`: CSV行のバリデーション、カテゴリとdonorTypeの整合性チェック
+
+### 4.4 Client層（DonorCsvImportClient.tsx / DonorCsvPreview.tsx）
 
 DonorCsvPreview に以下を追加：
 - インポートボタン（件数表示付き）
 - ローディング状態の管理
-- インポートアクションの呼び出し
+- インポートアクションの呼び出し（File → string 変換後に呼び出し）
 - toast通知の表示
 
 DonorCsvImportClient に以下を追加：
@@ -175,6 +192,19 @@ DonorCsvImportClient に以下を追加：
 **方針: 後勝ち**
 
 同一のtransaction_noが複数行ある場合、最後の行で上書きする。
+
+**処理順序:**
+1. CSVをパースして全行を取得
+2. transaction_no でグループ化し、同一 transaction_no の行は最後の行のみを残す（後勝ち）
+3. 残った行に対して Donor の重複除去を実施
+
+**具体例:**
+```
+CSV行1: transaction_no=001, name=山田太郎, donorType=individual
+CSV行2: transaction_no=001, name=山田花子, donorType=individual  ← この行が採用される（後勝ち）
+CSV行3: transaction_no=002, name=山田太郎, donorType=individual
+```
+結果: transaction_no=001 は「山田花子」、transaction_no=002 は「山田太郎」で紐付け
 
 理由:
 - ユーザーがCSVを編集して再アップロードする際、末尾に修正行を追加するケースが多い
@@ -197,19 +227,61 @@ DonorCsvImportClient に以下を追加：
 
 ## 6. エラーハンドリング
 
-| エラー種別 | Presentation層での対応 |
-|-----------|----------------------|
-| バリデーションエラー（invalid行あり） | `{ ok: false, error: "CSVにエラーがあります。プレビューを確認してください" }` |
-| DB保存エラー | `{ ok: false, error: "データベースへの保存に失敗しました。時間をおいて再試行してください" }` |
-| 予期しないエラー | `{ ok: false, error: "予期しないエラーが発生しました" }` |
+### 6.1 例外型とエラーマッピング
+
+| 例外型 | 発生箇所 | Presentation層での対応 |
+|--------|---------|----------------------|
+| `NoValidRowsError` | Usecase | `{ ok: false, error: "インポート可能な行がありません" }` |
+| `CsvFormatError` | Infrastructure | `{ ok: false, error: "CSVファイルの形式が正しくありません" }` |
+| `PrismaClientKnownRequestError` | Repository | `{ ok: false, error: "データベースへの保存に失敗しました。時間をおいて再試行してください" }` |
+| `Error`（その他） | 任意 | `{ ok: false, error: "予期しないエラーが発生しました" }` |
+
+### 6.2 Presentation層のエラーハンドリングパターン
+
+```typescript
+try {
+  const result = await usecase.execute(input);
+  revalidatePath("/import/donors");
+  return { ok: true, ...result };
+} catch (error) {
+  if (error instanceof NoValidRowsError) {
+    return { ok: false, error: "インポート可能な行がありません" };
+  }
+  if (error instanceof CsvFormatError) {
+    return { ok: false, error: "CSVファイルの形式が正しくありません" };
+  }
+  // DB関連エラー
+  if (error instanceof Error && error.message.includes("database")) {
+    return { ok: false, error: "データベースへの保存に失敗しました。時間をおいて再試行してください" };
+  }
+  return { ok: false, error: "予期しないエラーが発生しました" };
+}
+```
 
 ---
 
-## 7. E2Eテスト
+## 7. テスト
+
+### 7.1 Unit テスト（ImportDonorCsvUsecase）
+
+ファイル: `admin/src/server/contexts/report/application/usecases/__tests__/import-donor-csv-usecase.test.ts`
+
+**テストケース:**
+- 正常系: valid行のみインポートされる
+- 正常系: 新規Donorが作成される
+- 正常系: 既存Donorが再利用される（matchingDonor あり）
+- 後勝ち: 同一transaction_noは最後の行が採用される
+- 重複除去: 同一Donor（name + address + donorType）は1回のみ作成
+- エラー: valid行が0件の場合は例外
+- エラー: 5000行超過時は例外
+
+**モック:**
+- IDonorCsvLoader, IDonorCsvRecordConverter, IDonorCsvValidator
+- IDonorRepository, ITransactionDonorRepository, ITransactionWithDonorRepository
+
+### 7.2 E2Eテスト
 
 既存のE2Eテストファイル（`admin/e2e/tests/import-donors.spec.ts`）に以下のテストケースを追加する。
-
-### 7.1 追加するテストケース
 
 **インポートボタンの表示**
 - 1件以上がvalidの場合、インポートボタンが有効になる
@@ -220,7 +292,7 @@ DonorCsvImportClient に以下を追加：
 - インポート成功後、ファイル入力がリセットされる
 - インポート成功後、プレビューが消える
 
-### 7.2 テストデータ
+### 7.3 テストデータ
 
 既存のサンプルCSV（`data/sample_donor_import.csv`）を使用。必要に応じて、全件validなテスト用CSVを追加する。
 
@@ -234,4 +306,5 @@ DonorCsvImportClient に以下を追加：
 - [ ] toast通知が成功/失敗で適切に表示される
 - [ ] ファイル入力がインポート成功後にリセットされる
 - [ ] 5000行制限のバリデーションが機能している
+- [ ] Unit テストが全て通る
 - [ ] E2Eテストが全て通る


### PR DESCRIPTION
## Summary

- 寄付者CSVインポートの「インポート確定フェーズ」の設計ドキュメントを追加
- プレビュー後のインポートボタン、サーバーアクション、toast通知の設計を記載
- E2Eテストの方針も含む

## 目的

管理者が1000件以上の寄付者情報を1件ずつ手動入力する必要がある困りごとを解消するため

## 設計の要点

- インポートボタン: 全件validの場合のみ有効化
- toast通知: sonnerを使用した成功/失敗通知
- アーキテクチャ: reportコンテキストに新規Usecaseとサーバーアクションを追加
- 考慮事項: 重複transaction_noは後勝ち、1000行制限

## Test plan

- [ ] 設計ドキュメントのレビュー

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 寄付者CSVインポートの「確定」フェーズ設計ドキュメントを追加しました。確定後の取り込みフロー、UI挙動（インポートボタンの有効化/無効化・件数表示・処理中の状態）、トーストによる成功/失敗通知、検証ルール、重複処理方針（最終書き込み優先）、既存紐付けの置換、行数上限などを詳細に記載しています。
* **Tests**
  * 想定されるE2Eテスト案を含めています。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->