### PR TITLE
feat: 個人寄附の名寄せ小計行機能を実装

### DIFF
--- a/admin/src/server/contexts/report/domain/services/donation-serializer.ts
+++ b/admin/src/server/contexts/report/domain/services/donation-serializer.ts
@@ -36,12 +36,22 @@ export function serializePersonalDonationSection(section: PersonalDonationSectio
 
   for (const row of section.rows) {
     const rowEle = sheet.ele("ROW");
+    const isSubtotalRow = row.rowkbn === "1";
+
     rowEle.ele("ICHIREN_NO").txt(row.ichirenNo);
     rowEle.ele("KIFUSYA_NM").txt(row.kifusyaNm);
     rowEle.ele("KINGAKU").txt(formatAmount(row.kingaku));
-    rowEle.ele("DT").txt(formatWarekiDate(row.dt));
-    rowEle.ele("ADR").txt(row.adr);
-    rowEle.ele("SYOKUGYO").txt(row.syokugyo);
+
+    // 小計行の場合は日付・住所・職業を空で出力
+    if (isSubtotalRow) {
+      rowEle.ele("DT");
+      rowEle.ele("ADR");
+      rowEle.ele("SYOKUGYO");
+    } else {
+      rowEle.ele("DT").txt(formatWarekiDate(row.dt));
+      rowEle.ele("ADR").txt(row.adr);
+      rowEle.ele("SYOKUGYO").txt(row.syokugyo);
+    }
 
     if (row.bikou) {
       rowEle.ele("BIKOU").txt(row.bikou);

--- a/admin/tests/server/contexts/report/application/services/donation-assembler.test.ts
+++ b/admin/tests/server/contexts/report/application/services/donation-assembler.test.ts
@@ -65,14 +65,14 @@ describe("DonationAssembler", () => {
   describe("セクション構築の委譲", () => {
     it("取得したトランザクションを個人寄附セクションに正しく委譲する", async () => {
       const transactions: PersonalDonationTransaction[] = [
-        createDonationTransaction({ debitAmount: 100000 }),
-        createDonationTransaction({ debitAmount: 50000 }),
+        createDonationTransaction({ donorId: "donor-001", debitAmount: 100000 }),
+        createDonationTransaction({ donorId: "donor-002", debitAmount: 50001 }),
       ];
       mockRepository.findPersonalDonationTransactions.mockResolvedValue(transactions);
 
       const result = await assembler.assemble(defaultInput);
 
-      expect(result.personalDonations.totalAmount).toBe(150000);
+      expect(result.personalDonations.totalAmount).toBe(150001);
       expect(result.personalDonations.rows).toHaveLength(2);
     });
 


### PR DESCRIPTION
# feat: 個人寄附の名寄せ小計行機能を実装

## Summary

設計ドキュメント `docs/20260104_1224_個人寄附の名寄せ小計行実装設計.md` に従い、個人寄附セクションに小計行（名寄せ）機能を実装しました。

主な変更点:
- `PersonalDonationSection.fromTransactions()` を拡張し、同一寄附者からの複数取引に対して小計行を生成
- グループ内の明細を日付順にソート、グループ間は最初の取引日付順でソート
- 通し番号（seqNo）と一連番号（ichirenNo）の採番ロジックを実装
- 小計行（rowkbn="1"）のバリデーションスキップを追加
- `donation-serializer.ts` で小計行の日付・住所・職業を空要素として出力

## Review & Testing Checklist for Human

- [ ] **XML出力形式の確認**: 小計行の出力形式（空のDT/ADR/SYOKUGYO要素）が政治資金収支報告書のフォーマット要件を満たしているか確認
- [ ] **totalAmount計算の確認**: 小計行の金額がtotalAmountに二重計上されていないことを確認（テストでは検証済みだが、実データでも確認推奨）
- [ ] **ソート順の確認**: グループが「最初の取引日付順」、グループ内明細が「日付順」になっていることを実データで確認

### 推奨テスト手順
1. 同一寄附者から複数回の寄附がある取引データをインポート
2. XML出力を生成し、小計行が正しく出力されていることを確認
3. 出力されたXMLを政治資金収支報告書のバリデーションツールで検証

### Notes
- 設計ドキュメントに記載の全7テストケース + 追加のエッジケースを実装済み
- 既存テストは新しい小計行の挙動に合わせて更新

Link to Devin run: https://app.devin.ai/sessions/eafd4b07db6c471f897e6287f20694e7
Requested by: jun.ito@team-mir.ai (@jujunjun110)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **機能改善**
  * 寄付金取引のグループ化機能を改善し、同一寄付者の複数取引を自動で集約して表示するようになりました。
  * 取引額が一定額を超えるグループに対して、小計行が自動生成・表示されるようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->