### PR TITLE
docs: E2Eテスト用seed拡張の設計ドキュメントを追加

### DIFF
--- a/docs/20260103_2317_E2Eテスト用seed拡張設計.md
+++ b/docs/20260103_2317_E2Eテスト用seed拡張設計.md
@@ -158,7 +158,22 @@ seeder実行時は `orgSlug` でorganizationを都度取得する形に変更す
 | ファイル | 変更内容 |
 |---------|---------|
 | `prisma/seeds/politicalOrganizations.ts` | E2Eテスト団体を追加 |
-| `prisma/seeds/counterparts.ts` | E2Eテスト取引先を追加 |
-| `prisma/seeds/donors.ts` | E2Eテスト寄附者を追加 |
-| `prisma/seeds/transactions.ts` | `orgSlug` フィールド追加、E2Eテストトランザクション追加 |
+| `prisma/seeds/counterparts.ts` | E2Eテスト取引先を追加（共有エンティティのため構造変更なし） |
+| `prisma/seeds/donors.ts` | E2Eテスト寄附者を追加（共有エンティティのため構造変更なし） |
+| `prisma/seeds/transactions.ts` | 下記参照 |
 | `prisma/seeds/balanceSnapshots.ts` | （オプション）E2Eテスト団体の残高スナップショット追加 |
+
+### transactions.ts の変更詳細
+
+**既存データへの影響:**
+- 既存の sample-party 用トランザクションデータ **56件全て** に `orgSlug: 'sample-party'` を追加する必要がある
+
+**実装順序:**
+
+1. **Step 1: インターフェース変更 + 既存データ修正**
+   - `TransactionSeedData` インターフェースに `orgSlug: string` フィールドを追加
+   - 既存56件のトランザクションデータ全てに `orgSlug: 'sample-party'` を付与
+   - seeder の org 取得ロジックを `orgSlug` ベースに変更
+
+2. **Step 2: E2Eテスト用データ追加**
+   - E2Eテスト用トランザクション2件を追加（`orgSlug: 'e2e-test-org'`）


### PR DESCRIPTION
## Summary

- E2Eテスト用に新しいPoliticalOrganization（`e2e-test-org`）を追加するための設計ドキュメントを作成
- 寄付者(Donor)とカウンターパート(Counterpart)をトランザクションに紐付けるテストケースを作成できる最小構成を設計

## 目的

E2Eテストを実装するチームが、寄付者(Donor)やカウンターパート(Counterpart)をトランザクションに紐付けるテストケースを作成できるようにするため。

## 設計内容

追加するデータ:
- Political Organization: 1件 (`e2e-test-org`)
- Counterpart: 1件 (E2Eテスト取引先株式会社)
- Donor: 1件 (E2Eテスト寄附太郎)
- Transaction: 2件 (寄附1件 + 支出1件)

## Test plan

- [ ] 設計ドキュメントの内容をレビュー

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * E2Eテスト用のシード拡張設計に関する新しいドキュメントを追加しました。DonorとCounterpartを取引に紐付けるテスト用データ構成と設定手順、検証手順を説明しています。
* **テスト**
  * 新しいE2Eシナリオの検証ケースを記載し、Donor／Counterpartの関連付けが正しく行われることを確認する手順を示しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->