### PR TITLE
docs: マルチテナント化概要設計

### DIFF
--- a/docs/20260114_2240_マルチテナント化概要設計.md
+++ b/docs/20260114_2240_マルチテナント化概要設計.md
@@ -628,19 +628,53 @@ const transactions = await prisma.transaction.findMany({
    -- ポリシー作成時点ではRLSはまだ無効
    ```
 
-3. **RLS有効化**
+3. **ポリシー検証（RLS有効化前）**
    ```sql
-   -- テーブルごとにRLSを有効化
+   -- トランザクション内でテストし、ROLLBACKで変更を破棄
+   BEGIN;
+
+   -- テスト用にRLSを一時的に有効化
    ALTER TABLE transactions ENABLE ROW LEVEL SECURITY;
-   ALTER TABLE balance_snapshots ENABLE ROW LEVEL SECURITY;
-   -- ... 他テーブル
+
+   -- テストユーザーのJWTクレームを設定（Supabase Auth形式）
+   SET LOCAL "request.jwt.claims" = '{"sub": "test-user-id-belonging-to-tenant-1"}';
+
+   -- 検証1: 自テナントのデータのみ取得できることを確認
+   SELECT COUNT(*) FROM transactions;  -- 期待: テナント1のデータ件数
+
+   -- 検証2: 他テナントのデータが見えないことを確認
+   SELECT COUNT(*) FROM transactions
+   WHERE political_organization_id IN (
+     SELECT id FROM political_organizations WHERE tenant_id = 2
+   );  -- 期待: 0件
+
+   -- 検証3: 他テーブルも同様に確認
+   -- SELECT COUNT(*) FROM balance_snapshots;
+   -- SELECT COUNT(*) FROM counterparts;
+
+   -- 検証完了後、変更を破棄
+   ROLLBACK;
    ```
 
-4. **動作確認**
+4. **RLS有効化**
+   ```sql
+   -- テーブルごとにRLSを有効化（本番適用）
+   ALTER TABLE transactions ENABLE ROW LEVEL SECURITY;
+   ALTER TABLE balance_snapshots ENABLE ROW LEVEL SECURITY;
+   ALTER TABLE organization_report_profiles ENABLE ROW LEVEL SECURITY;
+   ALTER TABLE counterparts ENABLE ROW LEVEL SECURITY;
+   ALTER TABLE donors ENABLE ROW LEVEL SECURITY;
+   ALTER TABLE transaction_counterparts ENABLE ROW LEVEL SECURITY;
+   ALTER TABLE transaction_donors ENABLE ROW LEVEL SECURITY;
+   ALTER TABLE user_tenant_memberships ENABLE ROW LEVEL SECURITY;
+   ALTER TABLE tenants ENABLE ROW LEVEL SECURITY;
+   ```
+
+5. **動作確認**
    - 管理者アカウントでの動作確認
    - データアクセステスト
 
-5. **メンテナンスモード終了**
+6. **メンテナンスモード終了**
 
 ### 6.5 フェーズ4: 新規テナント受け入れ準備
 

--- a/docs/20260114_2240_マルチテナント化概要設計.md
+++ b/docs/20260114_2240_マルチテナント化概要設計.md
@@ -409,8 +409,14 @@ USING (
 - 政治団体の選択（テナント内で複数団体を切り替え）
 
 ```typescript
-// Domain層: テナントロール型
-type TenantRole = 'owner' | 'admin' | 'editor';
+// Domain層: テナントロール型（domain/models/tenant-role.ts）
+const TENANT_ROLES = ['owner', 'admin', 'editor'] as const;
+type TenantRole = typeof TENANT_ROLES[number];
+
+// ランタイム検証用の型ガード関数
+function isTenantRole(value: unknown): value is TenantRole {
+  return TENANT_ROLES.includes(value as TenantRole);
+}
 
 // Presentation層: 現在のコンテキストを解決
 interface CurrentContext {

--- a/docs/20260114_2240_マルチテナント化概要設計.md
+++ b/docs/20260114_2240_マルチテナント化概要設計.md
@@ -463,7 +463,55 @@ admin/
 - 政治団体レベル: `/t/[tenantSlug]/o/[orgSlug]/`
 - counterparts / donors はテナント内で共有するため、団体を横断して利用可能
 
-### 5.3 Usecase / Repository の変更
+### 5.3 デフォルトテナント/政治団体の選択と永続化
+
+複数テナント・複数政治団体に所属するユーザー向けに、最後にアクセスしたコンテキストを記憶し、ログイン時に自動的にリダイレクトする。
+
+**データモデル**:
+```sql
+-- ユーザー設定テーブル（新規）
+CREATE TABLE user_preferences (
+  id BIGSERIAL PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE UNIQUE,
+  last_accessed_tenant_id BIGINT REFERENCES tenants(id) ON DELETE SET NULL,
+  last_accessed_organization_id BIGINT REFERENCES political_organizations(id) ON DELETE SET NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+**ログイン後のリダイレクトフロー**:
+```typescript
+async function getDefaultRedirectPath(userId: string): Promise<string> {
+  // 1. ユーザー設定から最後にアクセスしたテナント/政治団体を取得
+  const prefs = await getUserPreferences(userId);
+
+  if (prefs?.lastAccessedTenantId) {
+    // アクセス権限を検証
+    const canAccess = await canAccessTenant(userId, prefs.lastAccessedTenantId);
+    if (canAccess && prefs.lastAccessedOrganizationId) {
+      // 最後にアクセスした政治団体のダッシュボードへ
+      return `/t/${tenantSlug}/o/${orgSlug}/dashboard`;
+    }
+  }
+
+  // 2. 所属テナント一覧を取得
+  const memberships = await getUserTenantMemberships(userId);
+
+  if (memberships.length === 1) {
+    // 単一テナントの場合、政治団体選択画面へ
+    return `/t/${memberships[0].tenantSlug}/select-organization`;
+  }
+
+  // 3. 複数テナントの場合、テナント選択画面へ
+  return '/select-tenant';
+}
+```
+
+**コンテキスト切り替え時の更新**:
+- テナント/政治団体を切り替えた際、`user_preferences` を更新
+- セッション内では URL パラメータで状態を保持（サーバーサイドで都度検証）
+
+### 5.4 Usecase / Repository の変更
 
 **原則**:
 - テナントレベルの操作: `tenantId` を必須パラメータ化
@@ -491,7 +539,7 @@ interface GetCounterpartsInput {
 }
 ```
 
-### 5.4 Prisma と RLS の統合
+### 5.5 Prisma と RLS の統合
 
 **課題**: Prismaは通常、サービスロールで接続するためRLSをバイパスする。
 
@@ -650,6 +698,7 @@ USING (true);  -- または特定条件で公開可否を制御
 
 - [ ] `tenants` テーブル作成
 - [ ] `user_tenant_memberships` テーブル作成
+- [ ] `user_preferences` テーブル作成（デフォルトテナント/政治団体記憶用）
 - [ ] `political_organizations` に `tenant_id` カラム追加
 - [ ] `counterparts` に `tenant_id` カラム追加
 - [ ] `donors` に `tenant_id` カラム追加
@@ -663,9 +712,11 @@ USING (true);  -- または特定条件で公開可否を制御
 - [ ] `TenantRole` 型定義
 - [ ] `Tenant` モデル
 - [ ] `UserTenantMembership` モデル
-- [ ] `TenantContext` の導入
+- [ ] `UserPreferences` モデル
+- [ ] `getCurrentContext()` 関数（URL からコンテキスト解決）
+- [ ] `getDefaultRedirectPath()` 関数（ログイン後リダイレクト）
 - [ ] テナントロール検証ロジック
-- [ ] 現在のテナント・政治団体取得・切り替えロジック
+- [ ] テナント/政治団体切り替え時の設定更新ロジック
 
 ### 8.3 data-import コンテキスト
 

--- a/docs/20260114_2240_マルチテナント化概要設計.md
+++ b/docs/20260114_2240_マルチテナント化概要設計.md
@@ -469,53 +469,33 @@ admin/
 - 政治団体レベル: `/t/[tenantSlug]/o/[orgSlug]/`
 - counterparts / donors はテナント内で共有するため、団体を横断して利用可能
 
-### 5.3 デフォルトテナント/政治団体の選択と永続化
+### 5.3 ログイン後のリダイレクトフロー
 
-複数テナント・複数政治団体に所属するユーザー向けに、最後にアクセスしたコンテキストを記憶し、ログイン時に自動的にリダイレクトする。
-
-**データモデル**:
-```sql
--- ユーザー設定テーブル（新規）
-CREATE TABLE user_preferences (
-  id BIGSERIAL PRIMARY KEY,
-  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE UNIQUE,
-  last_accessed_tenant_id BIGINT REFERENCES tenants(id) ON DELETE SET NULL,
-  last_accessed_organization_id BIGINT REFERENCES political_organizations(id) ON DELETE SET NULL,
-  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
-```
-
-**ログイン後のリダイレクトフロー**:
 ```typescript
 async function getDefaultRedirectPath(userId: string): Promise<string> {
-  // 1. ユーザー設定から最後にアクセスしたテナント/政治団体を取得
-  const prefs = await getUserPreferences(userId);
-
-  if (prefs?.lastAccessedTenantId) {
-    // アクセス権限を検証
-    const canAccess = await canAccessTenant(userId, prefs.lastAccessedTenantId);
-    if (canAccess && prefs.lastAccessedOrganizationId) {
-      // 最後にアクセスした政治団体のダッシュボードへ
-      return `/t/${tenantSlug}/o/${orgSlug}/dashboard`;
-    }
-  }
-
-  // 2. 所属テナント一覧を取得
   const memberships = await getUserTenantMemberships(userId);
 
-  if (memberships.length === 1) {
-    // 単一テナントの場合、政治団体選択画面へ
-    return `/t/${memberships[0].tenantSlug}/select-organization`;
+  if (memberships.length === 0) {
+    // テナント未所属（通常は発生しない）
+    return '/no-tenant';
   }
 
-  // 3. 複数テナントの場合、テナント選択画面へ
+  if (memberships.length === 1) {
+    const tenant = memberships[0];
+    const orgs = await getOrganizationsByTenantId(tenant.tenantId);
+
+    if (orgs.length === 1) {
+      // 単一テナント・単一政治団体 → ダッシュボードへ直行
+      return `/t/${tenant.tenantSlug}/o/${orgs[0].slug}/dashboard`;
+    }
+    // 単一テナント・複数政治団体 → 政治団体選択画面へ
+    return `/t/${tenant.tenantSlug}/select-organization`;
+  }
+
+  // 複数テナント → テナント選択画面へ
   return '/select-tenant';
 }
 ```
-
-**コンテキスト切り替え時の更新**:
-- テナント/政治団体を切り替えた際、`user_preferences` を更新
-- セッション内では URL パラメータで状態を保持（サーバーサイドで都度検証）
 
 ### 5.4 Usecase / Repository の変更
 
@@ -738,7 +718,6 @@ USING (true);  -- または特定条件で公開可否を制御
 
 - [ ] `tenants` テーブル作成
 - [ ] `user_tenant_memberships` テーブル作成
-- [ ] `user_preferences` テーブル作成（デフォルトテナント/政治団体記憶用）
 - [ ] `political_organizations` に `tenant_id` カラム追加
 - [ ] `counterparts` に `tenant_id` カラム追加
 - [ ] `donors` に `tenant_id` カラム追加
@@ -752,11 +731,9 @@ USING (true);  -- または特定条件で公開可否を制御
 - [ ] `TenantRole` 型定義
 - [ ] `Tenant` モデル
 - [ ] `UserTenantMembership` モデル
-- [ ] `UserPreferences` モデル
 - [ ] `getCurrentContext()` 関数（URL からコンテキスト解決）
 - [ ] `getDefaultRedirectPath()` 関数（ログイン後リダイレクト）
 - [ ] テナントロール検証ロジック
-- [ ] テナント/政治団体切り替え時の設定更新ロジック
 
 ### 8.3 data-import コンテキスト
 

--- a/docs/20260114_2240_マルチテナント化概要設計.md
+++ b/docs/20260114_2240_マルチテナント化概要設計.md
@@ -1,0 +1,755 @@
+# マルチテナント化概要設計
+
+## 目的
+
+複数の利用者（政党・個人議員など）が、公式がホスティングする「まるみえ」に参加できるようにするため。
+現在は単一利用者が自己ホスティングする想定だが、WordPress.com のようなSaaSモデルへ転換し、各利用者が自分のテナントとしてデータを管理・公開できる環境を実現する。
+
+---
+
+## 1. 現状分析
+
+### 1.1 想定されるテナントの種類
+
+利用者によってテナントの規模・構成は異なる:
+
+**パターンA: 政党としての利用**
+```
+テナント: 〇〇党
+├── 政治団体A: 〇〇党本部
+├── 政治団体B: 〇〇党△△支部
+├── 政治団体C: 〇〇党□□後援会
+└── ...
+```
+
+**パターンB: 個人議員としての利用**
+```
+テナント: 鈴木一郎事務所
+├── 政治団体A: 鈴木一郎後援会
+└── 政治団体B: 鈴木一郎を応援する会
+```
+
+したがって:
+- **テナント** = 契約・管理単位（政党、個人議員事務所など）← **新規エンティティ**
+- **PoliticalOrganization** = 政治団体（テナント配下に1つ以上存在）
+
+### 1.2 現在のデータモデル
+
+```
+political_organizations（政治団体）
+├── id (BIGSERIAL)
+├── slug (TEXT, UNIQUE) ← URL識別子
+├── displayName, orgName, description
+└── createdAt, updatedAt
+※ 現状、上位のテナント（政党）への紐づけがない
+```
+
+### 1.3 政治団体に紐づくデータ（既存）
+
+| テーブル | FK | 備考 |
+|---------|-----|------|
+| `transactions` | `politicalOrganizationId` | 取引データ。全ての収支情報 |
+| `balance_snapshots` | `politicalOrganizationId` | 残高スナップショット |
+| `organization_report_profiles` | `politicalOrganizationId` + `financialYear` | 報告書プロフィール |
+
+### 1.4 グローバルマスタ（現状は全体共有）
+
+| テーブル | 備考 |
+|---------|------|
+| `counterparts` | 取引先マスタ。現在は全体共有 |
+| `donors` | 寄付者マスタ。現在は全体共有 |
+
+### 1.5 ユーザーとの関連
+
+**現状**: `users` テーブルにテナント（政党）への紐づけが存在しない。全ユーザーが全データにアクセス可能。
+
+```
+users
+├── id (TEXT)
+├── authId (TEXT, UNIQUE) ← Supabase auth.uid
+├── email (VARCHAR, UNIQUE)
+├── role (admin | user) ← グローバルロール
+└── createdAt, updatedAt
+```
+
+### 1.6 RLSの現状
+
+**未設定**。Prismaマイグレーション内に `ENABLE ROW LEVEL SECURITY` や `CREATE POLICY` の記述なし。
+
+### 1.7 マルチテナント化後のエンティティ構造（概要）
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ Tenant（テナント = 契約・管理単位）                               │
+│ 例: 〇〇党、鈴木一郎事務所、など                                  │
+├─────────────────────────────────────────────────────────────────┤
+│ ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐  │
+│ │ PoliticalOrg A  │  │ PoliticalOrg B  │  │ PoliticalOrg C  │  │
+│ │ (本部)          │  │ (支部)          │  │ (後援会)        │  │
+│ ├─────────────────┤  ├─────────────────┤  ├─────────────────┤  │
+│ │ - Transactions  │  │ - Transactions  │  │ - Transactions  │  │
+│ │ - BalanceSnap   │  │ - BalanceSnap   │  │ - BalanceSnap   │  │
+│ │ - ReportProfile │  │ - ReportProfile │  │ - ReportProfile │  │
+│ └─────────────────┘  └─────────────────┘  └─────────────────┘  │
+│                                                                 │
+│ ┌─────────────────────────────────────────────────────────────┐ │
+│ │ テナント内共有リソース                                       │ │
+│ │ - Counterparts（取引先マスタ）                               │ │
+│ │ - Donors（寄付者マスタ）                                     │ │
+│ └─────────────────────────────────────────────────────────────┘ │
+│                                                                 │
+│ ┌─────────────────────────────────────────────────────────────┐ │
+│ │ テナントメンバー                                             │ │
+│ │ - User A (owner)                                            │ │
+│ │ - User B (admin)                                            │ │
+│ │ - User C (editor)                                            │ │
+│ └─────────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 2. マルチテナント方式の選定
+
+### 2.1 方式比較
+
+| 方式 | 概要 | メリット | デメリット |
+|------|------|----------|------------|
+| **DB分離** | テナントごとに別DB | 完全分離、パフォーマンス独立 | 運用コスト高、マイグレーション複雑 |
+| **スキーマ分離** | テナントごとに別スキーマ | 分離性高い | Prisma非対応、運用複雑 |
+| **行レベル分離（RLS）** | 単一DB、RLSで行分離 | 運用シンプル、コスト低 | ポリシー設計が重要 |
+
+### 2.2 採用方式
+
+**行レベル分離（RLS）** を採用。
+
+理由:
+- Supabase の RLS 機能がネイティブサポート
+- 単一 DB でインフラ運用がシンプル
+- Prisma との互換性が確保可能
+
+---
+
+## 3. データモデル変更
+
+### 3.1 新規テーブル: テナント
+
+```sql
+-- テナント（契約・管理単位）テーブル
+CREATE TABLE tenants (
+  id BIGSERIAL PRIMARY KEY,
+  name VARCHAR(100) NOT NULL,           -- テナント名（例: 〇〇党、鈴木一郎事務所）
+  slug VARCHAR(50) NOT NULL UNIQUE,     -- URL識別子（例: xx-party, suzuki-office）
+  description TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+### 3.2 既存テーブルの変更: PoliticalOrganization
+
+```sql
+-- political_organizations にテナントへの紐づけを追加
+ALTER TABLE political_organizations
+ADD COLUMN tenant_id BIGINT REFERENCES tenants(id);
+
+-- 既存データのマイグレーション後、NOT NULL制約を追加
+-- ALTER TABLE political_organizations
+-- ALTER COLUMN tenant_id SET NOT NULL;
+```
+
+変更後のエンティティ関係:
+```
+tenants (テナント)
+└── political_organizations (政治団体) ※1:N
+    └── transactions (取引) ※1:N
+    └── balance_snapshots (残高) ※1:N
+    └── organization_report_profiles (報告書プロフィール) ※1:N
+```
+
+### 3.3 新規テーブル: ユーザー・テナント関連
+
+```sql
+-- ユーザーとテナント（政党）の多対多関連
+CREATE TABLE user_tenant_memberships (
+  id BIGSERIAL PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  tenant_id BIGINT NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  role VARCHAR(20) NOT NULL DEFAULT 'editor',  -- 'owner', 'admin', 'editor'
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  UNIQUE(user_id, tenant_id)
+);
+```
+
+**ロール定義案**:
+
+| ロール | 権限 |
+|--------|------|
+| `owner` | テナント全権限、メンバー管理、テナント削除、政治団体の追加・削除 |
+| `admin` | データ管理全権限、メンバー招待 |
+| `editor` | データ編集（インポート、取引先設定等） |
+
+### 3.4 Counterpart / Donor のテナント分離
+
+Counterpart（取引先）と Donor（寄付者）はテナント単位で分離する。
+
+- テナント間では完全に分離され、RLSで保護
+- 同一テナント内の複数政治団体間では共有可能
+
+```sql
+-- counterparts テーブルへの追加
+ALTER TABLE counterparts
+ADD COLUMN tenant_id BIGINT REFERENCES tenants(id);
+
+-- donors テーブルへの追加
+ALTER TABLE donors
+ADD COLUMN tenant_id BIGINT REFERENCES tenants(id);
+```
+
+### 3.5 既存データのマイグレーション
+
+```sql
+-- 1. 既存の政党用テナントを作成
+INSERT INTO tenants (name, slug, description)
+VALUES ('既存政党名', 'existing-party', '既存データ用テナント');
+
+-- 2. 既存の political_organizations をテナントに紐づけ
+UPDATE political_organizations
+SET tenant_id = (SELECT id FROM tenants WHERE slug = 'existing-party');
+
+-- 3. 既存の counterparts / donors をテナントに紐づけ
+UPDATE counterparts SET tenant_id = (SELECT id FROM tenants WHERE slug = 'existing-party');
+UPDATE donors SET tenant_id = (SELECT id FROM tenants WHERE slug = 'existing-party');
+
+-- 4. 既存ユーザーをテナントに紐づけ
+INSERT INTO user_tenant_memberships (user_id, tenant_id, role)
+SELECT id, (SELECT id FROM tenants WHERE slug = 'existing-party'), 'owner'
+FROM users;
+```
+
+---
+
+## 4. RLS（Row Level Security）設計
+
+### 4.1 RLSの動作原理
+
+```
+┌─────────────────────────────────────────────────────┐
+│ Supabase Auth: JWTに user_id を含む               │
+└─────────────────────────────────────────────────────┘
+                    ↓
+┌─────────────────────────────────────────────────────┐
+│ PostgreSQL: auth.uid() で現在のユーザーID取得      │
+│ → user_tenant_memberships を参照                  │
+│ → 所属テナント（政党）のIDを取得                    │
+│ → political_organizations 経由で配下データにアクセス │
+└─────────────────────────────────────────────────────┘
+```
+
+### 4.2 RLSポリシー設計
+
+#### tenants テーブル
+
+```sql
+ALTER TABLE tenants ENABLE ROW LEVEL SECURITY;
+
+-- 公開情報: 全員参照可能（政党一覧の表示用）
+CREATE POLICY "Anyone can view tenants"
+ON tenants FOR SELECT
+USING (true);
+
+-- 編集: ownerのみ
+CREATE POLICY "Owners can update tenants"
+ON tenants FOR UPDATE
+USING (
+  id IN (
+    SELECT tenant_id
+    FROM user_tenant_memberships
+    WHERE user_id = auth.uid()::TEXT
+    AND role = 'owner'
+  )
+);
+```
+
+#### political_organizations テーブル
+
+```sql
+ALTER TABLE political_organizations ENABLE ROW LEVEL SECURITY;
+
+-- 公開情報（webapp用）: 全員参照可能
+CREATE POLICY "Anyone can view organizations"
+ON political_organizations FOR SELECT
+USING (true);
+
+-- 編集: owner/adminのみ（所属テナント配下の政治団体）
+CREATE POLICY "Admins can manage organizations"
+ON political_organizations FOR ALL
+USING (
+  tenant_id IN (
+    SELECT tenant_id
+    FROM user_tenant_memberships
+    WHERE user_id = auth.uid()::TEXT
+    AND role IN ('owner', 'admin')
+  )
+);
+```
+
+#### transactions テーブル
+
+```sql
+ALTER TABLE transactions ENABLE ROW LEVEL SECURITY;
+
+-- ポリシー: ユーザーが所属するテナントの政治団体のデータのみ参照可能
+CREATE POLICY "Users can view own tenant transactions"
+ON transactions FOR SELECT
+USING (
+  political_organization_id IN (
+    SELECT po.id
+    FROM political_organizations po
+    JOIN user_tenant_memberships utm ON po.tenant_id = utm.tenant_id
+    WHERE utm.user_id = auth.uid()::TEXT
+  )
+);
+
+-- ポリシー: editor以上のロールで挿入可能
+CREATE POLICY "Editors can insert transactions"
+ON transactions FOR INSERT
+WITH CHECK (
+  political_organization_id IN (
+    SELECT po.id
+    FROM political_organizations po
+    JOIN user_tenant_memberships utm ON po.tenant_id = utm.tenant_id
+    WHERE utm.user_id = auth.uid()::TEXT
+    AND utm.role IN ('owner', 'admin', 'editor')
+  )
+);
+
+-- 同様にUPDATE, DELETEも定義
+```
+
+#### 他テーブルのRLS
+
+同様のパターンで以下テーブルにRLSを設定:
+- `balance_snapshots`（political_organization_id 経由）
+- `organization_report_profiles`（political_organization_id 経由）
+- `counterparts`（tenant_id で直接フィルタ）
+- `donors`（tenant_id で直接フィルタ）
+- `transaction_counterparts`（transactions の FK で間接保護）
+- `transaction_donors`（transactions の FK で間接保護）
+
+### 4.3 user_tenant_memberships のRLS
+
+```sql
+ALTER TABLE user_tenant_memberships ENABLE ROW LEVEL SECURITY;
+
+-- 自分のメンバーシップは参照可能
+CREATE POLICY "Users can view own memberships"
+ON user_tenant_memberships FOR SELECT
+USING (user_id = auth.uid()::TEXT);
+
+-- ownerのみが同じテナントのメンバーを管理可能
+CREATE POLICY "Owners can manage memberships"
+ON user_tenant_memberships FOR ALL
+USING (
+  tenant_id IN (
+    SELECT tenant_id
+    FROM user_tenant_memberships
+    WHERE user_id = auth.uid()::TEXT
+    AND role = 'owner'
+  )
+);
+```
+
+### 4.4 counterparts / donors のRLS
+
+```sql
+ALTER TABLE counterparts ENABLE ROW LEVEL SECURITY;
+
+-- 同一テナント内で共有（複数政治団体間で取引先を共有可能）
+CREATE POLICY "Users can view own tenant counterparts"
+ON counterparts FOR SELECT
+USING (
+  tenant_id IN (
+    SELECT tenant_id
+    FROM user_tenant_memberships
+    WHERE user_id = auth.uid()::TEXT
+  )
+);
+
+-- editor以上で作成・編集可能
+CREATE POLICY "Editors can manage counterparts"
+ON counterparts FOR ALL
+USING (
+  tenant_id IN (
+    SELECT tenant_id
+    FROM user_tenant_memberships
+    WHERE user_id = auth.uid()::TEXT
+    AND role IN ('owner', 'admin', 'editor')
+  )
+);
+
+-- donors も同様のポリシー
+```
+
+---
+
+## 5. アプリケーション層の変更
+
+### 5.1 認証コンテキスト（auth）の拡張
+
+**現状**:
+- `UserRole`: `"admin" | "user"`（グローバルロール）
+- ユーザー取得時にテナント情報なし
+
+**変更後**:
+- テナントロール（`"owner" | "admin" | "editor" | "viewer"`）の導入
+- 現在のテナント（政党）コンテキストを保持する仕組み
+- 政治団体の選択（テナント内で複数団体を切り替え）
+
+```typescript
+// 新規: テナントコンテキスト型
+interface TenantContext {
+  tenantId: bigint;
+  tenantSlug: string;
+  tenantName: string;
+  role: TenantRole;
+  organizations: PoliticalOrganization[];  // テナント配下の政治団体一覧
+}
+
+// 拡張: 認証ユーザー型
+interface AuthenticatedUser {
+  id: string;
+  email: string;
+  globalRole: GlobalRole;  // システム管理者用
+  tenants: TenantMembership[];  // 所属テナント（政党）一覧
+  currentTenant?: TenantContext;  // 現在選択中のテナント
+  currentOrganization?: PoliticalOrganization;  // 現在選択中の政治団体
+}
+```
+
+### 5.2 URL構造とナビゲーション
+
+```
+admin/
+├── /select-tenant              # テナント（政党）選択画面（複数所属時）
+├── /t/[tenantSlug]/            # テナント別のルート
+│   ├── select-organization     # 政治団体選択画面
+│   ├── settings/               # テナント設定（メンバー管理等）
+│   └── o/[orgSlug]/            # 政治団体別のルート
+│       ├── dashboard/
+│       ├── transactions/
+│       ├── counterparts/       # テナント内共有（複数団体で共有可）
+│       ├── donors/             # テナント内共有
+│       └── report/
+```
+
+**ポイント**:
+- テナント（政党）レベル: `/t/[tenantSlug]/`
+- 政治団体レベル: `/t/[tenantSlug]/o/[orgSlug]/`
+- counterparts / donors はテナント内で共有するため、団体を横断して利用可能
+
+### 5.3 Usecase / Repository の変更
+
+**原則**:
+- テナントレベルの操作: `tenantId` を必須パラメータ化
+- 政治団体レベルの操作: `politicalOrganizationId` を必須パラメータ化
+- テナント配下であることの検証を追加
+
+```typescript
+// Before
+interface GetTransactionsInput {
+  financialYear: number;
+  // テナント・組織情報なし
+}
+
+// After
+interface GetTransactionsInput {
+  tenantId: string;  // テナント検証用
+  politicalOrganizationId: string;  // 必須
+  financialYear: number;
+}
+
+// Counterpart はテナント単位（政治団体を横断して共有）
+interface GetCounterpartsInput {
+  tenantId: string;  // 必須
+  // politicalOrganizationId は不要（テナント内共有）
+}
+```
+
+### 5.4 Prisma と RLS の統合
+
+**課題**: Prismaは通常、サービスロールで接続するためRLSをバイパスする。
+
+**解決策**:
+
+```typescript
+// Option A: Supabaseクライアント経由でRLSを適用
+const supabase = createServerClient(/* ユーザーのセッション */);
+const { data } = await supabase
+  .from('transactions')
+  .select('*');  // RLSが自動適用
+
+// Option B: Prismaで明示的にフィルタ（RLSはフォールバック保護）
+const transactions = await prisma.transactions.findMany({
+  where: {
+    political_organization_id: currentTenant.id,  // 明示的フィルタ
+    // ... その他の条件
+  }
+});
+```
+
+**推奨**: Option B + RLSによる二重保護
+- アプリケーション層で明示的にフィルタ（パフォーマンス・可読性）
+- RLSはセーフティネットとして機能（フィルタ漏れ防止）
+
+---
+
+## 6. 本番環境への RLS 導入手順
+
+### 6.1 前提条件
+
+- 既存の本番環境が稼働中
+- 単一テナント（政治団体）のデータが存在
+- ダウンタイムを最小限に抑える必要がある
+
+### 6.2 フェーズ1: 準備（ダウンタイムなし）
+
+1. **スキーマ変更の準備**
+   - `tenants` テーブル作成
+   - `user_tenant_memberships` テーブル作成
+   - `political_organizations` に `tenant_id` カラム追加（NULL許容）
+   - `counterparts`, `donors` に `tenant_id` カラム追加（NULL許容）
+
+2. **既存データのマイグレーション**
+   - 既存政党用の `tenants` レコード作成
+   - 既存 `political_organizations` をテナントに紐づけ
+   - 既存ユーザーをテナントに紐づけ（`user_tenant_memberships` へ INSERT）
+   - 既存 counterparts / donors をテナントに紐づけ
+
+3. **NOT NULL制約の追加**
+   - データ移行完了後、各テーブルの `tenant_id` に NOT NULL 制約追加
+
+### 6.3 フェーズ2: アプリケーション対応
+
+1. **admin アプリの修正**
+   - テナントコンテキストの導入
+   - 全 Usecase / Repository へのテナントID必須化
+   - URL構造の変更（`/t/[tenantSlug]/o/[orgSlug]/...`）
+   - テナント選択・政治団体選択画面の実装
+
+2. **webapp アプリの確認**
+   - 既に slug ベースで政治団体を分離しているため、大きな変更不要
+   - 必要に応じてテナント（政党）単位のトップページを検討
+   - RLS導入後も動作確認
+
+3. **テスト**
+   - ステージング環境での動作確認
+   - テナント間のデータ分離テスト
+
+### 6.4 フェーズ3: RLS有効化（メンテナンス時間）
+
+**注意**: RLS有効化は即座に全クエリに影響するため、メンテナンス時間を設ける。
+
+1. **メンテナンスモード開始**
+   - ユーザーアクセスを一時停止
+
+2. **RLSポリシー作成**
+   ```sql
+   -- 各テーブルに対してRLSポリシーを作成
+   -- ポリシー作成時点ではRLSはまだ無効
+   ```
+
+3. **RLS有効化**
+   ```sql
+   -- テーブルごとにRLSを有効化
+   ALTER TABLE transactions ENABLE ROW LEVEL SECURITY;
+   ALTER TABLE balance_snapshots ENABLE ROW LEVEL SECURITY;
+   -- ... 他テーブル
+   ```
+
+4. **動作確認**
+   - 管理者アカウントでの動作確認
+   - データアクセステスト
+
+5. **メンテナンスモード終了**
+
+### 6.5 フェーズ4: 新規テナント受け入れ準備
+
+1. **テナント作成フロー実装**
+   - 新規政治団体の登録
+   - 初期ユーザー（owner）の設定
+   - テナント設定画面
+
+2. **テナント管理機能**
+   - メンバー招待
+   - ロール変更
+   - テナント設定
+
+### 6.6 ロールバック計画
+
+RLS導入で問題が発生した場合のロールバック:
+
+```sql
+-- RLSを無効化（即座にデータアクセス可能に）
+ALTER TABLE transactions DISABLE ROW LEVEL SECURITY;
+-- ... 他テーブル
+
+-- ポリシーは削除しなくても、RLS無効化で影響なし
+```
+
+---
+
+## 7. webapp（公開サイト）への影響
+
+### 7.1 現状の動作
+
+- URL: `/o/[slug]/...`
+- slug から `politicalOrganizationId` を取得
+- テナントのデータのみを表示
+
+### 7.2 RLS導入後
+
+**変更なし**。
+
+理由:
+- webapp は匿名アクセス（Supabase Auth なし）
+- `political_organizations` テーブルの SELECT は全員許可
+- データ取得は slug 経由で明示的にフィルタ済み
+
+**注意点**:
+- webapp からの DB アクセスは Supabase の anon キーを使用
+- RLS ポリシーで anon アクセスを適切に許可する必要あり
+
+```sql
+-- 公開データ用のポリシー（匿名アクセス許可）
+CREATE POLICY "Anyone can view public transactions"
+ON transactions FOR SELECT
+USING (true);  -- または特定条件で公開可否を制御
+```
+
+---
+
+## 8. 実装タスク一覧
+
+### 8.1 DB / インフラ
+
+- [ ] `tenants` テーブル作成
+- [ ] `user_tenant_memberships` テーブル作成
+- [ ] `political_organizations` に `tenant_id` カラム追加
+- [ ] `counterparts` に `tenant_id` カラム追加
+- [ ] `donors` に `tenant_id` カラム追加
+- [ ] 既存データのテナント紐づけマイグレーション
+- [ ] NOT NULL 制約追加
+- [ ] RLS ポリシー作成スクリプト
+- [ ] RLS 有効化手順書
+
+### 8.2 認証・認可（auth コンテキスト）
+
+- [ ] `TenantRole` 型定義
+- [ ] `Tenant` モデル
+- [ ] `UserTenantMembership` モデル
+- [ ] `TenantContext` の導入
+- [ ] テナントロール検証ロジック
+- [ ] 現在のテナント・政治団体取得・切り替えロジック
+
+### 8.3 data-import コンテキスト
+
+- [ ] `tenantId`, `politicalOrganizationId` 必須化
+- [ ] テナント権限チェック追加
+- [ ] 政治団体がテナント配下であることの検証
+
+### 8.4 report コンテキスト
+
+- [ ] Counterpart 作成時のテナント紐づけ（`tenant_id` 設定）
+- [ ] Donor 作成時のテナント紐づけ（`tenant_id` 設定）
+- [ ] Bulk Assign 時のテナント検証
+- [ ] XML エクスポートのテナント検証
+
+### 8.5 admin UI
+
+- [ ] テナント（政党）選択画面
+- [ ] 政治団体選択画面
+- [ ] URL 構造変更（`/t/[tenantSlug]/o/[orgSlug]/...`）
+- [ ] テナント・政治団体切り替え UI
+- [ ] メンバー管理画面
+- [ ] 政治団体管理画面（テナント配下の団体追加・編集）
+
+### 8.6 webapp
+
+- [ ] RLS 導入後の動作確認
+- [ ] anon アクセス用 RLS ポリシー設定
+- [ ] （オプション）テナント（政党）単位のトップページ
+
+### 8.7 テスト・ドキュメント
+
+- [ ] マルチテナントテストケース作成
+- [ ] テナント間データ分離テスト
+- [ ] 本番 RLS 導入手順書
+- [ ] ロールバック手順書
+
+---
+
+## 9. 考慮事項・リスク
+
+### 9.1 パフォーマンス
+
+- RLS ポリシーの `IN (SELECT ...)` はサブクエリを毎回実行
+- 対策: `user_tenant_memberships` と `political_organizations` に適切なインデックス
+
+```sql
+CREATE INDEX idx_user_tenant_memberships_user_id
+ON user_tenant_memberships(user_id);
+
+CREATE INDEX idx_user_tenant_memberships_tenant_id
+ON user_tenant_memberships(tenant_id);
+
+CREATE INDEX idx_political_organizations_tenant_id
+ON political_organizations(tenant_id);
+
+CREATE INDEX idx_counterparts_tenant_id
+ON counterparts(tenant_id);
+
+CREATE INDEX idx_donors_tenant_id
+ON donors(tenant_id);
+```
+
+### 9.2 Prisma との統合
+
+- Prisma は RLS をバイパスする可能性がある（サービスロール使用時）
+- 対策: アプリケーション層での明示的フィルタを維持
+- RLS は「最後の砦」として機能
+
+### 9.3 既存データのマイグレーション
+
+- 単一テナント運用からの移行
+- 既存ユーザー・データの紐づけが必要
+- 対策: フェーズ1 で事前にデータ準備
+
+### 9.4 グローバル管理者を設けない設計
+
+**方針**: freee等のSaaSと同様に、全テナントを横断して閲覧できる管理者をアプリケーション上に設けない。
+
+**理由**:
+- 政治的中立性の担保: 運営者が特定政党のデータを覗き見できないことを技術的に保証
+- 信頼性の向上: 各テナント（政党）のデータが完全に独立していることを利用者に示せる
+- セキュリティリスクの低減: 万が一の内部不正や情報漏洩リスクを最小化
+
+**運用上の対応**:
+- システム障害対応やデータ移行が必要な場合は、Supabase管理コンソール（DB直接アクセス）で対応
+- アプリケーション経由では絶対に他テナントのデータにアクセスできない
+- 監査ログ等で直接アクセスの記録を残す
+
+**users.role について**:
+- マルチテナント化に伴い `users.role` カラムは削除する
+- 権限管理は全て `user_tenant_memberships.role` に一本化
+- 現在の「ユーザー管理」機能はテナント内「メンバー管理」に置き換え
+
+---
+
+## 10. 参考資料
+
+- [Supabase Row Level Security](https://supabase.com/docs/guides/auth/row-level-security)
+- [PostgreSQL RLS](https://www.postgresql.org/docs/current/ddl-rowsecurity.html)
+- [Prisma with Supabase RLS](https://supabase.com/docs/guides/integrations/prisma)

--- a/docs/20260114_2240_マルチテナント化概要設計.md
+++ b/docs/20260114_2240_マルチテナント化概要設計.md
@@ -404,7 +404,7 @@ USING (
 - ユーザー取得時にテナント情報なし
 
 **変更後**:
-- テナントロール（`"owner" | "admin" | "editor" | "viewer"`）の導入
+- テナントロール（`"owner" | "admin" | "editor"`）の導入
 - 現在のテナント（政党）コンテキストを保持する仕組み
 - 政治団体の選択（テナント内で複数団体を切り替え）
 
@@ -422,7 +422,6 @@ interface TenantContext {
 interface AuthenticatedUser {
   id: string;
   email: string;
-  globalRole: GlobalRole;  // システム管理者用
   tenants: TenantMembership[];  // 所属テナント（政党）一覧
   currentTenant?: TenantContext;  // 現在選択中のテナント
   currentOrganization?: PoliticalOrganization;  // 現在選択中の政治団体

--- a/docs/20260114_2240_マルチテナント化概要設計.md
+++ b/docs/20260114_2240_マルチテナント化概要設計.md
@@ -409,24 +409,38 @@ USING (
 - 政治団体の選択（テナント内で複数団体を切り替え）
 
 ```typescript
-// 新規: テナントコンテキスト型
-interface TenantContext {
+// Domain層: テナントロール型
+type TenantRole = 'owner' | 'admin' | 'editor';
+
+// Presentation層: 現在のコンテキストを解決
+interface CurrentContext {
   tenantId: bigint;
   tenantSlug: string;
-  tenantName: string;
-  role: TenantRole;
-  organizations: PoliticalOrganization[];  // テナント配下の政治団体一覧
+  tenantRole: TenantRole;
+  organizationId: bigint;
+  organizationSlug: string;
 }
 
-// 拡張: 認証ユーザー型
+// Presentation層でURLパラメータからコンテキストを解決し、Usecaseに渡す
+async function getCurrentContext(): Promise<CurrentContext> {
+  // URL（/t/[tenantSlug]/o/[orgSlug]/...）からslugを取得
+  // DBで検証し、現在のユーザーがアクセス可能か確認
+  // tenantId, organizationId を返す
+}
+
+// 認証ユーザー型（所属テナント一覧の参照用）
 interface AuthenticatedUser {
   id: string;
   email: string;
   tenants: TenantMembership[];  // 所属テナント（政党）一覧
-  currentTenant?: TenantContext;  // 現在選択中のテナント
-  currentOrganization?: PoliticalOrganization;  // 現在選択中の政治団体
 }
 ```
+
+**ポイント**:
+- `TenantRole` はドメイン層（`domain/models/`）に配置
+- `tenantId` / `organizationId` はUsecaseの `execute()` メソッドの入力パラメータとして渡す
+- Presentation層（loader / action）でURLからコンテキストを解決し、Usecaseに渡す
+- `AuthenticatedUser` にはテナント一覧のみを保持（現在選択中のコンテキストは保持しない）
 
 ### 5.2 URL構造とナビゲーション
 
@@ -465,14 +479,14 @@ interface GetTransactionsInput {
 
 // After
 interface GetTransactionsInput {
-  tenantId: string;  // テナント検証用
-  politicalOrganizationId: string;  // 必須
+  tenantId: bigint;  // テナント検証用
+  politicalOrganizationId: bigint;  // 必須
   financialYear: number;
 }
 
 // Counterpart はテナント単位（政治団体を横断して共有）
 interface GetCounterpartsInput {
-  tenantId: string;  // 必須
+  tenantId: bigint;  // 必須
   // politicalOrganizationId は不要（テナント内共有）
 }
 ```
@@ -491,10 +505,10 @@ const { data } = await supabase
   .select('*');  // RLSが自動適用
 
 // Option B: Prismaで明示的にフィルタ（RLSはフォールバック保護）
-const transactions = await prisma.transactions.findMany({
+const transactions = await prisma.transaction.findMany({
   where: {
-    political_organization_id: currentTenant.id,  // 明示的フィルタ
-    // ... その他の条件
+    politicalOrganizationId: input.politicalOrganizationId,  // 政治団体IDでフィルタ
+    financialYear: input.financialYear,
   }
 });
 ```

--- a/docs/20260114_2240_マルチテナント化概要設計.md
+++ b/docs/20260114_2240_マルチテナント化概要設計.md
@@ -819,19 +819,93 @@ CREATE INDEX idx_donors_tenant_id
 ON donors(tenant_id);
 ```
 
-### 9.2 Prisma との統合
+### 9.2 マルチテナント環境でのキャッシュ戦略
+
+マルチテナント環境では、キャッシュキーにテナントID・政治団体IDを含め、テナント間でキャッシュが混在しないようにする。
+
+**キャッシュキーの設計**:
+```typescript
+// presentation/loaders/transactions.ts
+import { unstable_cache } from 'next/cache';
+
+export async function transactionsLoader(
+  tenantSlug: string,
+  orgSlug: string,
+  financialYear: number
+) {
+  // URLからコンテキストを解決
+  const context = await getCurrentContext(tenantSlug, orgSlug);
+
+  // テナント・政治団体スコープのキャッシュ
+  const getCachedTransactions = unstable_cache(
+    async () => {
+      const usecase = new GetTransactionsUsecase(transactionRepository);
+      return usecase.execute({
+        tenantId: context.tenantId,
+        politicalOrganizationId: context.organizationId,
+        financialYear,
+      });
+    },
+    // キャッシュキー: テナントID・政治団体ID・年度を含める
+    [`transactions`, `tenant-${context.tenantId}`, `org-${context.organizationId}`, `year-${financialYear}`],
+    {
+      // タグ: 無効化時に使用
+      tags: [
+        `tenant-${context.tenantId}-transactions`,
+        `org-${context.organizationId}-transactions`,
+      ],
+      revalidate: 60, // 60秒
+    }
+  );
+
+  return getCachedTransactions();
+}
+```
+
+**テナントスコープのキャッシュ無効化**:
+```typescript
+// presentation/actions/import-transactions.ts
+import { revalidateTag } from 'next/cache';
+
+export async function importTransactionsAction(
+  tenantSlug: string,
+  orgSlug: string,
+  csvData: string
+) {
+  const context = await getCurrentContext(tenantSlug, orgSlug);
+
+  // インポート処理...
+  const usecase = new ImportTransactionsUsecase(transactionRepository);
+  await usecase.execute({
+    tenantId: context.tenantId,
+    politicalOrganizationId: context.organizationId,
+    csvData,
+  });
+
+  // 該当テナント・政治団体のキャッシュのみ無効化
+  revalidateTag(`tenant-${context.tenantId}-transactions`);
+  revalidateTag(`org-${context.organizationId}-transactions`);
+}
+```
+
+**RLSとキャッシュの関係**:
+- RLSはDBレベルでの保護であり、キャッシュレイヤーには影響しない
+- キャッシュキーにテナント情報を含めることで、テナント間のキャッシュ汚染を防止
+- RLSは「万が一キャッシュキーの設計ミスがあった場合」のセーフティネットとして機能
+
+### 9.3 Prisma との統合
 
 - Prisma は RLS をバイパスする可能性がある（サービスロール使用時）
 - 対策: アプリケーション層での明示的フィルタを維持
 - RLS は「最後の砦」として機能
 
-### 9.3 既存データのマイグレーション
+### 9.4 既存データのマイグレーション
 
 - 単一テナント運用からの移行
 - 既存ユーザー・データの紐づけが必要
 - 対策: フェーズ1 で事前にデータ準備
 
-### 9.4 グローバル管理者を設けない設計
+### 9.5 グローバル管理者を設けない設計
 
 **方針**: freee等のSaaSと同様に、全テナントを横断して閲覧できる管理者をアプリケーション上に設けない。
 


### PR DESCRIPTION
## Summary

- 複数の政党・個人議員が利用できるSaaSモデルへの転換に向けた概要設計を追加
- RLS（Row Level Security）による行レベル分離を採用
- グローバル管理者を設けない設計（政治的中立性の担保）

## 目的（Why）

運営者が複数の政党のデータをホスティングできるようにするため。各政党・個人議員が安心してデータを預けられるよう、テナント間の完全分離と政治的中立性を技術的に担保する。

## 主な設計方針

- **テナント**: 契約・管理単位（政党、個人議員事務所など）
- **RLS**: Supabaseネイティブ機能を活用した行レベルセキュリティ
- **グローバル管理者なし**: freee等と同様に、全テナント横断の管理者を設けない
- **users.role廃止**: 権限管理を `user_tenant_memberships.role` に一本化

## Test plan

- [ ] 設計内容のレビュー
- [ ] 実装フェーズでの詳細設計との整合性確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * マルチテナント化の概要設計書を追加しました。テナントを契約・管理単位とする新構成、テナント配下への組織紐付け、Counterparts/Donors 等のデータ分離対象、ユーザーとテナントの多対多関係、RLS前提の細粒度アクセス制御、認証コンテキストとURL構造(/t/[tenant]/o/[org]/...)案、テナント選択UI、移行・デプロイ計画、運用リスク対策と実装タスクを網羅。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->