### PR TITLE
fix: Vercelビルドでprisma schemaが見つからないエラーを修正

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -32,7 +32,7 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "build:vercel": "pnpm run db:setup && pnpm run build",
-    "db:setup": "prisma generate && prisma migrate deploy",
+    "db:setup": "cd .. && prisma generate && prisma migrate deploy",
     "start": "next start",
     "lint": "biome check",
     "type-check": "tsc --noEmit",


### PR DESCRIPTION
## 目的

**開発者が**、webappのVercelデプロイ時にビルドが失敗する状態を**解消するため**。

## 問題

E2E CI並列ビルド対応（docs/20260103_1006_E2E-CI並列ビルドのためのコマンド分離.md）で追加した `db:setup` スクリプトで、webappディレクトリ内から `prisma generate` を実行していたため、ルートディレクトリにある `prisma/schema.prisma` が見つからずビルドが失敗していた。

```
Error: Could not find Prisma Schema that is required for this command.
```

## 変更内容

- `webapp/package.json` の `db:setup` スクリプトに `cd .. &&` を追加し、ルートディレクトリに移動してからprismaコマンドを実行するように修正

## テスト計画

- [ ] Vercelプレビューデプロイが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * セットアップスクリプトの実行コンテキストを改善しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->