### PR TITLE
chore: change renovate schedule to weekly Saturday morning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,9 +4,7 @@
     "config:recommended"
   ],
   "timezone": "Asia/Tokyo",
-  "schedule": [
-    "after 3:15pm"
-  ],
+  "schedule": ["before 9am on saturday"],
   "prHourlyLimit": 5,
   "prConcurrentLimit": 10,
   "labels": [


### PR DESCRIPTION
## Summary

- renovate の実行スケジュールを毎日午後から毎週土曜朝に変更

## Why

開発者が平日の作業に集中できるよう、依存関係の更新PRが週末にまとめて作成されるようにするため。

## Test plan

- [ ] renovate の設定が正しく適用されることを確認


🤖 Generated with [Claude Code](https://claude.com/claude-code)