### PR TITLE
feat: XMLエクスポートファイル名を新フォーマットに変更

### DIFF
--- a/admin/src/server/contexts/report/application/usecases/xml-export-usecase.ts
+++ b/admin/src/server/contexts/report/application/usecases/xml-export-usecase.ts
@@ -52,8 +52,9 @@ export class XmlExportUsecase {
     // Step 3: Encode to Shift_JIS
     const shiftJisBuffer = iconv.encode(xml, "shift_jis");
 
-    // Generate filename
-    const filename = `report_${input.politicalOrganizationId}_${input.financialYear}.xml`;
+    // Generate filename with format: report_{fy}_{org_slug}_{exportedDateTime}.xml
+    const slug = await this.profileRepository.getOrganizationSlug(input.politicalOrganizationId);
+    const filename = this.generateFilename(input.financialYear, slug);
 
     return {
       xml,
@@ -61,6 +62,19 @@ export class XmlExportUsecase {
       filename,
       reportData,
     };
+  }
+
+  generateFilename(financialYear: number, slug: string | null): string {
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, "0");
+    const day = String(now.getDate()).padStart(2, "0");
+    const hours = String(now.getHours()).padStart(2, "0");
+    const minutes = String(now.getMinutes()).padStart(2, "0");
+    const exportedDateTime = `${year}${month}${day}_${hours}${minutes}`;
+
+    const orgSlug = slug ?? "unknown";
+    return `report_${financialYear}_${orgSlug}_${exportedDateTime}.xml`;
   }
 
   // ============================================================

--- a/admin/src/server/contexts/report/domain/repositories/organization-report-profile-repository.interface.ts
+++ b/admin/src/server/contexts/report/domain/repositories/organization-report-profile-repository.interface.ts
@@ -14,6 +14,11 @@ export interface IOrganizationReportProfileRepository {
   ): Promise<OrganizationReportProfile | null>;
 
   /**
+   * Get the slug of a political organization by its ID.
+   */
+  getOrganizationSlug(politicalOrganizationId: string): Promise<string | null>;
+
+  /**
    * Create a new organization report profile.
    */
   create(input: CreateOrganizationReportProfileInput): Promise<OrganizationReportProfile>;

--- a/admin/src/server/contexts/report/infrastructure/repositories/prisma-organization-report-profile.repository.ts
+++ b/admin/src/server/contexts/report/infrastructure/repositories/prisma-organization-report-profile.repository.ts
@@ -34,6 +34,15 @@ export class PrismaOrganizationReportProfileRepository
     return this.mapToModel(profile);
   }
 
+  async getOrganizationSlug(politicalOrganizationId: string): Promise<string | null> {
+    const organization = await this.prisma.politicalOrganization.findUnique({
+      where: { id: BigInt(politicalOrganizationId) },
+      select: { slug: true },
+    });
+
+    return organization?.slug ?? null;
+  }
+
   async create(input: CreateOrganizationReportProfileInput): Promise<OrganizationReportProfile> {
     const profile = await this.prisma.organizationReportProfile.create({
       data: {

--- a/admin/tests/server/contexts/report/application/usecases/get-organization-profile-usecase.test.ts
+++ b/admin/tests/server/contexts/report/application/usecases/get-organization-profile-usecase.test.ts
@@ -21,6 +21,7 @@ describe("GetOrganizationProfileUsecase", () => {
 
   const createMockRepository = (): jest.Mocked<IOrganizationReportProfileRepository> => ({
     findByOrganizationIdAndYear: jest.fn(),
+    getOrganizationSlug: jest.fn(),
     create: jest.fn(),
     update: jest.fn(),
   });

--- a/admin/tests/server/contexts/report/application/usecases/save-organization-profile-usecase.test.ts
+++ b/admin/tests/server/contexts/report/application/usecases/save-organization-profile-usecase.test.ts
@@ -21,6 +21,7 @@ describe("SaveOrganizationProfileUsecase", () => {
 
   const createMockRepository = (): jest.Mocked<IOrganizationReportProfileRepository> => ({
     findByOrganizationIdAndYear: jest.fn(),
+    getOrganizationSlug: jest.fn(),
     create: jest.fn(),
     update: jest.fn(),
   });


### PR DESCRIPTION
## Summary

XMLエクスポートのファイル名フォーマットを変更しました。

**変更前:** `report_{politicalOrganizationId}_{financialYear}.xml`  
**変更後:** `report_{fy}_{org_slug}_{exportedDateTime}.xml`

例: `report_2025_team-mirai_20260104_1225.xml`

### 主な変更点
- `IOrganizationReportProfileRepository`に`getOrganizationSlug`メソッドを追加
- `XmlExportUsecase`に`generateFilename`メソッドを追加し、新しいファイル名フォーマットを生成
- slugが取得できない場合は`unknown`にフォールバック

## Review & Testing Checklist for Human

- [ ] 実際にXMLエクスポートを実行し、ファイル名が`report_{fy}_{org_slug}_{YYYYMMDD_HHMM}.xml`形式になっていることを確認
- [ ] 存在しない組織IDでエクスポートした場合、slugが`unknown`になることを確認
- [ ] 既存のXMLエクスポート機能が正常に動作することを確認（ファイル名以外の内容に影響がないこと）

### 推奨テスト手順
1. ローカル環境でadminアプリを起動
2. XMLエクスポート機能を実行
3. ダウンロードされたファイル名が新フォーマットになっていることを確認

### Notes
- datetimeはサーバーのローカル時刻を使用しています
- Closes #1056
- Requested by: @jujunjun110
- Devin run: https://app.devin.ai/sessions/f1902fb7a34b445e965892b38788e3df

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * XMLエクスポートファイルの命名形式を改善しました。ファイル名に組織スラッグとエクスポート日時が含まれるようになり、複数の組織からのエクスポートを簡単に識別・管理できるようになりました。ファイル名は `report_{会計年度}_{組織スラッグ}_{日時}.xml` 形式です。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->