### PR TITLE
docs: 寄付者CSVインポート設計にN+1回避・トランザクション整合性の詳細を追加

### DIFF
--- a/docs/20260102_2322_寄付者CSVインポート確定フェーズ設計.md
+++ b/docs/20260102_2322_寄付者CSVインポート確定フェーズ設計.md
@@ -194,7 +194,7 @@ for (const row of validRows) {
   transactionDonorPairs.push({ transactionId: row.transactionId, donorId });
 }
 
-// 2. upsert（Prisma制約によりN回実行、ただしトランザクション内）
+// 2. バルクupsert（Raw SQL INSERT ... ON CONFLICT により1クエリで実行）
 await transactionDonorRepository.bulkUpsert(transactionDonorPairs);
 ```
 
@@ -314,34 +314,6 @@ interface ITransactionDonorRepository {
 Prismaには `upsertMany` が存在しないため、PostgreSQLの `INSERT ... ON CONFLICT` を使用して1クエリで処理する。
 5000件を個別upsertすると5000クエリ発生し、レイテンシ・タイムアウトのリスクがあるため、Raw SQLを採用する。
 
-```typescript
-async bulkUpsert(
-  pairs: { transactionId: string; donorId: string }[],
-  tx?: PrismaTransactionClient
-): Promise<void> {
-  if (pairs.length === 0) return;
-
-  const client = tx ?? this.prisma;
-
-  // VALUES句を構築（パラメータ化クエリでSQLインジェクション対策）
-  const values = pairs
-    .map((_, i) => `($${i * 2 + 1}::text, $${i * 2 + 2}::text)`)
-    .join(', ');
-  const params = pairs.flatMap(p => [p.transactionId, p.donorId]);
-
-  await client.$executeRawUnsafe(`
-    INSERT INTO "TransactionDonor" ("transactionId", "donorId", "createdAt", "updatedAt")
-    VALUES ${values.replace(/\$(\d+)::text, \$(\d+)::text/g,
-      (_, p1, p2) => `$${p1}::text, $${p2}::text, NOW(), NOW()`)}
-    ON CONFLICT ("transactionId")
-    DO UPDATE SET
-      "donorId" = EXCLUDED."donorId",
-      "updatedAt" = NOW()
-  `, ...params);
-}
-```
-
-より読みやすい実装:
 ```typescript
 async bulkUpsert(
   pairs: { transactionId: string; donorId: string }[],


### PR DESCRIPTION
## 目的

実装エージェントがN+1問題やトランザクション整合性を考慮せずに実装してしまう問題を解消するため、設計書を改善した。

## Summary

- トランザクション境界の設計を明確化（Donor作成とTransactionDonor紐付けを同一トランザクション内で実行）
- `IDonorRepository.createMany` のバルクインサート仕様を追加
- `ITransactionDonorRepository.bulkUpsert` のRaw SQL実装（`INSERT ... ON CONFLICT`）を追加
- `ITransactionManager` インターフェースを追加
- クエリ数見積もりを追加（5000件でも2クエリ）
- チェックリストにトランザクション・N+1関連項目を追加

## 主な変更点

### N+1問題の回避
| 処理 | クエリ数 | 備考 |
|------|---------|------|
| Donor一括作成 | 1 | createManyAndReturn |
| TransactionDonor upsert | 1 | Raw SQL `INSERT ... ON CONFLICT` |
| **合計** | **2** | 5000件でも2クエリ |

### トランザクション整合性
- Donor作成とTransactionDonor紐付けを同一トランザクション内で実行
- 失敗時は全変更がロールバック

## Test plan

- [ ] 設計書の内容を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 寄付者CSVインポートが完全な一括処理に対応し、大量データを効率的に登録できるようになりました。
  * 寄付者登録と寄付関連の紐付けを単一トランザクションで実行し、処理が原子化されるようになりました。

* **ドキュメント**
  * 一括インポート確定フェーズの設計・手順とUI表示フローを更新しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->