### PR TITLE
fix: dependabot lockfile workflowのNode.jsバージョン指定を修正

### DIFF
--- a/.github/workflows/dependabot-lockfile-update.yml
+++ b/.github/workflows/dependabot-lockfile-update.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: ".node-version"
+          node-version: '20'
           cache: "pnpm"
 
       - name: Update lockfile


### PR DESCRIPTION
## Summary

- dependabot-lockfile-update.ymlで存在しない`.node-version`ファイルを参照していたため、CIが失敗していた問題を修正
- 他のCIワークフロー（ci.yml）と同様に`node-version: '20'`を直接指定するよう変更

## Why

DependabotがPRを作成した際に、lockfile自動更新のCIジョブがNode.jsセットアップで失敗する状態を解消するため

関連: https://github.com/team-mirai/marumie/actions/runs/20869256421/job/59967375927?pr=1080

## Test plan

- [ ] DependabotのPRでCIが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)