### PR TITLE
fix: update Slack invite link on webapp top page

### DIFF
--- a/webapp/src/client/components/common/ExplanationSection.tsx
+++ b/webapp/src/client/components/common/ExplanationSection.tsx
@@ -22,7 +22,7 @@ export default function ExplanationSection() {
             </a>
             にて無償公開中であり、政党や所属を問わず利用可能な形で提供しております。開発コミュニティにご興味のある方は
             <a
-              href="https://join.slack.com/t/team-mirai-volunteer/shared_invite/zt-3dap6i768-1nztzb2S2SNDLX8DzzJ9Hg"
+              href="https://join.slack.com/t/team-mirai-volunteer/shared_invite/zt-3n6h3a45j-yfNpEPXFcKTcmXZlmRGsyw"
               target="_blank"
               rel="noopener noreferrer"
               className="font-bold text-[#238778] underline hover:no-underline"


### PR DESCRIPTION
## Summary
Updates the Slack invite link in the webapp's top page ExplanationSection component to a new invite URL.

The old link `zt-3dap6i768-1nztzb2S2SNDLX8DzzJ9Hg` has been replaced with the new link `zt-3n6h3a45j-yfNpEPXFcKTcmXZlmRGsyw`.

## Review & Testing Checklist for Human
- [ ] Click the new Slack invite link and verify it works and leads to the correct team-mirai-volunteer workspace

### Notes
- Link to Devin run: https://app.devin.ai/sessions/1737f79dd7e048debcdca92574ba4623
- Requested by: @jujunjun110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チューア**
  * Slack招待リンクを更新しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->