### PR TITLE
docs: フェーズ2マルチテナント化の詳細設計手順書を追加

### DIFF
--- a/docs/20260115_フェーズ2マルチテナント化詳細設計.md
+++ b/docs/20260115_フェーズ2マルチテナント化詳細設計.md
@@ -1,0 +1,1657 @@
+# フェーズ2: マルチテナント化アプリケーション対応 詳細設計手順書
+
+## 目的
+
+フェーズ1で整備したマルチテナント基盤（スキーマ・ドメインモデル）を活用し、admin アプリケーションをマルチテナント対応させる。URL構造の変更、テナントコンテキストの導入、全Usecase/Repositoryへのテナント必須化を実施する。
+
+---
+
+## スコープ
+
+フェーズ2で実施する内容:
+
+1. **テナントコンテキスト基盤**: `getCurrentContext()` 関数の実装、URLからのテナント解決
+2. **URL構造の変更**: `/t/[tenantSlug]/o/[orgSlug]/...` 形式への移行
+3. **Usecase / Repository の対応**: 全クエリへの `tenantId` 必須化、テナントフィルタリング
+4. **UI実装**: テナント選択画面、政治団体選択画面、ログイン後リダイレクト
+5. **キャッシュ戦略**: テナントスコープのキャッシュキー設計
+
+フェーズ2で実施しない内容:
+- RLSポリシーの作成・有効化（フェーズ3）
+- メンバー管理画面の実装（フェーズ4）
+- 新規テナント作成フローの実装（フェーズ4）
+
+---
+
+## 前提条件
+
+- フェーズ1が完了していること
+  - `tenants`, `user_tenant_memberships` テーブルが存在
+  - 既存データがテナントに紐づけ済み
+  - `tenant_id` カラムに NOT NULL 制約が適用済み
+- 既存の機能が正常に動作していること
+
+---
+
+## 1. テナントコンテキスト基盤
+
+### 1.1 TenantContext ドメインモデル
+
+**ファイル**: `admin/src/server/contexts/auth/domain/models/tenant-context.ts`
+
+```typescript
+import "server-only";
+
+import type { TenantRole } from "@/server/contexts/auth/domain/models/tenant-role";
+
+/**
+ * 現在のテナントコンテキスト
+ * URLパラメータから解決され、Usecaseに渡される
+ */
+export interface TenantContext {
+  /** テナントID */
+  tenantId: bigint;
+  /** テナントslug（URLパラメータ） */
+  tenantSlug: string;
+  /** テナント名 */
+  tenantName: string;
+  /** 現在のユーザーのテナント内ロール */
+  tenantRole: TenantRole;
+}
+
+/**
+ * 現在の政治団体コンテキスト（テナントコンテキストを含む）
+ * 政治団体レベルの操作で使用
+ */
+export interface OrganizationContext extends TenantContext {
+  /** 政治団体ID */
+  organizationId: bigint;
+  /** 政治団体slug（URLパラメータ） */
+  organizationSlug: string;
+  /** 政治団体名 */
+  organizationName: string;
+}
+
+/**
+ * コンテキスト解決エラー
+ */
+export class TenantContextError extends Error {
+  constructor(
+    message: string,
+    public readonly code:
+      | "TENANT_NOT_FOUND"
+      | "ORGANIZATION_NOT_FOUND"
+      | "ACCESS_DENIED"
+      | "NOT_AUTHENTICATED"
+  ) {
+    super(message);
+    this.name = "TenantContextError";
+  }
+}
+```
+
+### 1.2 AuthenticatedUserWithTenants ドメインモデル
+
+**ファイル**: `admin/src/server/contexts/auth/domain/models/authenticated-user.ts`
+
+```typescript
+import "server-only";
+
+import type { TenantMembershipWithTenant } from "@/server/contexts/auth/domain/models/user-tenant-membership";
+
+/**
+ * 認証済みユーザー（テナントメンバーシップ付き）
+ */
+export interface AuthenticatedUserWithTenants {
+  /** ユーザーID */
+  id: string;
+  /** メールアドレス */
+  email: string;
+  /** 所属テナント一覧 */
+  tenants: TenantMembershipWithTenant[];
+}
+
+/**
+ * AuthenticatedUserWithTenants のドメインモデル
+ */
+export const AuthenticatedUserWithTenantsModel = {
+  /**
+   * ユーザーが指定したテナントに所属しているか判定
+   */
+  belongsToTenant(
+    user: AuthenticatedUserWithTenants,
+    tenantId: bigint
+  ): boolean {
+    return user.tenants.some((t) => t.membership.tenantId === tenantId);
+  },
+
+  /**
+   * ユーザーが指定したテナントで持つロールを取得
+   */
+  getTenantRole(
+    user: AuthenticatedUserWithTenants,
+    tenantId: bigint
+  ): TenantMembershipWithTenant | undefined {
+    return user.tenants.find((t) => t.membership.tenantId === tenantId);
+  },
+
+  /**
+   * 単一テナント所属かどうか判定
+   */
+  hasSingleTenant(user: AuthenticatedUserWithTenants): boolean {
+    return user.tenants.length === 1;
+  },
+} as const;
+```
+
+### 1.3 GetCurrentUserWithTenantsUsecase
+
+**ファイル**: `admin/src/server/contexts/auth/application/usecases/get-current-user-with-tenants-usecase.ts`
+
+```typescript
+import "server-only";
+
+import type { AuthProvider } from "@/server/contexts/auth/domain/services/auth-provider.interface";
+import type { UserRepository } from "@/server/contexts/shared/domain/repositories/user-repository.interface";
+import type { UserTenantMembershipRepository } from "@/server/contexts/auth/domain/repositories/user-tenant-membership-repository.interface";
+import type { AuthenticatedUserWithTenants } from "@/server/contexts/auth/domain/models/authenticated-user";
+
+/**
+ * 現在のユーザーをテナントメンバーシップ付きで取得するUsecase
+ */
+export class GetCurrentUserWithTenantsUsecase {
+  constructor(
+    private readonly authProvider: AuthProvider,
+    private readonly userRepository: UserRepository,
+    private readonly membershipRepository: UserTenantMembershipRepository
+  ) {}
+
+  async execute(): Promise<AuthenticatedUserWithTenants | null> {
+    // 1. Supabase Authからユーザー情報を取得
+    const authUser = await this.authProvider.getUser();
+    if (!authUser) {
+      return null;
+    }
+
+    // 2. DBからユーザー情報を取得
+    const user = await this.userRepository.findByAuthId(authUser.authId);
+    if (!user) {
+      return null;
+    }
+
+    // 3. ユーザーのテナントメンバーシップを取得
+    const memberships = await this.membershipRepository.findByUserId(user.id);
+
+    return {
+      id: user.id,
+      email: user.email,
+      tenants: memberships,
+    };
+  }
+}
+```
+
+### 1.4 getCurrentUserWithTenants Loader
+
+**ファイル**: `admin/src/server/contexts/auth/presentation/loaders/load-current-user-with-tenants.ts`
+
+```typescript
+import "server-only";
+
+import { cache } from "react";
+
+import { SupabaseAuthProvider } from "@/server/contexts/auth/infrastructure/services/supabase-auth-provider";
+import { PrismaUserRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-user.repository";
+import { PrismaUserTenantMembershipRepository } from "@/server/contexts/auth/infrastructure/repositories/prisma-user-tenant-membership.repository";
+import { GetCurrentUserWithTenantsUsecase } from "@/server/contexts/auth/application/usecases/get-current-user-with-tenants-usecase";
+import type { AuthenticatedUserWithTenants } from "@/server/contexts/auth/domain/models/authenticated-user";
+
+/**
+ * 現在のユーザーをテナントメンバーシップ付きで取得
+ * React cache で同一リクエスト内でキャッシュ
+ */
+export const getCurrentUserWithTenants = cache(
+  async (): Promise<AuthenticatedUserWithTenants | null> => {
+    const authProvider = new SupabaseAuthProvider();
+    const userRepository = new PrismaUserRepository();
+    const membershipRepository = new PrismaUserTenantMembershipRepository();
+
+    const usecase = new GetCurrentUserWithTenantsUsecase(
+      authProvider,
+      userRepository,
+      membershipRepository
+    );
+
+    return usecase.execute();
+  }
+);
+```
+
+### 1.5 resolveTenantContext Loader
+
+**ファイル**: `admin/src/server/contexts/auth/presentation/loaders/resolve-tenant-context.ts`
+
+```typescript
+import "server-only";
+
+import { cache } from "react";
+
+import type {
+  TenantContext,
+  OrganizationContext,
+} from "@/server/contexts/auth/domain/models/tenant-context";
+import { TenantContextError } from "@/server/contexts/auth/domain/models/tenant-context";
+import { getCurrentUserWithTenants } from "@/server/contexts/auth/presentation/loaders/load-current-user-with-tenants";
+import { PrismaTenantRepository } from "@/server/contexts/auth/infrastructure/repositories/prisma-tenant.repository";
+import { PrismaPoliticalOrganizationRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-political-organization.repository";
+
+/**
+ * URLパラメータからテナントコンテキストを解決
+ * @param tenantSlug テナントslug（URLパラメータ）
+ * @throws TenantContextError 認証エラー、アクセス拒否、テナント不存在
+ */
+export const resolveTenantContext = cache(
+  async (tenantSlug: string): Promise<TenantContext> => {
+    // 1. 現在のユーザーを取得
+    const user = await getCurrentUserWithTenants();
+    if (!user) {
+      throw new TenantContextError(
+        "認証が必要です",
+        "NOT_AUTHENTICATED"
+      );
+    }
+
+    // 2. テナントをslugで取得
+    const tenantRepository = new PrismaTenantRepository();
+    const tenant = await tenantRepository.findBySlug(tenantSlug);
+    if (!tenant) {
+      throw new TenantContextError(
+        `テナント "${tenantSlug}" が見つかりません`,
+        "TENANT_NOT_FOUND"
+      );
+    }
+
+    // 3. ユーザーがテナントに所属しているか確認
+    const membership = user.tenants.find(
+      (t) => t.membership.tenantId === tenant.id
+    );
+    if (!membership) {
+      throw new TenantContextError(
+        `テナント "${tenantSlug}" へのアクセス権がありません`,
+        "ACCESS_DENIED"
+      );
+    }
+
+    return {
+      tenantId: tenant.id,
+      tenantSlug: tenant.slug,
+      tenantName: tenant.name,
+      tenantRole: membership.membership.role,
+    };
+  }
+);
+
+/**
+ * URLパラメータから政治団体コンテキストを解決
+ * @param tenantSlug テナントslug（URLパラメータ）
+ * @param orgSlug 政治団体slug（URLパラメータ）
+ * @throws TenantContextError 認証エラー、アクセス拒否、テナント/政治団体不存在
+ */
+export const resolveOrganizationContext = cache(
+  async (tenantSlug: string, orgSlug: string): Promise<OrganizationContext> => {
+    // 1. テナントコンテキストを解決
+    const tenantContext = await resolveTenantContext(tenantSlug);
+
+    // 2. 政治団体をslugで取得
+    const orgRepository = new PrismaPoliticalOrganizationRepository();
+    const org = await orgRepository.findBySlug(orgSlug);
+    if (!org) {
+      throw new TenantContextError(
+        `政治団体 "${orgSlug}" が見つかりません`,
+        "ORGANIZATION_NOT_FOUND"
+      );
+    }
+
+    // 3. 政治団体がテナントに所属しているか確認
+    if (org.tenantId !== tenantContext.tenantId) {
+      throw new TenantContextError(
+        `政治団体 "${orgSlug}" はテナント "${tenantSlug}" に所属していません`,
+        "ACCESS_DENIED"
+      );
+    }
+
+    return {
+      ...tenantContext,
+      organizationId: org.id,
+      organizationSlug: org.slug,
+      organizationName: org.displayName,
+    };
+  }
+);
+```
+
+### 1.6 getDefaultRedirectPath Loader
+
+**ファイル**: `admin/src/server/contexts/auth/presentation/loaders/get-default-redirect-path.ts`
+
+```typescript
+import "server-only";
+
+import { getCurrentUserWithTenants } from "@/server/contexts/auth/presentation/loaders/load-current-user-with-tenants";
+import { PrismaPoliticalOrganizationRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-political-organization.repository";
+
+/**
+ * ログイン後のデフォルトリダイレクト先を決定
+ */
+export async function getDefaultRedirectPath(): Promise<string> {
+  const user = await getCurrentUserWithTenants();
+
+  if (!user) {
+    // 未認証 → ログインページへ
+    return "/login";
+  }
+
+  if (user.tenants.length === 0) {
+    // テナント未所属（通常は発生しない）
+    return "/no-tenant";
+  }
+
+  if (user.tenants.length === 1) {
+    const tenant = user.tenants[0];
+    const orgRepository = new PrismaPoliticalOrganizationRepository();
+    const orgs = await orgRepository.findByTenantId(tenant.membership.tenantId);
+
+    if (orgs.length === 1) {
+      // 単一テナント・単一政治団体 → ダッシュボードへ直行
+      return `/t/${tenant.tenantSlug}/o/${orgs[0].slug}/dashboard`;
+    }
+
+    // 単一テナント・複数政治団体 → 政治団体選択画面へ
+    return `/t/${tenant.tenantSlug}/select-organization`;
+  }
+
+  // 複数テナント → テナント選択画面へ
+  return "/select-tenant";
+}
+```
+
+---
+
+## 2. URL構造の変更
+
+### 2.1 新しいURL構造
+
+```
+admin/src/app/
+├── (public)/                           # 公開ルート（認証不要）
+│   ├── login/
+│   ├── password-reset/
+│   └── setup/
+│
+├── (auth)/                             # 認証必須ルート
+│   ├── select-tenant/                  # テナント選択画面
+│   │   └── page.tsx
+│   ├── no-tenant/                      # テナント未所属画面
+│   │   └── page.tsx
+│   │
+│   └── t/[tenantSlug]/                 # テナント別ルート
+│       ├── layout.tsx                  # テナントコンテキストProvider
+│       ├── select-organization/        # 政治団体選択画面
+│       │   └── page.tsx
+│       ├── settings/                   # テナント設定（フェーズ4）
+│       │   └── page.tsx
+│       │
+│       └── o/[orgSlug]/                # 政治団体別ルート
+│           ├── layout.tsx              # 組織コンテキストProvider
+│           ├── dashboard/
+│           │   └── page.tsx
+│           ├── transactions/
+│           │   └── page.tsx
+│           ├── counterparts/
+│           │   ├── page.tsx
+│           │   └── [id]/
+│           │       └── page.tsx
+│           ├── donors/
+│           │   └── page.tsx
+│           ├── balance-snapshots/
+│           │   └── page.tsx
+│           ├── upload-csv/
+│           │   └── page.tsx
+│           └── export-report/
+│               ├── page.tsx
+│               └── [year]/
+│                   └── page.tsx
+```
+
+### 2.2 テナントレイアウト
+
+**ファイル**: `admin/src/app/(auth)/t/[tenantSlug]/layout.tsx`
+
+```typescript
+import { redirect } from "next/navigation";
+
+import { resolveTenantContext } from "@/server/contexts/auth/presentation/loaders/resolve-tenant-context";
+import { TenantContextError } from "@/server/contexts/auth/domain/models/tenant-context";
+import { TenantProvider } from "@/client/components/providers/tenant-provider";
+
+interface TenantLayoutProps {
+  children: React.ReactNode;
+  params: Promise<{ tenantSlug: string }>;
+}
+
+export default async function TenantLayout({
+  children,
+  params,
+}: TenantLayoutProps) {
+  const { tenantSlug } = await params;
+
+  try {
+    const tenantContext = await resolveTenantContext(tenantSlug);
+
+    return (
+      <TenantProvider value={tenantContext}>
+        {children}
+      </TenantProvider>
+    );
+  } catch (error) {
+    if (error instanceof TenantContextError) {
+      switch (error.code) {
+        case "NOT_AUTHENTICATED":
+          redirect("/login");
+        case "TENANT_NOT_FOUND":
+        case "ACCESS_DENIED":
+          redirect("/select-tenant");
+        default:
+          throw error;
+      }
+    }
+    throw error;
+  }
+}
+```
+
+### 2.3 政治団体レイアウト
+
+**ファイル**: `admin/src/app/(auth)/t/[tenantSlug]/o/[orgSlug]/layout.tsx`
+
+```typescript
+import { redirect } from "next/navigation";
+
+import { resolveOrganizationContext } from "@/server/contexts/auth/presentation/loaders/resolve-tenant-context";
+import { TenantContextError } from "@/server/contexts/auth/domain/models/tenant-context";
+import { OrganizationProvider } from "@/client/components/providers/organization-provider";
+
+interface OrganizationLayoutProps {
+  children: React.ReactNode;
+  params: Promise<{ tenantSlug: string; orgSlug: string }>;
+}
+
+export default async function OrganizationLayout({
+  children,
+  params,
+}: OrganizationLayoutProps) {
+  const { tenantSlug, orgSlug } = await params;
+
+  try {
+    const orgContext = await resolveOrganizationContext(tenantSlug, orgSlug);
+
+    return (
+      <OrganizationProvider value={orgContext}>
+        {children}
+      </OrganizationProvider>
+    );
+  } catch (error) {
+    if (error instanceof TenantContextError) {
+      switch (error.code) {
+        case "NOT_AUTHENTICATED":
+          redirect("/login");
+        case "TENANT_NOT_FOUND":
+        case "ACCESS_DENIED":
+          redirect("/select-tenant");
+        case "ORGANIZATION_NOT_FOUND":
+          redirect(`/t/${tenantSlug}/select-organization`);
+        default:
+          throw error;
+      }
+    }
+    throw error;
+  }
+}
+```
+
+### 2.4 TenantProvider / OrganizationProvider
+
+**ファイル**: `admin/src/client/components/providers/tenant-provider.tsx`
+
+```typescript
+"use client";
+
+import { createContext, useContext, type ReactNode } from "react";
+
+import type { TenantContext } from "@/server/contexts/auth/domain/models/tenant-context";
+
+const TenantContextReact = createContext<TenantContext | null>(null);
+
+interface TenantProviderProps {
+  value: TenantContext;
+  children: ReactNode;
+}
+
+export function TenantProvider({ value, children }: TenantProviderProps) {
+  // bigint は JSON シリアライズできないため、string に変換してクライアントに渡す
+  const serializedValue = {
+    ...value,
+    tenantId: value.tenantId.toString(),
+  };
+
+  return (
+    <TenantContextReact.Provider value={value}>
+      {children}
+    </TenantContextReact.Provider>
+  );
+}
+
+export function useTenantContext(): TenantContext {
+  const context = useContext(TenantContextReact);
+  if (!context) {
+    throw new Error("useTenantContext must be used within TenantProvider");
+  }
+  return context;
+}
+```
+
+**ファイル**: `admin/src/client/components/providers/organization-provider.tsx`
+
+```typescript
+"use client";
+
+import { createContext, useContext, type ReactNode } from "react";
+
+import type { OrganizationContext } from "@/server/contexts/auth/domain/models/tenant-context";
+
+const OrganizationContextReact = createContext<OrganizationContext | null>(null);
+
+interface OrganizationProviderProps {
+  value: OrganizationContext;
+  children: ReactNode;
+}
+
+export function OrganizationProvider({
+  value,
+  children,
+}: OrganizationProviderProps) {
+  return (
+    <OrganizationContextReact.Provider value={value}>
+      {children}
+    </OrganizationContextReact.Provider>
+  );
+}
+
+export function useOrganizationContext(): OrganizationContext {
+  const context = useContext(OrganizationContextReact);
+  if (!context) {
+    throw new Error(
+      "useOrganizationContext must be used within OrganizationProvider"
+    );
+  }
+  return context;
+}
+```
+
+---
+
+## 3. Repository のテナント対応
+
+### 3.1 テナントフィルタリングの基本方針
+
+**原則**:
+- テナントレベルのリソース（Counterpart, Donor）: `tenantId` でフィルタリング
+- 政治団体レベルのリソース（Transaction, BalanceSnapshot）: `politicalOrganizationId` でフィルタリングし、政治団体がテナントに所属していることを検証
+
+### 3.2 CounterpartRepository の変更
+
+**ファイル**: `admin/src/server/contexts/report/domain/repositories/counterpart-repository.interface.ts`
+
+```typescript
+import "server-only";
+
+import type { Counterpart } from "@/server/contexts/report/domain/models/counterpart";
+
+/**
+ * Counterpart 検索フィルター
+ */
+export interface CounterpartFilters {
+  /** テナントID（必須） */
+  tenantId: bigint;
+  /** 名前部分一致 */
+  name?: string;
+  /** 住所部分一致 */
+  address?: string;
+}
+
+/**
+ * Counterpart 作成入力
+ */
+export interface CreateCounterpartInput {
+  /** テナントID（必須） */
+  tenantId: bigint;
+  name: string;
+  postalCode?: string | null;
+  address?: string | null;
+}
+
+/**
+ * Counterpart 更新入力
+ */
+export interface UpdateCounterpartInput {
+  name?: string;
+  postalCode?: string | null;
+  address?: string | null;
+}
+
+/**
+ * Counterpart リポジトリインターフェース
+ */
+export interface ICounterpartRepository {
+  /**
+   * IDでCounterpartを取得（テナント検証付き）
+   */
+  findById(id: bigint, tenantId: bigint): Promise<Counterpart | null>;
+
+  /**
+   * 名前と住所でCounterpartを取得
+   */
+  findByNameAndAddress(
+    tenantId: bigint,
+    name: string,
+    address: string | null
+  ): Promise<Counterpart | null>;
+
+  /**
+   * フィルター条件に一致するCounterpart一覧を取得
+   */
+  findAll(filters: CounterpartFilters): Promise<Counterpart[]>;
+
+  /**
+   * Counterpartを作成
+   */
+  create(input: CreateCounterpartInput): Promise<Counterpart>;
+
+  /**
+   * Counterpartを更新（テナント検証付き）
+   */
+  update(
+    id: bigint,
+    tenantId: bigint,
+    input: UpdateCounterpartInput
+  ): Promise<Counterpart>;
+
+  /**
+   * Counterpartを削除（テナント検証付き）
+   */
+  delete(id: bigint, tenantId: bigint): Promise<void>;
+}
+```
+
+### 3.3 PrismaCounterpartRepository の変更
+
+**ファイル**: `admin/src/server/contexts/report/infrastructure/repositories/prisma-counterpart.repository.ts`
+
+```typescript
+import "server-only";
+
+import type {
+  ICounterpartRepository,
+  CounterpartFilters,
+  CreateCounterpartInput,
+  UpdateCounterpartInput,
+} from "@/server/contexts/report/domain/repositories/counterpart-repository.interface";
+import type { Counterpart } from "@/server/contexts/report/domain/models/counterpart";
+import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
+
+/**
+ * Prisma実装の Counterpart リポジトリ
+ */
+export class PrismaCounterpartRepository implements ICounterpartRepository {
+  async findById(id: bigint, tenantId: bigint): Promise<Counterpart | null> {
+    const counterpart = await prisma.counterpart.findFirst({
+      where: {
+        id,
+        tenantId, // テナントフィルタリング
+      },
+    });
+
+    if (!counterpart) return null;
+
+    return this.toModel(counterpart);
+  }
+
+  async findByNameAndAddress(
+    tenantId: bigint,
+    name: string,
+    address: string | null
+  ): Promise<Counterpart | null> {
+    const counterpart = await prisma.counterpart.findFirst({
+      where: {
+        tenantId, // テナントフィルタリング
+        name,
+        address,
+      },
+    });
+
+    if (!counterpart) return null;
+
+    return this.toModel(counterpart);
+  }
+
+  async findAll(filters: CounterpartFilters): Promise<Counterpart[]> {
+    const counterparts = await prisma.counterpart.findMany({
+      where: {
+        tenantId: filters.tenantId, // テナントフィルタリング（必須）
+        ...(filters.name && {
+          name: { contains: filters.name, mode: "insensitive" },
+        }),
+        ...(filters.address && {
+          address: { contains: filters.address, mode: "insensitive" },
+        }),
+      },
+      orderBy: { name: "asc" },
+    });
+
+    return counterparts.map(this.toModel);
+  }
+
+  async create(input: CreateCounterpartInput): Promise<Counterpart> {
+    const counterpart = await prisma.counterpart.create({
+      data: {
+        tenantId: input.tenantId, // テナント紐づけ（必須）
+        name: input.name,
+        postalCode: input.postalCode ?? null,
+        address: input.address ?? null,
+      },
+    });
+
+    return this.toModel(counterpart);
+  }
+
+  async update(
+    id: bigint,
+    tenantId: bigint,
+    input: UpdateCounterpartInput
+  ): Promise<Counterpart> {
+    // テナント検証付きで更新
+    const counterpart = await prisma.counterpart.updateMany({
+      where: {
+        id,
+        tenantId, // テナント検証
+      },
+      data: {
+        ...(input.name !== undefined && { name: input.name }),
+        ...(input.postalCode !== undefined && { postalCode: input.postalCode }),
+        ...(input.address !== undefined && { address: input.address }),
+      },
+    });
+
+    if (counterpart.count === 0) {
+      throw new Error("Counterpart not found or access denied");
+    }
+
+    // 更新後のデータを取得
+    const updated = await this.findById(id, tenantId);
+    if (!updated) {
+      throw new Error("Failed to retrieve updated counterpart");
+    }
+
+    return updated;
+  }
+
+  async delete(id: bigint, tenantId: bigint): Promise<void> {
+    const result = await prisma.counterpart.deleteMany({
+      where: {
+        id,
+        tenantId, // テナント検証
+      },
+    });
+
+    if (result.count === 0) {
+      throw new Error("Counterpart not found or access denied");
+    }
+  }
+
+  private toModel(data: {
+    id: bigint;
+    name: string;
+    postalCode: string | null;
+    address: string | null;
+    tenantId: bigint;
+    createdAt: Date;
+    updatedAt: Date;
+  }): Counterpart {
+    return {
+      id: data.id,
+      name: data.name,
+      postalCode: data.postalCode,
+      address: data.address,
+      tenantId: data.tenantId,
+      createdAt: data.createdAt,
+      updatedAt: data.updatedAt,
+    };
+  }
+}
+```
+
+### 3.4 DonorRepository の変更（同様のパターン）
+
+**ファイル**: `admin/src/server/contexts/report/domain/repositories/donor-repository.interface.ts`
+
+```typescript
+import "server-only";
+
+import type { Donor } from "@/server/contexts/report/domain/models/donor";
+
+/**
+ * Donor 検索フィルター
+ */
+export interface DonorFilters {
+  /** テナントID（必須） */
+  tenantId: bigint;
+  /** 名前部分一致 */
+  name?: string;
+  /** 寄付者種別 */
+  donorType?: "individual" | "corporation" | "organization";
+}
+
+/**
+ * Donor 作成入力
+ */
+export interface CreateDonorInput {
+  /** テナントID（必須） */
+  tenantId: bigint;
+  donorType: "individual" | "corporation" | "organization";
+  name: string;
+  address?: string | null;
+  occupation?: string | null;
+}
+
+/**
+ * Donor リポジトリインターフェース
+ */
+export interface IDonorRepository {
+  findById(id: bigint, tenantId: bigint): Promise<Donor | null>;
+  findAll(filters: DonorFilters): Promise<Donor[]>;
+  create(input: CreateDonorInput): Promise<Donor>;
+  // ... 他メソッドも同様にtenantIdを追加
+}
+```
+
+### 3.5 PoliticalOrganizationRepository の変更
+
+**ファイル**: `admin/src/server/contexts/shared/infrastructure/repositories/prisma-political-organization.repository.ts`
+
+```typescript
+import "server-only";
+
+import type { PoliticalOrganization } from "@/server/contexts/shared/domain/models/political-organization";
+import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
+
+/**
+ * Prisma実装の PoliticalOrganization リポジトリ
+ */
+export class PrismaPoliticalOrganizationRepository {
+  /**
+   * テナントに所属する政治団体一覧を取得
+   */
+  async findByTenantId(tenantId: bigint): Promise<PoliticalOrganization[]> {
+    const orgs = await prisma.politicalOrganization.findMany({
+      where: { tenantId },
+      orderBy: { displayName: "asc" },
+    });
+
+    return orgs.map(this.toModel);
+  }
+
+  /**
+   * slugで政治団体を取得
+   */
+  async findBySlug(slug: string): Promise<PoliticalOrganization | null> {
+    const org = await prisma.politicalOrganization.findUnique({
+      where: { slug },
+    });
+
+    if (!org) return null;
+
+    return this.toModel(org);
+  }
+
+  /**
+   * IDと所属テナントで政治団体を取得（アクセス検証用）
+   */
+  async findByIdAndTenantId(
+    id: bigint,
+    tenantId: bigint
+  ): Promise<PoliticalOrganization | null> {
+    const org = await prisma.politicalOrganization.findFirst({
+      where: { id, tenantId },
+    });
+
+    if (!org) return null;
+
+    return this.toModel(org);
+  }
+
+  private toModel(data: {
+    id: bigint;
+    slug: string;
+    displayName: string;
+    orgName: string | null;
+    description: string | null;
+    tenantId: bigint | null;
+    createdAt: Date;
+    updatedAt: Date;
+  }): PoliticalOrganization {
+    return {
+      id: data.id,
+      slug: data.slug,
+      displayName: data.displayName,
+      orgName: data.orgName,
+      description: data.description,
+      tenantId: data.tenantId,
+      createdAt: data.createdAt,
+      updatedAt: data.updatedAt,
+    };
+  }
+}
+```
+
+---
+
+## 4. Usecase のテナント対応
+
+### 4.1 GetCounterpartsUsecase の変更
+
+**ファイル**: `admin/src/server/contexts/report/application/usecases/get-counterparts-usecase.ts`
+
+```typescript
+import "server-only";
+
+import type { ICounterpartRepository } from "@/server/contexts/report/domain/repositories/counterpart-repository.interface";
+import type { Counterpart } from "@/server/contexts/report/domain/models/counterpart";
+
+/**
+ * Counterpart一覧取得の入力
+ */
+export interface GetCounterpartsInput {
+  /** テナントID（必須） */
+  tenantId: bigint;
+  /** 名前フィルター */
+  name?: string;
+  /** 住所フィルター */
+  address?: string;
+}
+
+/**
+ * Counterpart一覧取得Usecase
+ */
+export class GetCounterpartsUsecase {
+  constructor(private readonly repository: ICounterpartRepository) {}
+
+  async execute(input: GetCounterpartsInput): Promise<Counterpart[]> {
+    return this.repository.findAll({
+      tenantId: input.tenantId,
+      name: input.name,
+      address: input.address,
+    });
+  }
+}
+```
+
+### 4.2 CreateCounterpartUsecase の変更
+
+**ファイル**: `admin/src/server/contexts/report/application/usecases/create-counterpart-usecase.ts`
+
+```typescript
+import "server-only";
+
+import type { ICounterpartRepository } from "@/server/contexts/report/domain/repositories/counterpart-repository.interface";
+import type { Counterpart } from "@/server/contexts/report/domain/models/counterpart";
+
+/**
+ * Counterpart作成の入力
+ */
+export interface CreateCounterpartInput {
+  /** テナントID（必須） */
+  tenantId: bigint;
+  name: string;
+  postalCode?: string | null;
+  address?: string | null;
+}
+
+/**
+ * Counterpart作成Usecase
+ */
+export class CreateCounterpartUsecase {
+  constructor(private readonly repository: ICounterpartRepository) {}
+
+  async execute(input: CreateCounterpartInput): Promise<Counterpart> {
+    // 重複チェック（同一テナント内）
+    const existing = await this.repository.findByNameAndAddress(
+      input.tenantId,
+      input.name,
+      input.address ?? null
+    );
+
+    if (existing) {
+      throw new Error(
+        `同じ名前・住所の取引先が既に存在します: ${input.name}`
+      );
+    }
+
+    return this.repository.create({
+      tenantId: input.tenantId,
+      name: input.name,
+      postalCode: input.postalCode,
+      address: input.address,
+    });
+  }
+}
+```
+
+---
+
+## 5. Loader / Action のテナント対応
+
+### 5.1 loadCounterparts Loader の変更
+
+**ファイル**: `admin/src/server/contexts/report/presentation/loaders/load-counterparts.ts`
+
+```typescript
+import "server-only";
+
+import { unstable_cache } from "next/cache";
+
+import { PrismaCounterpartRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-counterpart.repository";
+import { GetCounterpartsUsecase } from "@/server/contexts/report/application/usecases/get-counterparts-usecase";
+import type { Counterpart } from "@/server/contexts/report/domain/models/counterpart";
+
+/**
+ * Counterpart一覧を取得（テナントスコープ）
+ */
+export async function loadCounterparts(
+  tenantId: bigint,
+  filters?: { name?: string; address?: string }
+): Promise<Counterpart[]> {
+  // テナントスコープのキャッシュ
+  const getCachedCounterparts = unstable_cache(
+    async () => {
+      const repository = new PrismaCounterpartRepository();
+      const usecase = new GetCounterpartsUsecase(repository);
+
+      return usecase.execute({
+        tenantId,
+        name: filters?.name,
+        address: filters?.address,
+      });
+    },
+    // キャッシュキー: テナントIDを含める
+    [
+      "counterparts",
+      `tenant-${tenantId.toString()}`,
+      `name-${filters?.name ?? ""}`,
+      `address-${filters?.address ?? ""}`,
+    ],
+    {
+      tags: [`tenant-${tenantId.toString()}-counterparts`],
+      revalidate: 60,
+    }
+  );
+
+  return getCachedCounterparts();
+}
+```
+
+### 5.2 createCounterpartAction の変更
+
+**ファイル**: `admin/src/server/contexts/report/presentation/actions/create-counterpart.ts`
+
+```typescript
+"use server";
+
+import { revalidateTag } from "next/cache";
+
+import { PrismaCounterpartRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-counterpart.repository";
+import { CreateCounterpartUsecase } from "@/server/contexts/report/application/usecases/create-counterpart-usecase";
+import { resolveTenantContext } from "@/server/contexts/auth/presentation/loaders/resolve-tenant-context";
+import type { Counterpart } from "@/server/contexts/report/domain/models/counterpart";
+
+/**
+ * Counterpart作成アクションの入力
+ */
+export interface CreateCounterpartActionInput {
+  /** テナントslug（URLパラメータから） */
+  tenantSlug: string;
+  name: string;
+  postalCode?: string | null;
+  address?: string | null;
+}
+
+/**
+ * Counterpart作成アクション
+ */
+export async function createCounterpartAction(
+  input: CreateCounterpartActionInput
+): Promise<Counterpart> {
+  // テナントコンテキストを解決（認証・権限チェック含む）
+  const tenantContext = await resolveTenantContext(input.tenantSlug);
+
+  const repository = new PrismaCounterpartRepository();
+  const usecase = new CreateCounterpartUsecase(repository);
+
+  const result = await usecase.execute({
+    tenantId: tenantContext.tenantId,
+    name: input.name,
+    postalCode: input.postalCode,
+    address: input.address,
+  });
+
+  // テナントスコープのキャッシュを無効化
+  revalidateTag(`tenant-${tenantContext.tenantId.toString()}-counterparts`);
+
+  return result;
+}
+```
+
+---
+
+## 6. UI実装
+
+### 6.1 テナント選択画面
+
+**ファイル**: `admin/src/app/(auth)/select-tenant/page.tsx`
+
+```typescript
+import { redirect } from "next/navigation";
+import Link from "next/link";
+
+import { getCurrentUserWithTenants } from "@/server/contexts/auth/presentation/loaders/load-current-user-with-tenants";
+import { Card, CardContent, CardHeader, CardTitle } from "@/client/components/ui/card";
+
+export default async function SelectTenantPage() {
+  const user = await getCurrentUserWithTenants();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  if (user.tenants.length === 0) {
+    redirect("/no-tenant");
+  }
+
+  // 単一テナントの場合は直接そのテナントへリダイレクト
+  if (user.tenants.length === 1) {
+    redirect(`/t/${user.tenants[0].tenantSlug}/select-organization`);
+  }
+
+  return (
+    <div className="container mx-auto py-8">
+      <h1 className="text-2xl font-bold mb-6">テナントを選択</h1>
+      <p className="text-muted-foreground mb-8">
+        管理するテナント（政党・事務所）を選択してください。
+      </p>
+
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {user.tenants.map((tenant) => (
+          <Link
+            key={tenant.membership.tenantId.toString()}
+            href={`/t/${tenant.tenantSlug}/select-organization`}
+          >
+            <Card className="hover:border-primary cursor-pointer transition-colors">
+              <CardHeader>
+                <CardTitle>{tenant.tenantName}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-muted-foreground">
+                  ロール: {tenant.membership.role}
+                </p>
+              </CardContent>
+            </Card>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+### 6.2 政治団体選択画面
+
+**ファイル**: `admin/src/app/(auth)/t/[tenantSlug]/select-organization/page.tsx`
+
+```typescript
+import { redirect } from "next/navigation";
+import Link from "next/link";
+
+import { resolveTenantContext } from "@/server/contexts/auth/presentation/loaders/resolve-tenant-context";
+import { PrismaPoliticalOrganizationRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-political-organization.repository";
+import { Card, CardContent, CardHeader, CardTitle } from "@/client/components/ui/card";
+
+interface SelectOrganizationPageProps {
+  params: Promise<{ tenantSlug: string }>;
+}
+
+export default async function SelectOrganizationPage({
+  params,
+}: SelectOrganizationPageProps) {
+  const { tenantSlug } = await params;
+  const tenantContext = await resolveTenantContext(tenantSlug);
+
+  const orgRepository = new PrismaPoliticalOrganizationRepository();
+  const organizations = await orgRepository.findByTenantId(
+    tenantContext.tenantId
+  );
+
+  // 単一政治団体の場合は直接ダッシュボードへリダイレクト
+  if (organizations.length === 1) {
+    redirect(
+      `/t/${tenantSlug}/o/${organizations[0].slug}/dashboard`
+    );
+  }
+
+  return (
+    <div className="container mx-auto py-8">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold">政治団体を選択</h1>
+          <p className="text-muted-foreground">
+            {tenantContext.tenantName}
+          </p>
+        </div>
+        <Link href="/select-tenant" className="text-sm text-muted-foreground hover:underline">
+          テナントを変更
+        </Link>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {organizations.map((org) => (
+          <Link
+            key={org.id.toString()}
+            href={`/t/${tenantSlug}/o/${org.slug}/dashboard`}
+          >
+            <Card className="hover:border-primary cursor-pointer transition-colors">
+              <CardHeader>
+                <CardTitle>{org.displayName}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                {org.description && (
+                  <p className="text-sm text-muted-foreground">
+                    {org.description}
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+### 6.3 ナビゲーションの変更
+
+**ファイル**: `admin/src/client/components/layout/sidebar.tsx`（変更箇所）
+
+```typescript
+"use client";
+
+import Link from "next/link";
+import { useParams } from "next/navigation";
+
+import { useOrganizationContext } from "@/client/components/providers/organization-provider";
+
+export function Sidebar() {
+  const params = useParams();
+  const tenantSlug = params.tenantSlug as string;
+  const orgSlug = params.orgSlug as string;
+  const orgContext = useOrganizationContext();
+
+  // ベースパスをテナント・政治団体コンテキストから構築
+  const basePath = `/t/${tenantSlug}/o/${orgSlug}`;
+
+  const navItems = [
+    { label: "ダッシュボード", href: `${basePath}/dashboard` },
+    { label: "取引一覧", href: `${basePath}/transactions` },
+    { label: "取引先", href: `${basePath}/counterparts` },
+    { label: "寄付者", href: `${basePath}/donors` },
+    { label: "残高スナップショット", href: `${basePath}/balance-snapshots` },
+    { label: "CSVインポート", href: `${basePath}/upload-csv` },
+    { label: "報告書エクスポート", href: `${basePath}/export-report` },
+  ];
+
+  return (
+    <aside className="w-64 border-r">
+      {/* テナント・政治団体表示 */}
+      <div className="p-4 border-b">
+        <p className="text-sm text-muted-foreground">{orgContext.tenantName}</p>
+        <p className="font-medium">{orgContext.organizationName}</p>
+      </div>
+
+      {/* ナビゲーション */}
+      <nav className="p-4">
+        <ul className="space-y-2">
+          {navItems.map((item) => (
+            <li key={item.href}>
+              <Link
+                href={item.href}
+                className="block px-3 py-2 rounded-md hover:bg-accent"
+              >
+                {item.label}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      {/* テナント・政治団体切り替えリンク */}
+      <div className="p-4 border-t mt-auto">
+        <Link
+          href={`/t/${tenantSlug}/select-organization`}
+          className="text-sm text-muted-foreground hover:underline"
+        >
+          政治団体を切り替え
+        </Link>
+      </div>
+    </aside>
+  );
+}
+```
+
+---
+
+## 7. API Route のテナント対応
+
+### 7.1 transactions API の変更
+
+**ファイル**: `admin/src/app/api/transactions/route.ts`
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+
+import { resolveOrganizationContext } from "@/server/contexts/auth/presentation/loaders/resolve-tenant-context";
+import { TenantContextError } from "@/server/contexts/auth/domain/models/tenant-context";
+import { PrismaTransactionRepository } from "@/server/contexts/data-import/infrastructure/repositories/prisma-transaction.repository";
+import { GetTransactionsUsecase } from "@/server/contexts/data-import/application/usecases/get-transactions-usecase";
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const tenantSlug = searchParams.get("tenantSlug");
+  const orgSlug = searchParams.get("orgSlug");
+  const financialYear = searchParams.get("financialYear");
+
+  if (!tenantSlug || !orgSlug) {
+    return NextResponse.json(
+      { error: "tenantSlug and orgSlug are required" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    // テナント・政治団体コンテキストを解決（認証・権限チェック含む）
+    const orgContext = await resolveOrganizationContext(tenantSlug, orgSlug);
+
+    const repository = new PrismaTransactionRepository();
+    const usecase = new GetTransactionsUsecase(repository);
+
+    const transactions = await usecase.execute({
+      politicalOrganizationId: orgContext.organizationId,
+      financialYear: financialYear ? parseInt(financialYear, 10) : undefined,
+    });
+
+    return NextResponse.json(transactions);
+  } catch (error) {
+    if (error instanceof TenantContextError) {
+      switch (error.code) {
+        case "NOT_AUTHENTICATED":
+          return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        case "ACCESS_DENIED":
+        case "TENANT_NOT_FOUND":
+        case "ORGANIZATION_NOT_FOUND":
+          return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      }
+    }
+    throw error;
+  }
+}
+```
+
+---
+
+## 8. 既存ページの移行
+
+### 8.1 移行対象ページ一覧
+
+| 現在のパス | 新しいパス | 対応内容 |
+|-----------|-----------|---------|
+| `/counterparts` | `/t/[tenantSlug]/o/[orgSlug]/counterparts` | テナントコンテキスト追加 |
+| `/counterparts/[id]` | `/t/[tenantSlug]/o/[orgSlug]/counterparts/[id]` | テナントコンテキスト追加 |
+| `/donors` | `/t/[tenantSlug]/o/[orgSlug]/donors` | テナントコンテキスト追加 |
+| `/transactions` | `/t/[tenantSlug]/o/[orgSlug]/transactions` | 組織コンテキスト追加 |
+| `/balance-snapshots` | `/t/[tenantSlug]/o/[orgSlug]/balance-snapshots` | 組織コンテキスト追加 |
+| `/upload-csv` | `/t/[tenantSlug]/o/[orgSlug]/upload-csv` | 組織コンテキスト追加 |
+| `/export-report/[orgId]/[year]` | `/t/[tenantSlug]/o/[orgSlug]/export-report/[year]` | URLパラメータ変更 |
+
+### 8.2 ページ移行の手順
+
+1. 新しいディレクトリ構造を作成
+2. 既存ページをコピーして移行
+3. Loaderの呼び出しにテナントコンテキストを追加
+4. Actionの呼び出しにテナントコンテキストを追加
+5. リンク・ナビゲーションのパスを更新
+6. 旧ルートから新ルートへのリダイレクトを設定
+
+### 8.3 counterparts ページの移行例
+
+**ファイル**: `admin/src/app/(auth)/t/[tenantSlug]/o/[orgSlug]/counterparts/page.tsx`
+
+```typescript
+import { resolveTenantContext } from "@/server/contexts/auth/presentation/loaders/resolve-tenant-context";
+import { loadCounterparts } from "@/server/contexts/report/presentation/loaders/load-counterparts";
+import { CounterpartsTable } from "@/client/components/counterparts/counterparts-table";
+
+interface CounterpartsPageProps {
+  params: Promise<{ tenantSlug: string; orgSlug: string }>;
+}
+
+export default async function CounterpartsPage({
+  params,
+}: CounterpartsPageProps) {
+  const { tenantSlug } = await params;
+  const tenantContext = await resolveTenantContext(tenantSlug);
+
+  // テナントスコープでCounterpartを取得
+  const counterparts = await loadCounterparts(tenantContext.tenantId);
+
+  return (
+    <div className="container mx-auto py-8">
+      <h1 className="text-2xl font-bold mb-6">取引先一覧</h1>
+      <CounterpartsTable
+        counterparts={counterparts}
+        tenantSlug={tenantSlug}
+      />
+    </div>
+  );
+}
+```
+
+---
+
+## 9. キャッシュ戦略
+
+### 9.1 キャッシュキーの設計
+
+**原則**: 全てのキャッシュキーにテナントID（または政治団体ID）を含める
+
+```typescript
+// テナントレベルのリソース（Counterpart, Donor）
+const cacheKey = [
+  "counterparts",
+  `tenant-${tenantId.toString()}`,
+];
+const tags = [`tenant-${tenantId.toString()}-counterparts`];
+
+// 政治団体レベルのリソース（Transaction, BalanceSnapshot）
+const cacheKey = [
+  "transactions",
+  `tenant-${tenantId.toString()}`,
+  `org-${organizationId.toString()}`,
+  `year-${financialYear}`,
+];
+const tags = [
+  `tenant-${tenantId.toString()}-transactions`,
+  `org-${organizationId.toString()}-transactions`,
+];
+```
+
+### 9.2 キャッシュ無効化
+
+```typescript
+// テナントレベルの無効化
+revalidateTag(`tenant-${tenantId.toString()}-counterparts`);
+
+// 政治団体レベルの無効化
+revalidateTag(`org-${organizationId.toString()}-transactions`);
+
+// テナント全体の無効化（政治団体追加時など）
+revalidateTag(`tenant-${tenantId.toString()}-transactions`);
+```
+
+---
+
+## 10. 実装チェックリスト
+
+### 10.1 テナントコンテキスト基盤
+
+- [ ] `admin/src/server/contexts/auth/domain/models/tenant-context.ts` を作成
+- [ ] `admin/src/server/contexts/auth/domain/models/authenticated-user.ts` を作成
+- [ ] `admin/src/server/contexts/auth/application/usecases/get-current-user-with-tenants-usecase.ts` を作成
+- [ ] `admin/src/server/contexts/auth/presentation/loaders/load-current-user-with-tenants.ts` を作成
+- [ ] `admin/src/server/contexts/auth/presentation/loaders/resolve-tenant-context.ts` を作成
+- [ ] `admin/src/server/contexts/auth/presentation/loaders/get-default-redirect-path.ts` を作成
+
+### 10.2 Provider
+
+- [ ] `admin/src/client/components/providers/tenant-provider.tsx` を作成
+- [ ] `admin/src/client/components/providers/organization-provider.tsx` を作成
+
+### 10.3 URL構造
+
+- [ ] `admin/src/app/(auth)/select-tenant/page.tsx` を作成
+- [ ] `admin/src/app/(auth)/no-tenant/page.tsx` を作成
+- [ ] `admin/src/app/(auth)/t/[tenantSlug]/layout.tsx` を作成
+- [ ] `admin/src/app/(auth)/t/[tenantSlug]/select-organization/page.tsx` を作成
+- [ ] `admin/src/app/(auth)/t/[tenantSlug]/o/[orgSlug]/layout.tsx` を作成
+
+### 10.4 Repository の変更
+
+- [ ] `ICounterpartRepository` に `tenantId` パラメータを追加
+- [ ] `PrismaCounterpartRepository` にテナントフィルタリングを実装
+- [ ] `IDonorRepository` に `tenantId` パラメータを追加
+- [ ] `PrismaDonorRepository` にテナントフィルタリングを実装
+- [ ] `PrismaPoliticalOrganizationRepository` に `findByTenantId` を追加
+
+### 10.5 Usecase の変更
+
+- [ ] `GetCounterpartsUsecase` に `tenantId` パラメータを追加
+- [ ] `CreateCounterpartUsecase` に `tenantId` パラメータを追加
+- [ ] `GetDonorsUsecase` に `tenantId` パラメータを追加
+- [ ] `CreateDonorUsecase` に `tenantId` パラメータを追加
+
+### 10.6 Loader / Action の変更
+
+- [ ] `loadCounterparts` にテナントスコープのキャッシュを実装
+- [ ] `createCounterpartAction` にテナントコンテキスト解決を追加
+- [ ] `loadDonors` にテナントスコープのキャッシュを実装
+- [ ] `createDonorAction` にテナントコンテキスト解決を追加
+- [ ] 全ての既存 Loader / Action を更新
+
+### 10.7 ページ移行
+
+- [ ] counterparts ページを移行
+- [ ] donors ページを移行
+- [ ] transactions ページを移行
+- [ ] balance-snapshots ページを移行
+- [ ] upload-csv ページを移行
+- [ ] export-report ページを移行
+- [ ] 旧ルートからのリダイレクトを設定
+
+### 10.8 API Route
+
+- [ ] `/api/transactions` を更新
+- [ ] `/api/export-report` を更新
+- [ ] 全ての API Route にテナント検証を追加
+
+### 10.9 ナビゲーション
+
+- [ ] Sidebar をテナント対応に更新
+- [ ] Header にテナント・政治団体表示を追加
+- [ ] ログイン後のリダイレクトロジックを実装
+
+### 10.10 動作確認
+
+- [ ] テナント選択画面が正しく表示される
+- [ ] 政治団体選択画面が正しく表示される
+- [ ] 単一テナント・単一政治団体の場合、直接ダッシュボードへ遷移する
+- [ ] Counterpart がテナント内でのみ表示される
+- [ ] Donor がテナント内でのみ表示される
+- [ ] Transaction が政治団体ごとに分離されている
+- [ ] 他テナントの URL にアクセスすると適切にリダイレクトされる
+
+---
+
+## 11. 注意事項
+
+### 11.1 移行期間中の対応
+
+- 旧URLから新URLへのリダイレクトを設定し、既存のブックマーク等に対応
+- 段階的に移行し、全ページの移行完了後に旧ルートを削除
+
+### 11.2 キャッシュの考慮
+
+- テナントIDを含まないキャッシュキーが残っていないか確認
+- 移行時に既存のキャッシュが残っている可能性があるため、デプロイ後にキャッシュクリアを推奨
+
+### 11.3 エラーハンドリング
+
+- `TenantContextError` を適切にキャッチし、ユーザーフレンドリーなエラー画面を表示
+- アクセス拒否時は適切なリダイレクト先を設定
+
+### 11.4 テスト
+
+- 複数テナントでのデータ分離テスト
+- 権限のないテナントへのアクセス拒否テスト
+- キャッシュが正しくテナント分離されているかのテスト
+
+---
+
+## 12. 次のフェーズ（フェーズ3）への引き継ぎ事項
+
+フェーズ2完了後、フェーズ3で以下を実施する:
+
+1. **RLSポリシーの作成**
+   - 各テーブルへのRLSポリシー作成
+   - ポリシーの検証テスト
+
+2. **RLSの有効化**
+   - メンテナンス時間を設けてRLSを有効化
+   - 動作確認・ロールバック手順の準備
+
+3. **webapp の対応**
+   - RLS導入後の動作確認
+   - 匿名アクセス用RLSポリシーの設定
+
+---
+
+## 参考資料
+
+- [マルチテナント化概要設計](./20260114_2240_マルチテナント化概要設計.md)
+- [フェーズ1: マルチテナント化準備 詳細設計](./20260115_1004_フェーズ1マルチテナント化詳細設計.md)
+- [バックエンドアーキテクチャガイド](./backend-architecture-guide.md)

--- a/docs/20260115_フェーズ2マルチテナント化詳細設計.md
+++ b/docs/20260115_フェーズ2マルチテナント化詳細設計.md
@@ -39,13 +39,16 @@
 
 **ファイル**: `admin/src/server/contexts/auth/domain/models/tenant-context.ts`
 
+サーバー側で使用するテナント・政治団体コンテキスト。
+クライアント側で使用する型は Provider 内で別途定義する（2.4 参照）。
+
 ```typescript
 import "server-only";
 
 import type { TenantRole } from "@/server/contexts/auth/domain/models/tenant-role";
 
 /**
- * 現在のテナントコンテキスト
+ * 現在のテナントコンテキスト（サーバー側専用）
  * URLパラメータから解決され、Usecaseに渡される
  */
 export interface TenantContext {
@@ -60,7 +63,7 @@ export interface TenantContext {
 }
 
 /**
- * 現在の政治団体コンテキスト（テナントコンテキストを含む）
+ * 現在の政治団体コンテキスト（サーバー側専用、テナントコンテキストを含む）
  * 政治団体レベルの操作で使用
  */
 export interface OrganizationContext extends TenantContext {
@@ -101,6 +104,17 @@ import type { TenantMembershipWithTenant } from "@/server/contexts/auth/domain/m
 
 /**
  * 認証済みユーザー（テナントメンバーシップ付き）
+ *
+ * TenantMembershipWithTenant 型はフェーズ1で定義済み:
+ * @see admin/src/server/contexts/auth/domain/models/user-tenant-membership.ts
+ *
+ * ```typescript
+ * interface TenantMembershipWithTenant {
+ *   membership: UserTenantMembership;  // { id, userId, tenantId, role, createdAt, updatedAt }
+ *   tenantSlug: string;
+ *   tenantName: string;
+ * }
+ * ```
  */
 export interface AuthenticatedUserWithTenants {
   /** ユーザーID */
@@ -521,37 +535,69 @@ export default async function OrganizationLayout({
 
 ### 2.4 TenantProvider / OrganizationProvider
 
+クライアントコンポーネントで使用する Context Provider。
+bigint は JSON シリアライズできないため、サーバーから渡される値を string に変換してコンテキストに格納する。
+
 **ファイル**: `admin/src/client/components/providers/tenant-provider.tsx`
 
 ```typescript
 "use client";
 
-import { createContext, useContext, type ReactNode } from "react";
+import { createContext, useContext, useMemo, type ReactNode } from "react";
 
-import type { TenantContext } from "@/server/contexts/auth/domain/models/tenant-context";
+import type { TenantRole } from "@/server/contexts/auth/domain/models/tenant-role";
 
-const TenantContextReact = createContext<TenantContext | null>(null);
+/**
+ * クライアント側で使用するテナントコンテキスト
+ * bigint は JSON シリアライズできないため、string に変換済み
+ */
+interface ClientTenantContext {
+  /** テナントID（string に変換済み） */
+  tenantId: string;
+  /** テナントslug */
+  tenantSlug: string;
+  /** テナント名 */
+  tenantName: string;
+  /** 現在のユーザーのテナント内ロール */
+  tenantRole: TenantRole;
+}
 
+const TenantContextReact = createContext<ClientTenantContext | null>(null);
+
+/**
+ * サーバーから渡されるプロパティ
+ * tenantId は bigint（サーバー）から string（クライアント）に変換される
+ */
 interface TenantProviderProps {
-  value: TenantContext;
+  value: {
+    tenantId: bigint | string;
+    tenantSlug: string;
+    tenantName: string;
+    tenantRole: TenantRole;
+  };
   children: ReactNode;
 }
 
 export function TenantProvider({ value, children }: TenantProviderProps) {
-  // bigint は JSON シリアライズできないため、string に変換してクライアントに渡す
-  const serializedValue = {
-    ...value,
-    tenantId: value.tenantId.toString(),
-  };
+  // bigint を string に変換してコンテキストに格納
+  const serializedValue = useMemo<ClientTenantContext>(
+    () => ({
+      tenantId: value.tenantId.toString(),
+      tenantSlug: value.tenantSlug,
+      tenantName: value.tenantName,
+      tenantRole: value.tenantRole,
+    }),
+    [value.tenantId, value.tenantSlug, value.tenantName, value.tenantRole]
+  );
 
   return (
-    <TenantContextReact.Provider value={value}>
+    <TenantContextReact.Provider value={serializedValue}>
       {children}
     </TenantContextReact.Provider>
   );
 }
 
-export function useTenantContext(): TenantContext {
+export function useTenantContext(): ClientTenantContext {
   const context = useContext(TenantContextReact);
   if (!context) {
     throw new Error("useTenantContext must be used within TenantProvider");
@@ -565,14 +611,47 @@ export function useTenantContext(): TenantContext {
 ```typescript
 "use client";
 
-import { createContext, useContext, type ReactNode } from "react";
+import { createContext, useContext, useMemo, type ReactNode } from "react";
 
-import type { OrganizationContext } from "@/server/contexts/auth/domain/models/tenant-context";
+import type { TenantRole } from "@/server/contexts/auth/domain/models/tenant-role";
 
-const OrganizationContextReact = createContext<OrganizationContext | null>(null);
+/**
+ * クライアント側で使用する政治団体コンテキスト
+ * bigint は JSON シリアライズできないため、string に変換済み
+ */
+interface ClientOrganizationContext {
+  /** テナントID（string に変換済み） */
+  tenantId: string;
+  /** テナントslug */
+  tenantSlug: string;
+  /** テナント名 */
+  tenantName: string;
+  /** 現在のユーザーのテナント内ロール */
+  tenantRole: TenantRole;
+  /** 政治団体ID（string に変換済み） */
+  organizationId: string;
+  /** 政治団体slug */
+  organizationSlug: string;
+  /** 政治団体名 */
+  organizationName: string;
+}
 
+const OrganizationContextReact = createContext<ClientOrganizationContext | null>(null);
+
+/**
+ * サーバーから渡されるプロパティ
+ * tenantId, organizationId は bigint（サーバー）から string（クライアント）に変換される
+ */
 interface OrganizationProviderProps {
-  value: OrganizationContext;
+  value: {
+    tenantId: bigint | string;
+    tenantSlug: string;
+    tenantName: string;
+    tenantRole: TenantRole;
+    organizationId: bigint | string;
+    organizationSlug: string;
+    organizationName: string;
+  };
   children: ReactNode;
 }
 
@@ -580,14 +659,36 @@ export function OrganizationProvider({
   value,
   children,
 }: OrganizationProviderProps) {
+  // bigint を string に変換してコンテキストに格納
+  const serializedValue = useMemo<ClientOrganizationContext>(
+    () => ({
+      tenantId: value.tenantId.toString(),
+      tenantSlug: value.tenantSlug,
+      tenantName: value.tenantName,
+      tenantRole: value.tenantRole,
+      organizationId: value.organizationId.toString(),
+      organizationSlug: value.organizationSlug,
+      organizationName: value.organizationName,
+    }),
+    [
+      value.tenantId,
+      value.tenantSlug,
+      value.tenantName,
+      value.tenantRole,
+      value.organizationId,
+      value.organizationSlug,
+      value.organizationName,
+    ]
+  );
+
   return (
-    <OrganizationContextReact.Provider value={value}>
+    <OrganizationContextReact.Provider value={serializedValue}>
       {children}
     </OrganizationContextReact.Provider>
   );
 }
 
-export function useOrganizationContext(): OrganizationContext {
+export function useOrganizationContext(): ClientOrganizationContext {
   const context = useContext(OrganizationContextReact);
   if (!context) {
     throw new Error(

--- a/docs/20260115_フェーズ2マルチテナント化詳細設計.md
+++ b/docs/20260115_フェーズ2マルチテナント化詳細設計.md
@@ -222,7 +222,12 @@ import type { AuthenticatedUserWithTenants } from "@/server/contexts/auth/domain
 
 /**
  * 現在のユーザーをテナントメンバーシップ付きで取得
- * React cache で同一リクエスト内でキャッシュ
+ *
+ * React.cache を使用（unstable_cache ではなく）:
+ * - 認証情報はユーザーごとに異なるため、リクエスト間でキャッシュを共有すると
+ *   他ユーザーの認証情報が漏れるリスクがある
+ * - React.cache は同一リクエスト内でのみキャッシュされるため安全
+ * - 同一リクエスト内で複数回呼ばれた場合の重複クエリ防止が目的
  */
 export const getCurrentUserWithTenants = cache(
   async (): Promise<AuthenticatedUserWithTenants | null> => {

--- a/docs/20260115_フェーズ2マルチテナント化詳細設計.md
+++ b/docs/20260115_フェーズ2マルチテナント化詳細設計.md
@@ -349,7 +349,46 @@ export const resolveOrganizationContext = cache(
 );
 ```
 
-### 1.6 getDefaultRedirectPath Loader
+### 1.6 loadOrganizationsByTenantId Loader
+
+**ファイル**: `admin/src/server/contexts/shared/presentation/loaders/load-organizations-by-tenant.ts`
+
+```typescript
+import "server-only";
+
+import { unstable_cache } from "next/cache";
+
+import { PrismaPoliticalOrganizationRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-political-organization.repository";
+import type { PoliticalOrganization } from "@/server/contexts/shared/domain/models/political-organization";
+
+/**
+ * テナントに所属する政治団体一覧を取得
+ *
+ * unstable_cache を使用:
+ * - 政治団体一覧はテナント単位のデータであり、キャッシュキーにtenantIdを含めれば安全に共有可能
+ * - 政治団体の追加・削除時にキャッシュを無効化する
+ */
+export async function loadOrganizationsByTenantId(
+  tenantId: bigint
+): Promise<PoliticalOrganization[]> {
+  const getCachedOrganizations = unstable_cache(
+    async () => {
+      const repository = new PrismaPoliticalOrganizationRepository();
+      return repository.findByTenantId(tenantId);
+    },
+    // キャッシュキー: テナントIDを含める
+    ["organizations", `tenant-${tenantId.toString()}`],
+    {
+      tags: [`tenant-${tenantId.toString()}-organizations`],
+      revalidate: 60,
+    }
+  );
+
+  return getCachedOrganizations();
+}
+```
+
+### 1.7 getDefaultRedirectPath Loader
 
 **ファイル**: `admin/src/server/contexts/auth/presentation/loaders/get-default-redirect-path.ts`
 
@@ -357,7 +396,7 @@ export const resolveOrganizationContext = cache(
 import "server-only";
 
 import { getCurrentUserWithTenants } from "@/server/contexts/auth/presentation/loaders/load-current-user-with-tenants";
-import { PrismaPoliticalOrganizationRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-political-organization.repository";
+import { loadOrganizationsByTenantId } from "@/server/contexts/shared/presentation/loaders/load-organizations-by-tenant";
 
 /**
  * ログイン後のデフォルトリダイレクト先を決定
@@ -377,8 +416,7 @@ export async function getDefaultRedirectPath(): Promise<string> {
 
   if (user.tenants.length === 1) {
     const tenant = user.tenants[0];
-    const orgRepository = new PrismaPoliticalOrganizationRepository();
-    const orgs = await orgRepository.findByTenantId(tenant.membership.tenantId);
+    const orgs = await loadOrganizationsByTenantId(tenant.membership.tenantId);
 
     if (orgs.length === 1) {
       // 単一テナント・単一政治団体 → ダッシュボードへ直行
@@ -1337,7 +1375,7 @@ import { redirect } from "next/navigation";
 import Link from "next/link";
 
 import { resolveTenantContext } from "@/server/contexts/auth/presentation/loaders/resolve-tenant-context";
-import { PrismaPoliticalOrganizationRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-political-organization.repository";
+import { loadOrganizationsByTenantId } from "@/server/contexts/shared/presentation/loaders/load-organizations-by-tenant";
 import { Card, CardContent, CardHeader, CardTitle } from "@/client/components/ui/card";
 
 interface SelectOrganizationPageProps {
@@ -1350,8 +1388,8 @@ export default async function SelectOrganizationPage({
   const { tenantSlug } = await params;
   const tenantContext = await resolveTenantContext(tenantSlug);
 
-  const orgRepository = new PrismaPoliticalOrganizationRepository();
-  const organizations = await orgRepository.findByTenantId(
+  // Loaderを使用してテナントに所属する政治団体一覧を取得
+  const organizations = await loadOrganizationsByTenantId(
     tenantContext.tenantId
   );
 
@@ -1641,6 +1679,7 @@ revalidateTag(`tenant-${tenantId.toString()}-transactions`);
 - [ ] `admin/src/server/contexts/auth/application/usecases/get-current-user-with-tenants-usecase.ts` を作成
 - [ ] `admin/src/server/contexts/auth/presentation/loaders/load-current-user-with-tenants.ts` を作成
 - [ ] `admin/src/server/contexts/auth/presentation/loaders/resolve-tenant-context.ts` を作成
+- [ ] `admin/src/server/contexts/shared/presentation/loaders/load-organizations-by-tenant.ts` を作成
 - [ ] `admin/src/server/contexts/auth/presentation/loaders/get-default-redirect-path.ts` を作成
 
 ### 10.2 Provider


### PR DESCRIPTION
## Summary

- フェーズ2マルチテナント化の詳細設計手順書を追加

## 目的

開発チームがマルチテナント化フェーズ2の実装を進められるようにするため。

## 内容

フェーズ1（スキーマ・ドメインモデル準備）完了後のフェーズ2として、以下の詳細設計を記載:

- **テナントコンテキスト基盤**: `TenantContext`, `OrganizationContext`, `getCurrentUserWithTenants`, `resolveTenantContext` 等
- **URL構造の変更**: `/t/[tenantSlug]/o/[orgSlug]/...` 形式への移行
- **Repository/Usecaseのテナント対応**: 全クエリへの `tenantId` 必須化パターン
- **UI実装**: テナント選択画面、政治団体選択画面
- **キャッシュ戦略**: テナントスコープのキャッシュキー設計
- **実装チェックリスト**: 各タスクの詳細なチェックリスト

## Test plan

- [ ] ドキュメントの内容を確認
- [ ] フェーズ1の設計書との整合性を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Phase 2のマルチテナント詳細設計ドキュメントを追加しました。移行手順、キャッシュ戦略、検証チェックリストを含みます。
* **New Features**
  * 管理画面のテナント/組織対応（URL構造・ルーティングの案）。
* **UI**
  * テナント選択・組織選択フロー、テナントに応じたログインリダイレクト、サイドバーなどのテナント認識ナビゲーションの設計を追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->