### PR TITLE
chore(renovate): exclude Prisma v7 due to ESM compatibility issues

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,9 +13,10 @@
   },
   "packageRules": [
     {
-      "description": "Prisma packages",
+      "description": "Prisma packages (exclude v7 due to ESM compatibility issues)",
       "matchPackagePatterns": ["^prisma$", "^@prisma/"],
-      "groupName": "prisma"
+      "groupName": "prisma",
+      "allowedVersions": "<7.0.0"
     },
     {
       "description": "Supabase packages",


### PR DESCRIPTION
## 目的

開発者がPrisma 7.xのESM互換性問題によるビルドエラーを回避するため

## 変更内容

- Renovate設定でPrismaパッケージに `allowedVersions: "<7.0.0"` を追加
- Prisma 7.x へのアップデートPRが作成されなくなる

## 背景

Prisma 7.xはESM互換性に問題があり、現在のプロジェクト構成ではビルドエラーが発生します。ESM問題が解決されるまで6.x系を維持します。