### PR TITLE
test(webapp): E2EテストでJSエラーが発生しないことをチェック

### DIFF
--- a/webapp/e2e/tests/organization.spec.ts
+++ b/webapp/e2e/tests/organization.spec.ts
@@ -24,8 +24,10 @@ test.describe("政治団体ページ", () => {
 			await expect(
 				page.locator("#cash-flow").getByText("収支の流れ"),
 			).toBeVisible();
-			// グラフ等の非同期描画のための最小限の待機
-			await page.waitForTimeout(500);
+			// サンキーチャート（SVG）が描画されるまで待機
+			await expect(
+				page.locator("#cash-flow").locator('[role="img"][aria-label="政治資金の収支フロー図"]'),
+			).toBeVisible();
 
 			// 実行時エラーが発生していないことを確認
 			expect(

--- a/webapp/e2e/tests/transactions.spec.ts
+++ b/webapp/e2e/tests/transactions.spec.ts
@@ -23,8 +23,10 @@ test.describe("取引一覧ページ", () => {
 		await expect(
 			page.getByRole("heading", { name: /すべての出入金|全ての出入金/ }),
 		).toBeVisible();
-		// グラフ等の非同期描画のための最小限の待機
-		await page.waitForTimeout(500);
+		// 取引一覧テーブルが描画されるまで待機
+		await expect(
+			page.locator('table[aria-label="政治資金取引一覧表"]'),
+		).toBeVisible();
 
 		// 実行時エラーが発生していないことを確認
 		expect(


### PR DESCRIPTION
## Summary

- トップページと取引一覧ページでJavaScriptの実行時エラー(error)が発生しないことを検証するE2Eテストを追加
- グラフ描画等で発生しうるランタイムエラーを早期に検出できるようにする
- warningは許容し、errorレベルのみをチェック対象とする

## Why

開発者がグラフ系コンポーネントのランタイムエラーに気づきやすくするため

## Test plan

- [x] `pnpm exec playwright test` でE2Eテストがパスすることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * ページのランタイムエラーを収集し、最終検証で捕捉された例外を失敗として報告する仕組みを追加しました。
  * ナビゲーション後にHTTP 200 応答を確認し、ページタイトルの日本語パターン検証を含む同期処理で安定性を向上しました。
  * 重要要素（キャッシュフローの可視化やトランザクション表）の描画完了を待機するチェックを導入しました。
  * トランザクション画面のE2Eテストを新規追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->