### PR TITLE
docs: エラーハンドリング違反箇所の調査結果を追加

### DIFF
--- a/docs/20260105_1108_エラーハンドリング違反箇所調査.md
+++ b/docs/20260105_1108_エラーハンドリング違反箇所調査.md
@@ -1,0 +1,260 @@
+# エラーハンドリング違反箇所調査
+
+## 目的
+
+開発者がエラーハンドリングの原則（docs/backend-architecture-guide.md セクション6.3）に沿った実装になっていない箇所を特定し、修正タスクとしてLLMに投げられるようにするための調査。
+
+---
+
+## エラーハンドリング原則（参照）
+
+| 層 | 原則 |
+|---|---|
+| **Presentation** | `{ ok: false, error: "..." }` 形式でユーザーフレンドリーなエラーメッセージを返す |
+| **Application** | `throw new Error(\`Failed to ...: ${error.message}\`)` で詳細メッセージでラップして投げる |
+| **Domain** | `{ status: "invalid", errors: [...] }` 形式でビジネスルールエラーを返す。拡張エラー型（path, code, message, severity）を使用 |
+| **Infrastructure** | 技術的なエラーを throw する |
+
+リファレンス実装: `admin/src/server/contexts/report/domain/types/validation.ts`
+
+---
+
+## コンテキスト別違反箇所一覧
+
+### 1. admin/auth
+
+#### 違反サマリー
+
+| 違反原則 | 件数 |
+|---------|------|
+| 原則1（Presentation） | 1件 |
+| 原則2（Application） | 複数（英語メッセージ） |
+| 原則3（Domain） | 未実装 |
+| 原則4（Infrastructure） | AuthErrorへの依存 |
+
+#### 違反箇所
+
+##### 原則1違反（Presentation層）
+
+| ファイル | 行番号 | 違反内容 |
+|---------|--------|---------|
+| presentation/actions/request-password-reset.ts | 16-26 | エラーをキャッチするが何もせず、常に成功時と同じリダイレクトを行う。`{ ok: false, error }` 形式で返すべき |
+
+##### 原則2違反（Application層）
+
+| ファイル | 行番号 | 違反内容 |
+|---------|--------|---------|
+| application/usecases/login-usecase.ts | 14-15 | 英語のバリデーションエラーメッセージを使用 |
+| application/usecases/invite-user-usecase.ts | 38-44 | 英語のバリデーションエラーメッセージを使用 |
+| application/usecases/complete-invite-session-usecase.ts | 18-19 | 英語のバリデーションエラーメッセージを使用 |
+| application/usecases/complete-recovery-session-usecase.ts | 15-16 | 英語のバリデーションエラーメッセージを使用 |
+
+##### 原則3違反（Domain層）
+
+- Domain層でのビジネスルールエラー形式（`{ status: "invalid", errors: [...] }`）が未実装
+- `AuthError` を throw する形式で統一されているが、拡張エラー型を使用していない
+
+##### 原則4違反（Infrastructure層）
+
+| ファイル | 行番号 | 違反内容 |
+|---------|--------|---------|
+| infrastructure/supabase/supabase-auth-provider.ts | 38-59 | Infrastructure層が `AuthError`（Domain層のエラー型）を直接 throw している |
+
+---
+
+### 2. admin/report
+
+#### 違反サマリー
+
+| 違反原則 | 件数 |
+|---------|------|
+| 原則1（Presentation） | 5件 |
+| 原則2（Application） | 7件 |
+| 原則3（Domain） | 3件 |
+
+#### 違反箇所
+
+##### 原則1違反（Presentation層）
+
+| ファイル | 行番号 | 違反内容 |
+|---------|--------|---------|
+| presentation/actions/save-organization-profile.ts | 40-42 | エラーをそのまま throw している |
+| presentation/actions/suggest-counterpart.ts | 22-28 | Usecase の戻り値をそのまま返している（統一形式への変換なし） |
+| presentation/actions/preview-donor-csv.ts | 59-71 | エラーを throw している |
+| presentation/actions/search-counterpart-address.ts | 11-42 | Usecase の戻り値をそのまま返している |
+| presentation/actions/bulk-unassign-counterpart.ts | 12-25 | エラーハンドリングがない |
+
+##### 原則2違反（Application層）
+
+| ファイル | 行番号 | 違反内容 |
+|---------|--------|---------|
+| application/usecases/import-donor-csv-usecase.ts | 218 | エラーを直接 throw（詳細ラップなし） |
+| application/usecases/manage-counterpart-usecase.ts | 71-74 | Domain からのエラーをラップせずそのまま返す |
+| application/usecases/manage-counterpart-usecase.ts | 114-121 | Domain からのエラーをラップせずそのまま返す |
+| application/usecases/manage-donor-usecase.ts | 67-70 | Domain からのエラーをラップせずそのまま返す |
+| application/usecases/manage-donor-usecase.ts | 115-123 | Domain からのエラーをラップせずそのまま返す |
+| application/usecases/bulk-unassign-counterpart-usecase.ts | 17-42 | 副作用的にエラーを処理し、Presentation層の責務を侵害 |
+| application/usecases/preview-donor-csv-usecase.ts | 37-72 | 副作用的にエラーを処理 |
+
+##### 原則3違反（Domain層）
+
+| ファイル | 行番号 | 違反内容 |
+|---------|--------|---------|
+| domain/services/donor-csv-validator.ts | 104-137 | エラーを文字列配列で返している（拡張エラー型を使用すべき） |
+| domain/models/counterpart.ts | 30-46 | `validateCounterpartInput()` が文字列配列でエラーを返している |
+| domain/models/donor.ts | 66-90 | `validateDonorInput()` が文字列配列でエラーを返している |
+
+---
+
+### 3. admin/data-import
+
+#### 違反サマリー
+
+| 違反原則 | 件数 |
+|---------|------|
+| 原則1（Presentation） | 2件 |
+| 原則2（Application） | 2件 |
+| 原則3（Domain） | 1件 |
+| その他（エラーフロー不整合） | 1件 |
+
+#### 違反箇所
+
+##### 原則1違反（Presentation層）
+
+| ファイル | 行番号 | 違反内容 |
+|---------|--------|---------|
+| presentation/actions/preview-csv.ts | 39-41 | エラーを throw している |
+| presentation/actions/upload-csv.ts | 73-75 | エラーを throw している |
+
+##### 原則2違反（Application層）
+
+| ファイル | 行番号 | 違反内容 |
+|---------|--------|---------|
+| application/usecases/preview-mf-csv-usecase.ts | 74-79 | エラーをサイレントに飲み込んで空の結果を返している |
+| application/usecases/save-preview-transactions-usecase.ts | 86-88 | エラーをサイレントに飲み込んでいる |
+
+##### 原則3違反（Domain層）
+
+| ファイル | 行番号 | 違反内容 |
+|---------|--------|---------|
+| domain/services/transaction-validator.ts | 全体 | 拡張エラー型（path, code, message, severity）を使用していない |
+
+##### その他
+
+| ファイル | 行番号 | 違反内容 |
+|---------|--------|---------|
+| infrastructure/mf/mf-csv-loader.ts | 66, 71, 83 | Usecaseでエラーがサイレントに飲み込まれるため、これらのエラーがユーザーに伝わらない |
+
+---
+
+### 4. admin/shared
+
+#### 違反サマリー
+
+| 違反原則 | 件数 |
+|---------|------|
+| 原則1（Presentation） | 5件 |
+| 原則2（Application） | 2件 |
+| 原則3（Domain） | 未実装 |
+
+#### 違反箇所
+
+##### 原則1違反（Presentation層）
+
+| ファイル | 行番号 | 違反内容 |
+|---------|--------|---------|
+| presentation/actions/create-balance-snapshot.ts | 39-45 | エラーを throw している |
+| presentation/actions/delete-balance-snapshot.ts | 21-27 | エラーを throw している |
+| presentation/actions/create-political-organization.ts | 26-34 | エラーを throw している。Prismaエラーメッセージに依存した条件分岐あり |
+| presentation/actions/update-political-organization.ts | 32-44 | エラーを throw している。Prismaエラーメッセージに依存した条件分岐あり |
+| presentation/actions/clear-webapp-cache.ts | 14-15 | エラーハンドリングなし |
+
+##### 原則2違反（Application層）
+
+| ファイル | 行番号 | 違反内容 |
+|---------|--------|---------|
+| application/usecases/delete-political-organization-usecase.ts | 30-36 | Usecaseが `{ success, message }` 形式で返している（Presentation層の責務） |
+| application/usecases/clear-webapp-cache-usecase.ts | 13-25 | Usecaseが `{ success, message }` 形式で返している |
+
+##### 原則3違反（Domain層）
+
+- Domain層にエラー型定義（ValidationError等）が存在しない
+- report コンテキストの `validation.ts` を共有化すべき
+
+##### その他の問題
+
+- **Prismaエラーメッセージへの依存**: `error.message.includes("Unique constraint")` のような文字列マッチがあり、脆弱かつ保守性が低い
+
+---
+
+### 5. webapp/public-finance
+
+#### 違反サマリー
+
+| 違反原則 | 件数 |
+|---------|------|
+| 原則1（Presentation） | 4件 |
+| 原則2（Application） | 6件 |
+
+#### 違反箇所
+
+##### 原則1違反（Presentation層）
+
+| ファイル | 行番号 | 違反内容 |
+|---------|--------|---------|
+| presentation/loaders/load-top-page-data.ts | 24-102 | エラーハンドリングなし |
+| presentation/loaders/load-transactions-page-data.ts | 16-29 | エラーハンドリングなし |
+| presentation/loaders/load-organizations.ts | 9-19 | エラーハンドリングなし |
+| presentation/loaders/load-transactions-for-csv.ts | 34-83 | エラーハンドリングは実装されているが、全エラーを汎用メッセージでマスク |
+
+##### 原則2違反（Application層）
+
+| ファイル | 行番号 | 違反内容 |
+|---------|--------|---------|
+| application/usecases/get-transactions-by-slug-usecase.ts | 52-54 | エラーを直接 throw（詳細ラップなし） |
+| application/usecases/get-monthly-aggregation-usecase.ts | 37-41 | エラーを直接 throw（詳細ラップなし） |
+| application/usecases/get-balance-sheet-usecase.ts | 33-37 | エラーを直接 throw（詳細ラップなし） |
+| application/usecases/get-sankey-aggregation-usecase.ts | 39-43 | エラーを直接 throw（詳細ラップなし） |
+| application/usecases/get-all-transactions-by-slug-usecase.ts | 43-47 | エラーを直接 throw（詳細ラップなし） |
+| application/usecases/get-transactions-for-csv-usecase.ts | 30-34 | エラーを直接 throw（詳細ラップなし） |
+
+---
+
+## 全体統計
+
+| コンテキスト | 原則1違反 | 原則2違反 | 原則3違反 | 原則4違反 | 合計 |
+|-------------|----------|----------|----------|----------|------|
+| admin/auth | 1 | 4 | 1（未実装） | 1 | 7 |
+| admin/report | 5 | 7 | 3 | 0 | 15 |
+| admin/data-import | 2 | 2 | 1 | 0 | 5 |
+| admin/shared | 5 | 2 | 1（未実装） | 0 | 8 |
+| webapp/public-finance | 4 | 6 | 0 | 0 | 10 |
+| **合計** | **17** | **21** | **6** | **1** | **45** |
+
+---
+
+## タスク分割案
+
+### 高優先度（バグ相当）
+
+1. **admin/auth**: request-password-reset.ts のエラー無視問題
+2. **admin/data-import**: preview-mf-csv-usecase.ts のサイレントエラー飲み込み
+
+### 中優先度（原則準拠）
+
+3. **admin/report**: Presentation層のエラーハンドリング統一（5件）
+4. **admin/report**: Application層のエラーラップ統一（7件）
+5. **admin/report**: Domain層の拡張エラー型導入（3件）
+6. **admin/shared**: Presentation層のエラーハンドリング統一（5件）
+7. **admin/shared**: Application層の責務是正（2件）
+8. **webapp/public-finance**: Presentation層のエラーハンドリング追加（4件）
+9. **webapp/public-finance**: Application層のエラーラップ統一（6件）
+10. **admin/data-import**: Presentation層のエラーハンドリング統一（2件）
+11. **admin/data-import**: Domain層の拡張エラー型導入（1件）
+
+### 低優先度（厳密性）
+
+12. **admin/auth**: Application層の英語メッセージを日本語化
+13. **admin/auth**: Infrastructure層のAuthError依存の見直し
+14. **admin/shared**: Prismaエラーメッセージ依存の解消
+15. **admin/shared + webapp**: Domain層エラー型の共通化検討


### PR DESCRIPTION
## Summary

- backend-architecture-guide.mdのエラーハンドリング原則と実装状況を調査し、違反箇所をリストアップ
- 全5コンテキスト（auth, report, data-import, shared, public-finance）で計45件の違反を検出
- コンテキスト別の違反箇所一覧とタスク分割案を記載

## 目的

開発者がエラーハンドリングの改善タスクをLLMに投げる際の概要資料として活用するため。

## Test plan

- [x] ドキュメントの内容確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * エラーハンドリング監査に関する技術ドキュメントが追加されました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->