### PR TITLE
test: webappの政治団体ページE2Eテストを追加

### DIFF
--- a/webapp/e2e/tests/organization.spec.ts
+++ b/webapp/e2e/tests/organization.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("政治団体ページ", () => {
+	test.describe("読み込み", () => {
+		test("ルートにアクセスすると政治団体ページにリダイレクトされる", async ({
+			page,
+		}) => {
+			await page.goto("/");
+
+			// /o/{slug} にリダイレクトされることを確認
+			await expect(page).toHaveURL(/\/o\/[\w-]+$/);
+			await expect(page).toHaveTitle(/みらいまる見え政治資金/);
+		});
+
+		test("政治団体ページが正常に表示される", async ({ page }) => {
+			const response = await page.goto("/o/sample-party");
+
+			expect(response?.status()).toBe(200);
+			await expect(page).toHaveTitle(/サンプル党.*みらいまる見え政治資金/);
+		});
+
+		test("存在しないslugの場合はデフォルトの政治団体にリダイレクトされる", async ({
+			page,
+		}) => {
+			await page.goto("/o/non-existent-org");
+
+			// デフォルトの政治団体にリダイレクトされる
+			await expect(page).toHaveURL(/\/o\/[\w-]+$/);
+			await expect(page).not.toHaveURL(/non-existent-org/);
+		});
+
+		test("収支の流れセクションが表示される", async ({ page }) => {
+			await page.goto("/o/sample-party");
+
+			// 収支の流れセクションが存在することを確認（メインコンテンツ内のセクション）
+			await expect(page.locator("#cash-flow").getByText("収支の流れ")).toBeVisible();
+		});
+	});
+
+	test.describe("政治団体セレクター", () => {
+		test("セレクターをクリックするとドロップダウンが開く", async ({ page }) => {
+			await page.goto("/o/sample-party");
+
+			// セレクターボタンをクリック
+			const selectorButton = page.getByRole("button", { name: /サンプル党/ });
+			await selectorButton.click();
+
+			// ドロップダウンが開いて選択肢が表示される
+			await expect(page.getByText("表示する政治団体")).toBeVisible();
+		});
+
+		test("別の政治団体を選択するとページが切り替わる", async ({ page }) => {
+			await page.goto("/o/sample-party");
+
+			// セレクターを開く
+			const selectorButton = page.getByRole("button", { name: /サンプル党/ });
+			await selectorButton.click();
+
+			// ドロップダウン内の選択肢をクリック（E2Eテスト団体が存在する場合）
+			// 最初のシードデータ以外のオプションを選択
+			const options = page.locator(
+				'[class*="absolute"] button:has-text("E2Eテスト団体")',
+			);
+			const optionCount = await options.count();
+
+			if (optionCount > 0) {
+				await options.first().click();
+				await expect(page).toHaveURL("/o/e2e-test-org");
+			} else {
+				// E2Eテスト団体がない場合はスキップ
+				test.skip();
+			}
+		});
+	});
+
+	test.describe("詳細画面への遷移", () => {
+		test("取引一覧ページに遷移できる", async ({ page }) => {
+			await page.goto("/o/sample-party");
+
+			// 「すべての取引を見る」リンクをクリック
+			const viewAllLink = page.getByRole("link", {
+				name: /すべての.*見る|もっと見る/,
+			});
+			await viewAllLink.first().click();
+
+			// 取引一覧ページに遷移することを確認
+			await expect(page).toHaveURL("/o/sample-party/transactions");
+			await expect(
+				page.getByRole("heading", { name: /すべての出入金/ }),
+			).toBeVisible();
+		});
+
+		test("取引一覧ページが正常に表示される", async ({ page }) => {
+			const response = await page.goto("/o/sample-party/transactions");
+
+			expect(response?.status()).toBe(200);
+			await expect(page).toHaveTitle(/全ての出入金.*みらいまる見え政治資金/);
+		});
+
+		test("取引一覧ページでもセレクターで団体を切り替えられる", async ({
+			page,
+		}) => {
+			await page.goto("/o/sample-party/transactions");
+
+			// セレクターを開く
+			const selectorButton = page.getByRole("button", { name: /サンプル党/ });
+			await selectorButton.click();
+
+			// ドロップダウン内の選択肢をクリック
+			const options = page.locator(
+				'[class*="absolute"] button:has-text("E2Eテスト団体")',
+			);
+			const optionCount = await options.count();
+
+			if (optionCount > 0) {
+				await options.first().click();
+				// URLが変更されることを確認（transactionsパスは維持）
+				await expect(page).toHaveURL("/o/e2e-test-org/transactions");
+			} else {
+				// E2Eテスト団体がない場合はスキップ
+				test.skip();
+			}
+		});
+	});
+});


### PR DESCRIPTION
## 目的

開発者がwebappの基本的な機能（ページ表示、リダイレクト、政治団体セレクター、詳細画面遷移）が正常に動作しているかを自動で確認できるようにするため。

## 変更内容

`webapp/e2e/tests/organization.spec.ts` を新規作成し、以下のテストケースを追加:

### 読み込みテスト
- ルートにアクセスすると政治団体ページにリダイレクトされる
- 政治団体ページが正常に表示される
- 存在しないslugの場合はデフォルトの政治団体にリダイレクトされる
- 収支の流れセクションが表示される

### 政治団体セレクター
- セレクターをクリックするとドロップダウンが開く
- 別の政治団体を選択するとページが切り替わる

### 詳細画面への遷移
- 取引一覧ページに遷移できる
- 取引一覧ページが正常に表示される
- 取引一覧ページでもセレクターで団体を切り替えられる

## テスト

```bash
cd webapp && pnpm test:e2e
```

全10件パス（既存のprivacy.spec.ts含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * 組織ページの機能に対するエンドツーエンドテストスイートを追加しました。ページ読み込み、リダイレクト、政党セレクタの切り替え、トランザクションナビゲーション、ステータス検証などをカバーしています。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->