### PR TITLE
docs: E2E CI並列ビルドのためのコマンド分離設計

### DIFF
--- a/docs/20260103_1006_E2E-CI並列ビルドのためのコマンド分離.md
+++ b/docs/20260103_1006_E2E-CI並列ビルドのためのコマンド分離.md
@@ -1,0 +1,137 @@
+# E2E CI 並列ビルドのためのコマンド分離設計
+
+## 目的
+
+**CIのE2Eテストジョブが、ビルド時にデータベース接続エラーで失敗している状態を解消するため**
+
+現在、`webapp/package.json` の `build` スクリプトに `prisma migrate deploy` が含まれており、CIのE2Eジョブでは Supabase 起動前にビルドが開始されるため、データベース接続エラー（`P1001: Can't reach database server`）が発生している。
+
+## 現状の問題
+
+### webapp の build スクリプト
+
+```json
+"build": "cd ../ && prisma generate && prisma migrate deploy && cd webapp && next build"
+```
+
+このスクリプトには以下が含まれている：
+1. `prisma generate` - Prisma クライアント生成（DB接続不要、postinstall で実行済み）
+2. `prisma migrate deploy` - マイグレーション適用（**DB接続が必要、ビルドの責務ではない**）
+3. `next build` - Next.js ビルド（DB接続不要）
+
+**問題点：** ビルドコマンドにマイグレーションが混在しており、責務が分離されていない。
+
+### CI の E2E ジョブ（ci.yml 250-280行目）
+
+```yaml
+- name: Start Supabase and build in parallel
+  run: |
+    # Start Supabase in background
+    supabase start --exclude imgproxy,edge-runtime,vector,studio &
+    SUPABASE_PID=$!
+
+    # Build admin and webapp in parallel
+    pnpm build:admin &
+    pnpm build:webapp &  # ← ここで prisma migrate deploy が実行される
+
+    # Wait for builds to complete
+    wait $ADMIN_PID
+    wait $WEBAPP_PID
+
+    # Wait for Supabase to complete
+    wait $SUPABASE_PID
+```
+
+**問題点：** Supabase（DB）の起動完了を待たずにビルドを開始しているため、`prisma migrate deploy` が DB に接続できず失敗する。
+
+## 設計方針
+
+### 責務の分離
+
+ビルドとマイグレーションは別の責務であり、分離すべき。
+
+| 責務 | コマンド | 実行タイミング |
+|------|----------|----------------|
+| Prisma クライアント生成 | `prisma generate` | `postinstall` で自動実行 |
+| DB マイグレーション | `prisma migrate deploy` | デプロイパイプラインで明示的に実行 |
+| Next.js ビルド | `next build` | ビルド時 |
+
+### 変更対象ファイル
+
+1. **webapp/package.json**
+   - `build`: `next build` のみに変更
+
+2. **ルート package.json**
+   - `db:migrate:deploy`: 既存（変更なし）
+
+3. **.github/workflows/ci.yml**
+   - 変更なし（既存の `db:migrate:deploy` ステップでマイグレーション実行）
+
+4. **Vercel の設定**
+   - ビルドコマンド: `next build`（変更なし or 確認）
+   - マイグレーション: Vercel の prebuild フックまたは別途実行
+
+## 変更内容の詳細
+
+### 1. webapp/package.json
+
+**変更前:**
+```json
+{
+  "scripts": {
+    "build": "cd ../ && prisma generate && prisma migrate deploy && cd webapp && next build"
+  }
+}
+```
+
+**変更後:**
+```json
+{
+  "scripts": {
+    "build": "next build"
+  }
+}
+```
+
+### 2. CI フロー（変更なし）
+
+現行のCIフローは以下のようになり、正しく動作する：
+
+1. Supabase 起動開始（バックグラウンド）
+2. `pnpm build:admin` と `pnpm build:webapp` を並列実行（両方 DB 接続不要）
+3. Supabase 起動完了を待機
+4. `pnpm db:migrate:deploy` でマイグレーション適用
+5. `pnpm db:seed` でシードデータ投入
+6. E2E テスト実行
+
+### 3. Vercel 設定
+
+**webapp/vercel.json を作成:**
+
+```json
+{
+  "buildCommand": "pnpm run build:vercel"
+}
+```
+
+**webapp/package.json に追加:**
+
+```json
+{
+  "scripts": {
+    "build:vercel": "pnpm run db:setup && pnpm run build",
+    "db:setup": "prisma generate && prisma migrate deploy"
+  }
+}
+```
+
+参考: [Prisma - Deploy to Vercel](https://www.prisma.io/docs/orm/prisma-client/deployment/serverless/deploy-to-vercel)
+
+## 影響範囲
+
+| 対象 | 影響 |
+|------|------|
+| CI E2E ジョブ | ビルドが並列実行可能になり、DB 接続エラーが解消される |
+| ローカル開発 | 変更なし（`pnpm dev` は Supabase 起動後に実行される） |
+| Vercel デプロイ | `vercel-build` でマイグレーション込みのビルドが実行される |
+| admin | 変更なし（元々 `next build` のみ） |


### PR DESCRIPTION
## 目的

CIのE2Eテストジョブが、ビルド時にデータベース接続エラー（`P1001: Can't reach database server`）で失敗している状態を解消するため。

## 問題

現在の `webapp/package.json` の `build` スクリプトに `prisma migrate deploy` が含まれており、CIのE2Eジョブでは Supabase 起動前にビルドが開始されるため、DB接続エラーが発生している。

## 解決策

1. `webapp/package.json` の `build` を `next build` のみに変更
2. Vercel デプロイ用に `build:vercel` と `db:setup` コマンドを追加
3. `webapp/vercel.json` で Vercel ビルド時は `build:vercel` を使用するよう設定

## 変更内容

設計ドキュメントのみ（実装は別PRで行う）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI/CDパイプラインを改善し、ビルドとデータベースマイグレーションの責任を分離しました。これにより、並列ビルドが可能になり、デプロイメント時の接続エラーが減少します。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->