### PR TITLE
feat(admin): Repository/UseCase/Action層にtenantIdパラメータを追加

### DIFF
--- a/admin/src/app/(auth)/assign/counterparts/page.tsx
+++ b/admin/src/app/(auth)/assign/counterparts/page.tsx
@@ -47,7 +47,10 @@ export default async function CounterpartAssignmentPage({
   const params = await searchParams;
   const organizations = await loadPoliticalOrganizationsData();
 
-  const allCounterparts = await loadAllCounterpartsData();
+  // TODO: マルチテナント対応後はURLパラメータからtenantIdを取得する
+  const tenantId = BigInt(1); // 固定値: sample-party
+
+  const allCounterparts = await loadAllCounterpartsData(tenantId);
 
   const categoryOptions = buildCategoryOptions();
 

--- a/admin/src/app/(auth)/assign/donors/page.tsx
+++ b/admin/src/app/(auth)/assign/donors/page.tsx
@@ -35,7 +35,10 @@ export default async function DonorAssignmentPage({ searchParams }: DonorAssignm
   const params = await searchParams;
   const organizations = await loadPoliticalOrganizationsData();
 
-  const allDonors = await loadAllDonorsData();
+  // TODO: マルチテナント対応後はURLパラメータからtenantIdを取得する
+  const tenantId = BigInt(1); // 固定値: sample-party
+
+  const allDonors = await loadAllDonorsData(tenantId);
 
   const categoryOptions = buildCategoryOptions();
 

--- a/admin/src/app/(auth)/counterparts/[id]/page.tsx
+++ b/admin/src/app/(auth)/counterparts/[id]/page.tsx
@@ -24,8 +24,11 @@ export default async function CounterpartDetailPage({
   const { id } = await params;
   const searchParamsResolved = await searchParams;
 
+  // TODO: マルチテナント対応後はURLパラメータからtenantIdを取得する
+  const tenantId = BigInt(1); // 固定値: sample-party
+
   const [{ counterpart, usageCount, allCounterparts }, organizations] = await Promise.all([
-    loadCounterpartDetailPageData(id),
+    loadCounterpartDetailPageData(id, tenantId),
     loadPoliticalOrganizationsData(),
   ]);
 

--- a/admin/src/app/(auth)/counterparts/page.tsx
+++ b/admin/src/app/(auth)/counterparts/page.tsx
@@ -17,7 +17,11 @@ export default async function CounterpartMasterPage({ searchParams }: Counterpar
   const page = Number.isNaN(parsedPage) || parsedPage < 1 ? 1 : parsedPage;
   const perPage = 50;
 
+  // TODO: マルチテナント対応後はURLパラメータからtenantIdを取得する
+  const tenantId = BigInt(1); // 固定値: sample-party
+
   const data = await loadCounterpartsData({
+    tenantId,
     searchQuery,
     page,
     perPage,

--- a/admin/src/app/(auth)/donors/page.tsx
+++ b/admin/src/app/(auth)/donors/page.tsx
@@ -21,7 +21,11 @@ export default async function DonorMasterPage({ searchParams }: DonorMasterPageP
   const page = Number.isNaN(parsedPage) || parsedPage < 1 ? 1 : parsedPage;
   const perPage = 50;
 
+  // TODO: マルチテナント対応後はURLパラメータからtenantIdを取得する
+  const tenantId = BigInt(1); // 固定値: sample-party
+
   const data = await loadDonorsData({
+    tenantId,
     searchQuery,
     donorType,
     page,

--- a/admin/src/client/components/counterpart-assignment/AssignWithCounterpartContent.tsx
+++ b/admin/src/client/components/counterpart-assignment/AssignWithCounterpartContent.tsx
@@ -39,8 +39,14 @@ export function AssignWithCounterpartContent({
 
     setError(null);
     startTransition(async () => {
+      // TODO: マルチテナント対応後はコンテキストからtenantIdを取得する
+      const tenantId = "1"; // 固定値: sample-party
       const transactionIds = transactions.map((t) => t.id);
-      const result = await bulkAssignCounterpartAction(transactionIds, selectedCounterpartId);
+      const result = await bulkAssignCounterpartAction(
+        tenantId,
+        transactionIds,
+        selectedCounterpartId,
+      );
       if (!result.success) {
         setError(result.errors?.join(", ") ?? "紐付けに失敗しました");
         return;
@@ -56,7 +62,11 @@ export function AssignWithCounterpartContent({
   }) => {
     setError(null);
 
+    // TODO: マルチテナント対応後はコンテキストからtenantIdを取得する
+    const tenantId = "1"; // 固定値: sample-party
+
     const createResult = await createCounterpartAction({
+      tenantId,
       name: data.name,
       postalCode: data.postalCode,
       address: data.address,
@@ -71,7 +81,11 @@ export function AssignWithCounterpartContent({
     }
 
     const transactionIds = transactions.map((t) => t.id);
-    const result = await bulkAssignCounterpartAction(transactionIds, createResult.counterpartId);
+    const result = await bulkAssignCounterpartAction(
+      tenantId,
+      transactionIds,
+      createResult.counterpartId,
+    );
     if (!result.success) {
       throw new Error(result.errors?.join(", ") ?? "紐付けに失敗しました");
     }

--- a/admin/src/client/components/counterparts/CounterpartFormDialog.tsx
+++ b/admin/src/client/components/counterparts/CounterpartFormDialog.tsx
@@ -33,8 +33,12 @@ export function CounterpartFormDialog(props: CounterpartFormDialogProps) {
   }) => {
     setIsLoading(true);
     try {
+      // TODO: マルチテナント対応後はコンテキストからtenantIdを取得する
+      const tenantId = "1"; // 固定値: sample-party
+
       if (mode === "create") {
         const result = await createCounterpartAction({
+          tenantId,
           name: data.name,
           postalCode: data.postalCode,
           address: data.address,
@@ -44,7 +48,7 @@ export function CounterpartFormDialog(props: CounterpartFormDialogProps) {
           throw new Error(result.errors?.join(", ") ?? "作成に失敗しました");
         }
       } else if (counterpart) {
-        const result = await updateCounterpartAction(counterpart.id, {
+        const result = await updateCounterpartAction(counterpart.id, tenantId, {
           name: data.name,
           postalCode: data.postalCode,
           address: data.address,

--- a/admin/src/client/components/counterparts/CounterpartSelectorContent.tsx
+++ b/admin/src/client/components/counterparts/CounterpartSelectorContent.tsx
@@ -51,8 +51,10 @@ export function CounterpartSelectorContent({
     if (transactions.length === 0 || !politicalOrganizationId) return;
 
     setIsLoadingSuggestions(true);
+    // TODO: マルチテナント対応後はコンテキストからtenantIdを取得する
+    const tenantId = "1"; // 固定値: sample-party
     const transactionId = transactions[0].id;
-    suggestCounterpartAction(transactionId, politicalOrganizationId, 5)
+    suggestCounterpartAction(tenantId, transactionId, politicalOrganizationId, 5)
       .then((result) => {
         if (result.success) {
           setSuggestions(result.suggestions);

--- a/admin/src/client/components/counterparts/DeleteCounterpartButton.tsx
+++ b/admin/src/client/components/counterparts/DeleteCounterpartButton.tsx
@@ -32,7 +32,9 @@ export function DeleteCounterpartButton({
 
     try {
       setIsDeleting(true);
-      const result = await deleteCounterpartAction(counterpartId);
+      // TODO: マルチテナント対応後はコンテキストからtenantIdを取得する
+      const tenantId = "1"; // 固定値: sample-party
+      const result = await deleteCounterpartAction(counterpartId, tenantId);
 
       if (result.success) {
         onDelete();

--- a/admin/src/client/components/donor-assignment/AssignWithDonorContent.tsx
+++ b/admin/src/client/components/donor-assignment/AssignWithDonorContent.tsx
@@ -45,8 +45,10 @@ export function AssignWithDonorContent({
 
     setError(null);
     startTransition(async () => {
+      // TODO: マルチテナント対応後はコンテキストからtenantIdを取得する
+      const tenantId = "1"; // 固定値: sample-party
       const transactionIds = transactions.map((t) => t.id);
-      const result = await bulkAssignDonorAction(transactionIds, selectedDonorId);
+      const result = await bulkAssignDonorAction(tenantId, transactionIds, selectedDonorId);
       if (!result.success) {
         setError(result.errors?.join(", ") ?? "紐付けに失敗しました");
         return;
@@ -63,7 +65,11 @@ export function AssignWithDonorContent({
   }) => {
     setError(null);
 
+    // TODO: マルチテナント対応後はコンテキストからtenantIdを取得する
+    const tenantId = "1"; // 固定値: sample-party
+
     const createResult = await createDonorAction({
+      tenantId,
       donorType: data.donorType,
       name: data.name,
       address: data.address,
@@ -79,7 +85,7 @@ export function AssignWithDonorContent({
     }
 
     const transactionIds = transactions.map((t) => t.id);
-    const result = await bulkAssignDonorAction(transactionIds, createResult.donorId);
+    const result = await bulkAssignDonorAction(tenantId, transactionIds, createResult.donorId);
     if (!result.success) {
       throw new Error(result.errors?.join(", ") ?? "紐付けに失敗しました");
     }

--- a/admin/src/client/components/donor-csv-import/DonorCsvImportClient.tsx
+++ b/admin/src/client/components/donor-csv-import/DonorCsvImportClient.tsx
@@ -68,7 +68,10 @@ export default function DonorCsvImportClient({
       setError(null);
 
       try {
+        // TODO: マルチテナント対応後はコンテキストからtenantIdを取得する
+        const tenantId = "1"; // 固定値: sample-party
         const result = await stablePreviewAction({
+          tenantId,
           file,
           politicalOrganizationId,
         });
@@ -102,8 +105,11 @@ export default function DonorCsvImportClient({
     setIsImporting(true);
 
     try {
+      // TODO: マルチテナント対応後はコンテキストからtenantIdを取得する
+      const tenantId = "1"; // 固定値: sample-party
       const csvContent = await file.text();
       const result = await importActionRef.current({
+        tenantId,
         csvContent,
         politicalOrganizationId,
       });

--- a/admin/src/client/components/donors/DeleteDonorButton.tsx
+++ b/admin/src/client/components/donors/DeleteDonorButton.tsx
@@ -32,7 +32,9 @@ export function DeleteDonorButton({
 
     try {
       setIsDeleting(true);
-      const result = await deleteDonorAction(donorId);
+      // TODO: マルチテナント対応後はコンテキストからtenantIdを取得する
+      const tenantId = "1"; // 固定値: sample-party
+      const result = await deleteDonorAction(donorId, tenantId);
 
       if (result.success) {
         onDelete();

--- a/admin/src/client/components/donors/DonorFormDialog.tsx
+++ b/admin/src/client/components/donors/DonorFormDialog.tsx
@@ -34,8 +34,12 @@ export function DonorFormDialog(props: DonorFormDialogProps) {
   }) => {
     setIsLoading(true);
     try {
+      // TODO: マルチテナント対応後はコンテキストからtenantIdを取得する
+      const tenantId = "1"; // 固定値: sample-party
+
       if (mode === "create") {
         const result = await createDonorAction({
+          tenantId,
           donorType: data.donorType,
           name: data.name,
           address: data.address,
@@ -46,7 +50,7 @@ export function DonorFormDialog(props: DonorFormDialogProps) {
           throw new Error(result.errors?.join(", ") ?? "作成に失敗しました");
         }
       } else if (donor) {
-        const result = await updateDonorAction(donor.id, {
+        const result = await updateDonorAction(donor.id, tenantId, {
           donorType: data.donorType,
           name: data.name,
           address: data.address,

--- a/admin/src/server/contexts/report/application/services/counterpart-suggester.ts
+++ b/admin/src/server/contexts/report/application/services/counterpart-suggester.ts
@@ -11,6 +11,7 @@ export interface CounterpartSuggestion {
 }
 
 export interface SuggestionContext {
+  tenantId: bigint;
   politicalOrganizationId: string;
   repository: ICounterpartRepository;
 }
@@ -31,6 +32,7 @@ export class FrequencyStrategy implements SuggestionStrategy {
     context: SuggestionContext,
   ): Promise<CounterpartSuggestion[]> {
     const frequentCounterparts = await context.repository.findByUsageFrequency(
+      context.tenantId,
       context.politicalOrganizationId,
       10,
     );
@@ -41,6 +43,7 @@ export class FrequencyStrategy implements SuggestionStrategy {
         name: cp.name,
         postalCode: cp.postalCode,
         address: cp.address,
+        tenantId: cp.tenantId,
         createdAt: cp.createdAt,
         updatedAt: cp.updatedAt,
       },
@@ -63,6 +66,7 @@ export class PartnerNameStrategy implements SuggestionStrategy {
     }
 
     const matchingCounterparts = await context.repository.findByPartnerName(
+      context.tenantId,
       context.politicalOrganizationId,
       partnerName,
     );
@@ -73,6 +77,7 @@ export class PartnerNameStrategy implements SuggestionStrategy {
         name: cp.name,
         postalCode: cp.postalCode,
         address: cp.address,
+        tenantId: cp.tenantId,
         createdAt: cp.createdAt,
         updatedAt: cp.updatedAt,
       },
@@ -90,10 +95,12 @@ export class CounterpartSuggester {
 
   async suggest(
     transaction: TransactionWithCounterpart,
+    tenantId: bigint,
     politicalOrganizationId: string,
     limit = 5,
   ): Promise<CounterpartSuggestion[]> {
     const context: SuggestionContext = {
+      tenantId,
       politicalOrganizationId,
       repository: this.repository,
     };

--- a/admin/src/server/contexts/report/application/usecases/assign-donor-usecase.ts
+++ b/admin/src/server/contexts/report/application/usecases/assign-donor-usecase.ts
@@ -6,6 +6,7 @@ import type { ITransactionWithDonorRepository } from "@/server/contexts/report/d
 import { isDonorTypeAllowedForCategory } from "@/server/contexts/report/domain/models/donor-assignment-rules";
 
 export interface BulkAssignDonorInput {
+  tenantId: bigint;
   transactionIds: string[];
   donorId: string;
 }
@@ -44,7 +45,7 @@ export class BulkAssignDonorUsecase {
       return { success: false, errors: ["無効な寄付者IDです"] };
     }
 
-    const donor = await this.donorRepository.findById(input.donorId);
+    const donor = await this.donorRepository.findById(input.donorId, input.tenantId);
     if (!donor) {
       return { success: false, errors: ["寄付者が見つかりません"] };
     }

--- a/admin/src/server/contexts/report/application/usecases/bulk-assign-counterpart-usecase.ts
+++ b/admin/src/server/contexts/report/application/usecases/bulk-assign-counterpart-usecase.ts
@@ -5,6 +5,7 @@ import type { ICounterpartRepository } from "@/server/contexts/report/domain/rep
 import type { ITransactionCounterpartRepository } from "@/server/contexts/report/domain/repositories/transaction-counterpart-repository.interface";
 
 export interface BulkAssignCounterpartInput {
+  tenantId: bigint;
   transactionIds: string[];
   counterpartId: string;
 }
@@ -44,7 +45,10 @@ export class BulkAssignCounterpartUsecase {
       };
     }
 
-    const counterpart = await this.counterpartRepository.findById(input.counterpartId);
+    const counterpart = await this.counterpartRepository.findById(
+      input.counterpartId,
+      input.tenantId,
+    );
     if (!counterpart) {
       return { success: false, successCount: 0, failedIds: [], errors: ["無効な取引先IDです"] };
     }

--- a/admin/src/server/contexts/report/application/usecases/preview-donor-csv-usecase.ts
+++ b/admin/src/server/contexts/report/application/usecases/preview-donor-csv-usecase.ts
@@ -16,6 +16,7 @@ import type { IDonorRepository } from "@/server/contexts/report/domain/repositor
 import type { ITransactionWithDonorRepository } from "@/server/contexts/report/domain/repositories/transaction-with-donor-repository.interface";
 
 export interface PreviewDonorCsvInput {
+  tenantId: bigint;
   csvContent: string;
   politicalOrganizationId: string;
 }
@@ -57,7 +58,7 @@ export class PreviewDonorCsvUsecase {
         transactions.map((t) => [t.transactionNo, t]),
       );
 
-      const rowsWithMatchingDonor = await this.enrichWithMatchingDonors(rows);
+      const rowsWithMatchingDonor = await this.enrichWithMatchingDonors(input.tenantId, rows);
 
       const validatedRows = this.validator.validate(rowsWithMatchingDonor, transactionMap);
 
@@ -76,6 +77,7 @@ export class PreviewDonorCsvUsecase {
   }
 
   private async enrichWithMatchingDonors(
+    tenantId: bigint,
     rows: PreviewDonorCsvRow[],
   ): Promise<PreviewDonorCsvRow[]> {
     const searchKeys = new Map<
@@ -92,7 +94,7 @@ export class PreviewDonorCsvUsecase {
     }
 
     const uniqueCriteria = [...searchKeys.values()];
-    const donors = await this.donorRepository.findByMatchCriteriaBatch(uniqueCriteria);
+    const donors = await this.donorRepository.findByMatchCriteriaBatch(tenantId, uniqueCriteria);
 
     const donorMap = new Map<string, Donor>(
       donors.map((d) => [this.getDonorMatchKey(d.name, d.address, d.donorType), d]),

--- a/admin/src/server/contexts/report/application/usecases/suggest-counterpart-usecase.ts
+++ b/admin/src/server/contexts/report/application/usecases/suggest-counterpart-usecase.ts
@@ -8,6 +8,7 @@ import {
 } from "@/server/contexts/report/application/services/counterpart-suggester";
 
 export interface SuggestCounterpartInput {
+  tenantId: bigint;
   transactionId: string;
   politicalOrganizationId: string;
   limit?: number;
@@ -53,6 +54,7 @@ export class SuggestCounterpartUsecase {
 
     const suggestions = await suggester.suggest(
       transactionWithCounterpart,
+      input.tenantId,
       input.politicalOrganizationId,
       input.limit ?? 5,
     );

--- a/admin/src/server/contexts/report/domain/models/counterpart.ts
+++ b/admin/src/server/contexts/report/domain/models/counterpart.ts
@@ -3,6 +3,7 @@ export interface Counterpart {
   name: string;
   postalCode: string | null;
   address: string | null;
+  tenantId: string | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -15,6 +16,7 @@ export interface CreateCounterpartInput {
   name: string;
   postalCode: string | null;
   address: string | null;
+  tenantId: bigint;
 }
 
 export interface UpdateCounterpartInput {
@@ -27,7 +29,13 @@ export const MAX_NAME_LENGTH = 120;
 export const MAX_ADDRESS_LENGTH = 120;
 export const MAX_POSTAL_CODE_LENGTH = 10;
 
-export function validateCounterpartInput(input: CreateCounterpartInput): string[] {
+export interface ValidateCounterpartInput {
+  name: string;
+  postalCode: string | null;
+  address: string | null;
+}
+
+export function validateCounterpartInput(input: ValidateCounterpartInput): string[] {
   const errors: string[] = [];
   const trimmedName = input.name?.trim() ?? "";
   const trimmedAddress = input.address?.trim() ?? "";

--- a/admin/src/server/contexts/report/domain/models/donor.ts
+++ b/admin/src/server/contexts/report/domain/models/donor.ts
@@ -6,6 +6,7 @@ export interface Donor {
   name: string;
   address: string | null;
   occupation: string | null;
+  tenantId: string | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -19,6 +20,7 @@ export interface CreateDonorInput {
   name: string;
   address: string | null;
   occupation: string | null;
+  tenantId: bigint;
 }
 
 export interface UpdateDonorInput {
@@ -63,7 +65,14 @@ export function parseDonorType(value: string): DonorType | null {
   return isValidDonorType(normalized) ? normalized : null;
 }
 
-export function validateDonorInput(input: CreateDonorInput): string[] {
+export interface ValidateDonorInput {
+  donorType: DonorType;
+  name: string;
+  address: string | null;
+  occupation: string | null;
+}
+
+export function validateDonorInput(input: ValidateDonorInput): string[] {
   const errors: string[] = [];
   const trimmedName = input.name?.trim() ?? "";
   const trimmedAddress = input.address?.trim() ?? "";

--- a/admin/src/server/contexts/report/domain/repositories/counterpart-repository.interface.ts
+++ b/admin/src/server/contexts/report/domain/repositories/counterpart-repository.interface.ts
@@ -6,6 +6,7 @@ import type {
 } from "@/server/contexts/report/domain/models/counterpart";
 
 export interface CounterpartFilters {
+  tenantId: bigint;
   searchQuery?: string;
   limit?: number;
   offset?: number;
@@ -16,22 +17,28 @@ export interface CounterpartWithUsageAndLastUsed extends CounterpartWithUsage {
 }
 
 export interface ICounterpartRepository {
-  findById(id: string): Promise<Counterpart | null>;
-  findByNameAndAddress(name: string, address: string | null): Promise<Counterpart | null>;
-  findAll(filters?: CounterpartFilters): Promise<Counterpart[]>;
-  findAllWithUsage(filters?: CounterpartFilters): Promise<CounterpartWithUsage[]>;
+  findById(id: string, tenantId: bigint): Promise<Counterpart | null>;
+  findByNameAndAddress(
+    tenantId: bigint,
+    name: string,
+    address: string | null,
+  ): Promise<Counterpart | null>;
+  findAll(filters: CounterpartFilters): Promise<Counterpart[]>;
+  findAllWithUsage(filters: CounterpartFilters): Promise<CounterpartWithUsage[]>;
   create(data: CreateCounterpartInput): Promise<Counterpart>;
-  update(id: string, data: UpdateCounterpartInput): Promise<Counterpart>;
-  delete(id: string): Promise<void>;
+  update(id: string, tenantId: bigint, data: UpdateCounterpartInput): Promise<Counterpart>;
+  delete(id: string, tenantId: bigint): Promise<void>;
   getUsageCount(id: string): Promise<number>;
-  count(filters?: CounterpartFilters): Promise<number>;
+  count(filters: CounterpartFilters): Promise<number>;
 
   findByUsageFrequency(
+    tenantId: bigint,
     politicalOrganizationId: string,
     limit: number,
   ): Promise<CounterpartWithUsageAndLastUsed[]>;
 
   findByPartnerName(
+    tenantId: bigint,
     politicalOrganizationId: string,
     partnerName: string,
   ): Promise<CounterpartWithUsageAndLastUsed[]>;

--- a/admin/src/server/contexts/report/domain/repositories/donor-repository.interface.ts
+++ b/admin/src/server/contexts/report/domain/repositories/donor-repository.interface.ts
@@ -8,6 +8,7 @@ import type {
 import type { PrismaTransactionClient } from "@/server/contexts/report/domain/repositories/transaction-manager.interface";
 
 export interface DonorFilters {
+  tenantId: bigint;
   searchQuery?: string;
   donorType?: DonorType;
   limit?: number;
@@ -19,28 +20,36 @@ export interface DonorWithUsageAndLastUsed extends DonorWithUsage {
 }
 
 export interface IDonorRepository {
-  findById(id: string): Promise<Donor | null>;
+  findById(id: string, tenantId: bigint): Promise<Donor | null>;
   findByNameAddressAndType(
+    tenantId: bigint,
     name: string,
     address: string | null,
     donorType: DonorType,
   ): Promise<Donor | null>;
-  findAll(filters?: DonorFilters): Promise<Donor[]>;
-  findAllWithUsage(filters?: DonorFilters): Promise<DonorWithUsage[]>;
-  findByType(donorType: DonorType): Promise<Donor[]>;
+  findAll(filters: DonorFilters): Promise<Donor[]>;
+  findAllWithUsage(filters: DonorFilters): Promise<DonorWithUsage[]>;
+  findByType(tenantId: bigint, donorType: DonorType): Promise<Donor[]>;
   create(data: CreateDonorInput): Promise<Donor>;
-  update(id: string, data: UpdateDonorInput): Promise<Donor>;
-  delete(id: string): Promise<void>;
+  update(id: string, tenantId: bigint, data: UpdateDonorInput): Promise<Donor>;
+  delete(id: string, tenantId: bigint): Promise<void>;
   getUsageCount(id: string): Promise<number>;
-  count(filters?: DonorFilters): Promise<number>;
-  exists(name: string, address: string | null, donorType: DonorType): Promise<boolean>;
+  count(filters: DonorFilters): Promise<number>;
+  exists(
+    tenantId: bigint,
+    name: string,
+    address: string | null,
+    donorType: DonorType,
+  ): Promise<boolean>;
 
   findByUsageFrequency(
+    tenantId: bigint,
     politicalOrganizationId: string,
     limit: number,
   ): Promise<DonorWithUsageAndLastUsed[]>;
 
   findByPartnerName(
+    tenantId: bigint,
     politicalOrganizationId: string,
     partnerName: string,
   ): Promise<DonorWithUsageAndLastUsed[]>;
@@ -51,10 +60,12 @@ export interface IDonorRepository {
    * 同一人物判定に使用。政治資金報告書では同一寄付者の寄付を合算して
    * 5万円以上かを判定する必要があるため、既存Donorとの照合が重要。
    *
+   * @param tenantId テナントID
    * @param criteria 検索条件の配列
    * @returns 条件に一致した Donor の配列（一致しない条件は結果に含まれない）
    */
   findByMatchCriteriaBatch(
+    tenantId: bigint,
     criteria: Array<{ name: string; address: string | null; donorType: DonorType }>,
   ): Promise<Donor[]>;
 

--- a/admin/src/server/contexts/report/presentation/actions/bulk-assign-counterpart.ts
+++ b/admin/src/server/contexts/report/presentation/actions/bulk-assign-counterpart.ts
@@ -14,7 +14,11 @@ export interface BulkAssignCounterpartActionResult {
   errors?: string[];
 }
 
+/**
+ * tenantId は JSON シリアライズのため string で受け取る
+ */
 export async function bulkAssignCounterpartAction(
+  tenantId: string,
   transactionIds: string[],
   counterpartId: string,
 ): Promise<BulkAssignCounterpartActionResult> {
@@ -27,7 +31,11 @@ export async function bulkAssignCounterpartAction(
       counterpartRepository,
       transactionCounterpartRepository,
     );
-    const result = await usecase.execute({ transactionIds, counterpartId });
+    const result = await usecase.execute({
+      tenantId: BigInt(tenantId),
+      transactionIds,
+      counterpartId,
+    });
 
     if (!result.success) {
       return {

--- a/admin/src/server/contexts/report/presentation/actions/bulk-assign-donor.ts
+++ b/admin/src/server/contexts/report/presentation/actions/bulk-assign-donor.ts
@@ -13,7 +13,11 @@ export interface BulkAssignDonorActionResult {
   errors?: string[];
 }
 
+/**
+ * tenantId は JSON シリアライズのため string で受け取る
+ */
 export async function bulkAssignDonorAction(
+  tenantId: string,
   transactionIds: string[],
   donorId: string,
 ): Promise<BulkAssignDonorActionResult> {
@@ -26,7 +30,7 @@ export async function bulkAssignDonorAction(
       donorRepository,
       transactionDonorRepository,
     );
-    const result = await usecase.execute({ transactionIds, donorId });
+    const result = await usecase.execute({ tenantId: BigInt(tenantId), transactionIds, donorId });
 
     if (!result.success) {
       return { success: false, errors: result.errors };

--- a/admin/src/server/contexts/report/presentation/actions/create-donor.ts
+++ b/admin/src/server/contexts/report/presentation/actions/create-donor.ts
@@ -4,7 +4,19 @@ import { revalidatePath } from "next/cache";
 import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaDonorRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-donor.repository";
 import { CreateDonorUsecase } from "@/server/contexts/report/application/usecases/manage-donor-usecase";
-import type { CreateDonorInput } from "@/server/contexts/report/domain/models/donor";
+import type { DonorType } from "@/server/contexts/report/domain/models/donor";
+
+/**
+ * クライアントから受け取る入力
+ * tenantId は JSON シリアライズのため string で受け取る
+ */
+export interface CreateDonorActionInput {
+  tenantId: string;
+  donorType: DonorType;
+  name: string;
+  address: string | null;
+  occupation: string | null;
+}
 
 export interface CreateDonorActionResult {
   success: boolean;
@@ -12,12 +24,21 @@ export interface CreateDonorActionResult {
   errors?: string[];
 }
 
-export async function createDonorAction(input: CreateDonorInput): Promise<CreateDonorActionResult> {
+export async function createDonorAction(
+  input: CreateDonorActionInput,
+): Promise<CreateDonorActionResult> {
   try {
     const repository = new PrismaDonorRepository(prisma);
     const usecase = new CreateDonorUsecase(repository);
 
-    const result = await usecase.execute(input);
+    // クライアントから受け取った string を bigint に変換
+    const result = await usecase.execute({
+      tenantId: BigInt(input.tenantId),
+      donorType: input.donorType,
+      name: input.name,
+      address: input.address,
+      occupation: input.occupation,
+    });
 
     if (!result.success) {
       return { success: false, errors: result.errors };

--- a/admin/src/server/contexts/report/presentation/actions/delete-counterpart.ts
+++ b/admin/src/server/contexts/report/presentation/actions/delete-counterpart.ts
@@ -12,12 +12,18 @@ export interface DeleteCounterpartActionResult {
   errors?: string[];
 }
 
-export async function deleteCounterpartAction(id: string): Promise<DeleteCounterpartActionResult> {
+/**
+ * tenantId は JSON シリアライズのため string で受け取る
+ */
+export async function deleteCounterpartAction(
+  id: string,
+  tenantId: string,
+): Promise<DeleteCounterpartActionResult> {
   try {
     const repository = new PrismaCounterpartRepository(prisma);
     const usecase = new DeleteCounterpartUsecase(repository);
 
-    const result = await usecase.execute(id);
+    const result = await usecase.execute(id, BigInt(tenantId));
 
     if (!result.success) {
       return { success: false, errors: result.errors };

--- a/admin/src/server/contexts/report/presentation/actions/delete-donor.ts
+++ b/admin/src/server/contexts/report/presentation/actions/delete-donor.ts
@@ -12,12 +12,18 @@ export interface DeleteDonorActionResult {
   errors?: string[];
 }
 
-export async function deleteDonorAction(id: string): Promise<DeleteDonorActionResult> {
+/**
+ * tenantId は JSON シリアライズのため string で受け取る
+ */
+export async function deleteDonorAction(
+  id: string,
+  tenantId: string,
+): Promise<DeleteDonorActionResult> {
   try {
     const repository = new PrismaDonorRepository(prisma);
     const usecase = new DeleteDonorUsecase(repository, false);
 
-    const result = await usecase.execute(id);
+    const result = await usecase.execute(id, BigInt(tenantId));
 
     if (!result.success) {
       return { success: false, errors: result.errors };

--- a/admin/src/server/contexts/report/presentation/actions/import-donor-csv.ts
+++ b/admin/src/server/contexts/report/presentation/actions/import-donor-csv.ts
@@ -17,7 +17,12 @@ import {
 } from "@/server/contexts/report/domain/errors/donor-csv-error";
 import { ImportDonorCsvUsecase } from "@/server/contexts/report/application/usecases/import-donor-csv-usecase";
 
+/**
+ * クライアントから受け取る入力
+ * tenantId は JSON シリアライズのため string で受け取る
+ */
 export interface ImportDonorCsvRequest {
+  tenantId: string;
   csvContent: string;
   politicalOrganizationId: string;
 }
@@ -28,7 +33,7 @@ export type ImportDonorCsvResult =
 
 export async function importDonorCsv(data: ImportDonorCsvRequest): Promise<ImportDonorCsvResult> {
   try {
-    const { csvContent, politicalOrganizationId } = data;
+    const { tenantId, csvContent, politicalOrganizationId } = data;
 
     if (!csvContent) {
       return { ok: false, error: "CSVコンテンツが指定されていません" };
@@ -57,6 +62,7 @@ export async function importDonorCsv(data: ImportDonorCsvRequest): Promise<Impor
     );
 
     const result = await usecase.execute({
+      tenantId: BigInt(tenantId),
       csvContent,
       politicalOrganizationId,
     });

--- a/admin/src/server/contexts/report/presentation/actions/preview-donor-csv.ts
+++ b/admin/src/server/contexts/report/presentation/actions/preview-donor-csv.ts
@@ -14,7 +14,12 @@ import {
 import { PreviewDonorCsvUsecase } from "@/server/contexts/report/application/usecases/preview-donor-csv-usecase";
 import type { PreviewDonorCsvResult } from "@/server/contexts/report/presentation/types/preview-donor-csv-types";
 
+/**
+ * クライアントから受け取る入力
+ * tenantId は JSON シリアライズのため string で受け取る
+ */
 export interface PreviewDonorCsvRequest {
+  tenantId: string;
   file: File;
   politicalOrganizationId: string;
 }
@@ -23,7 +28,7 @@ export async function previewDonorCsv(
   data: PreviewDonorCsvRequest,
 ): Promise<PreviewDonorCsvResult> {
   try {
-    const { file, politicalOrganizationId } = data;
+    const { tenantId, file, politicalOrganizationId } = data;
 
     if (!file) {
       throw new Error("ファイルが選択されていません");
@@ -51,6 +56,7 @@ export async function previewDonorCsv(
     );
 
     const result = await usecase.execute({
+      tenantId: BigInt(tenantId),
       csvContent,
       politicalOrganizationId,
     });

--- a/admin/src/server/contexts/report/presentation/actions/suggest-counterpart.ts
+++ b/admin/src/server/contexts/report/presentation/actions/suggest-counterpart.ts
@@ -8,7 +8,11 @@ import {
 import { PrismaReportTransactionRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-report-transaction.repository";
 import { PrismaCounterpartRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-counterpart.repository";
 
+/**
+ * tenantId は JSON シリアライズのため string で受け取る
+ */
 export async function suggestCounterpartAction(
+  tenantId: string,
   transactionId: string,
   politicalOrganizationId: string,
   limit?: number,
@@ -17,7 +21,12 @@ export async function suggestCounterpartAction(
     const transactionRepository = new PrismaReportTransactionRepository(prisma);
     const counterpartRepository = new PrismaCounterpartRepository(prisma);
     const usecase = new SuggestCounterpartUsecase(transactionRepository, counterpartRepository);
-    return await usecase.execute({ transactionId, politicalOrganizationId, limit });
+    return await usecase.execute({
+      tenantId: BigInt(tenantId),
+      transactionId,
+      politicalOrganizationId,
+      limit,
+    });
   } catch (error) {
     console.error("Error suggesting counterpart:", error);
     return {

--- a/admin/src/server/contexts/report/presentation/actions/update-counterpart.ts
+++ b/admin/src/server/contexts/report/presentation/actions/update-counterpart.ts
@@ -11,15 +11,19 @@ export interface UpdateCounterpartActionResult {
   errors?: string[];
 }
 
+/**
+ * tenantId は JSON シリアライズのため string で受け取る
+ */
 export async function updateCounterpartAction(
   id: string,
+  tenantId: string,
   input: UpdateCounterpartInput,
 ): Promise<UpdateCounterpartActionResult> {
   try {
     const repository = new PrismaCounterpartRepository(prisma);
     const usecase = new UpdateCounterpartUsecase(repository);
 
-    const result = await usecase.execute(id, input);
+    const result = await usecase.execute(id, BigInt(tenantId), input);
 
     if (!result.success) {
       return { success: false, errors: result.errors };

--- a/admin/src/server/contexts/report/presentation/actions/update-donor.ts
+++ b/admin/src/server/contexts/report/presentation/actions/update-donor.ts
@@ -11,15 +11,19 @@ export interface UpdateDonorActionResult {
   errors?: string[];
 }
 
+/**
+ * tenantId は JSON シリアライズのため string で受け取る
+ */
 export async function updateDonorAction(
   id: string,
+  tenantId: string,
   input: UpdateDonorInput,
 ): Promise<UpdateDonorActionResult> {
   try {
     const repository = new PrismaDonorRepository(prisma);
     const usecase = new UpdateDonorUsecase(repository);
 
-    const result = await usecase.execute(id, input);
+    const result = await usecase.execute(id, BigInt(tenantId), input);
 
     if (!result.success) {
       return { success: false, errors: result.errors };

--- a/admin/src/server/contexts/shared/domain/repositories/political-organization-repository.interface.ts
+++ b/admin/src/server/contexts/shared/domain/repositories/political-organization-repository.interface.ts
@@ -7,9 +7,18 @@ export interface UpdatePoliticalOrganizationInput {
   description?: string;
 }
 
+/**
+ * 政治団体（テナントID付き）
+ */
+export interface PoliticalOrganizationWithTenantId extends PoliticalOrganization {
+  tenantId: bigint | null;
+}
+
 export interface IPoliticalOrganizationRepository {
   findAll(): Promise<PoliticalOrganization[]>;
   findById(id: bigint): Promise<PoliticalOrganization | null>;
+  findBySlug(slug: string): Promise<PoliticalOrganizationWithTenantId | null>;
+  findByTenantId(tenantId: bigint): Promise<PoliticalOrganization[]>;
   create(
     displayName: string,
     slug: string,

--- a/admin/src/server/contexts/shared/infrastructure/repositories/prisma-political-organization.repository.ts
+++ b/admin/src/server/contexts/shared/infrastructure/repositories/prisma-political-organization.repository.ts
@@ -2,6 +2,7 @@ import type { PrismaClient } from "@prisma/client";
 import type { PoliticalOrganization } from "@/shared/models/political-organization";
 import type {
   IPoliticalOrganizationRepository,
+  PoliticalOrganizationWithTenantId,
   UpdatePoliticalOrganizationInput,
 } from "@/server/contexts/shared/domain/repositories/political-organization-repository.interface";
 
@@ -44,6 +45,44 @@ export class PrismaPoliticalOrganizationRepository implements IPoliticalOrganiza
       createdAt: organization.createdAt,
       updatedAt: organization.updatedAt,
     };
+  }
+
+  async findBySlug(slug: string): Promise<PoliticalOrganizationWithTenantId | null> {
+    const organization = await this.prisma.politicalOrganization.findUnique({
+      where: { slug },
+    });
+
+    if (!organization) {
+      return null;
+    }
+
+    return {
+      id: organization.id.toString(),
+      displayName: organization.displayName,
+      orgName: organization.orgName,
+      slug: organization.slug,
+      description: organization.description,
+      tenantId: organization.tenantId,
+      createdAt: organization.createdAt,
+      updatedAt: organization.updatedAt,
+    };
+  }
+
+  async findByTenantId(tenantId: bigint): Promise<PoliticalOrganization[]> {
+    const organizations = await this.prisma.politicalOrganization.findMany({
+      where: { tenantId },
+      orderBy: { displayName: "asc" },
+    });
+
+    return organizations.map((org) => ({
+      id: org.id.toString(),
+      displayName: org.displayName,
+      orgName: org.orgName,
+      slug: org.slug,
+      description: org.description,
+      createdAt: org.createdAt,
+      updatedAt: org.updatedAt,
+    }));
   }
 
   async create(

--- a/admin/tests/server/contexts/report/application/services/counterpart-suggester.test.ts
+++ b/admin/tests/server/contexts/report/application/services/counterpart-suggester.test.ts
@@ -10,9 +10,11 @@ import type { TransactionWithCounterpart } from "@/server/contexts/report/domain
 
 describe("CounterpartSuggester", () => {
   let mockRepository: jest.Mocked<ICounterpartRepository>;
+  const tenantId = BigInt(1);
 
   const createMockCounterpart = (overrides: Partial<CounterpartWithUsageAndLastUsed> = {}): CounterpartWithUsageAndLastUsed => ({
     id: "cp-1",
+    tenantId: "1",
     name: "テスト取引先",
     postalCode: null,
     address: "東京都千代田区",
@@ -70,6 +72,7 @@ describe("CounterpartSuggester", () => {
       mockRepository.findByUsageFrequency.mockResolvedValue(counterparts);
 
       const context: SuggestionContext = {
+        tenantId,
         politicalOrganizationId: "org-1",
         repository: mockRepository,
       };
@@ -92,6 +95,7 @@ describe("CounterpartSuggester", () => {
       mockRepository.findByUsageFrequency.mockResolvedValue(counterparts);
 
       const context: SuggestionContext = {
+        tenantId,
         politicalOrganizationId: "org-1",
         repository: mockRepository,
       };
@@ -107,6 +111,7 @@ describe("CounterpartSuggester", () => {
       mockRepository.findByUsageFrequency.mockResolvedValue([]);
 
       const context: SuggestionContext = {
+        tenantId,
         politicalOrganizationId: "org-1",
         repository: mockRepository,
       };
@@ -126,6 +131,7 @@ describe("CounterpartSuggester", () => {
       mockRepository.findByPartnerName.mockResolvedValue(counterparts);
 
       const context: SuggestionContext = {
+        tenantId,
         politicalOrganizationId: "org-1",
         repository: mockRepository,
       };
@@ -142,6 +148,7 @@ describe("CounterpartSuggester", () => {
       const strategy = new PartnerNameStrategy();
 
       const context: SuggestionContext = {
+        tenantId,
         politicalOrganizationId: "org-1",
         repository: mockRepository,
       };
@@ -161,6 +168,7 @@ describe("CounterpartSuggester", () => {
       mockRepository.findByPartnerName.mockResolvedValue(counterparts);
 
       const context: SuggestionContext = {
+        tenantId,
         politicalOrganizationId: "org-1",
         repository: mockRepository,
       };
@@ -169,7 +177,7 @@ describe("CounterpartSuggester", () => {
       const suggestions = await strategy.suggest(transaction, context);
 
       expect(suggestions).toHaveLength(1);
-      expect(mockRepository.findByPartnerName).toHaveBeenCalledWith("org-1", "ガス会社");
+      expect(mockRepository.findByPartnerName).toHaveBeenCalledWith(tenantId, "org-1", "ガス会社");
     });
   });
 
@@ -188,6 +196,7 @@ describe("CounterpartSuggester", () => {
 
       const suggestions = await suggester.suggest(
         createMockTransaction({ debitPartner: "取引先A" }),
+        tenantId,
         "org-1",
       );
 
@@ -209,6 +218,7 @@ describe("CounterpartSuggester", () => {
 
       const suggestions = await suggester.suggest(
         createMockTransaction({ debitPartner: "共通取引先" }),
+        tenantId,
         "org-1",
       );
 
@@ -229,7 +239,7 @@ describe("CounterpartSuggester", () => {
         mockRepository,
       );
 
-      const suggestions = await suggester.suggest(createMockTransaction(), "org-1");
+      const suggestions = await suggester.suggest(createMockTransaction(), tenantId, "org-1");
 
       expect(suggestions[0].counterpart.id).toBe("cp-2");
     });
@@ -247,7 +257,7 @@ describe("CounterpartSuggester", () => {
         mockRepository,
       );
 
-      const suggestions = await suggester.suggest(createMockTransaction(), "org-1", 3);
+      const suggestions = await suggester.suggest(createMockTransaction(), tenantId, "org-1", 3);
 
       expect(suggestions).toHaveLength(3);
     });
@@ -265,6 +275,7 @@ describe("CounterpartSuggester", () => {
 
       const suggestions = await suggester.suggest(
         createMockTransaction({ debitPartner: "取引先A" }),
+        tenantId,
         "org-1",
       );
 

--- a/admin/tests/server/contexts/report/application/usecases/import-donor-csv-usecase.test.ts
+++ b/admin/tests/server/contexts/report/application/usecases/import-donor-csv-usecase.test.ts
@@ -18,6 +18,8 @@ import type { Donor } from "@/server/contexts/report/domain/models/donor";
 import { NoValidRowsError } from "@/server/contexts/report/domain/errors/donor-csv-error";
 
 describe("ImportDonorCsvUsecase", () => {
+  const tenantId = BigInt(1);
+
   const mockCsvLoader: jest.Mocked<IDonorCsvLoader> = {
     load: jest.fn(),
   } as unknown as jest.Mocked<IDonorCsvLoader>;
@@ -106,6 +108,7 @@ describe("ImportDonorCsvUsecase", () => {
 
   const createMockDonor = (overrides: Partial<Donor> = {}): Donor => ({
     id: "1",
+    tenantId: "1",
     name: "テスト太郎",
     donorType: "individual",
     address: "東京都渋谷区",
@@ -143,6 +146,7 @@ describe("ImportDonorCsvUsecase", () => {
     const usecase = createUsecase();
 
     const input: ImportDonorCsvInput = {
+      tenantId,
       csvContent: "dummy csv content",
       politicalOrganizationId: "org-123",
     };
@@ -158,6 +162,7 @@ describe("ImportDonorCsvUsecase", () => {
           address: "東京都渋谷区",
           donorType: "individual",
           occupation: "会社員",
+          tenantId,
         },
       ],
       expect.anything(),
@@ -174,6 +179,7 @@ describe("ImportDonorCsvUsecase", () => {
     const usecase = createUsecase();
 
     const input: ImportDonorCsvInput = {
+      tenantId,
       csvContent: "",
       politicalOrganizationId: "org-123",
     };
@@ -195,6 +201,7 @@ describe("ImportDonorCsvUsecase", () => {
     const usecase = createUsecase();
 
     const input: ImportDonorCsvInput = {
+      tenantId,
       csvContent: "dummy csv content",
       politicalOrganizationId: "org-123",
     };
@@ -226,6 +233,7 @@ describe("ImportDonorCsvUsecase", () => {
     const usecase = createUsecase();
 
     const input: ImportDonorCsvInput = {
+      tenantId,
       csvContent: "dummy csv content",
       politicalOrganizationId: "org-123",
     };
@@ -268,6 +276,7 @@ describe("ImportDonorCsvUsecase", () => {
     const usecase = createUsecase();
 
     const input: ImportDonorCsvInput = {
+      tenantId,
       csvContent: "dummy csv content",
       politicalOrganizationId: "org-123",
     };
@@ -311,6 +320,7 @@ describe("ImportDonorCsvUsecase", () => {
     const usecase = createUsecase();
 
     const input: ImportDonorCsvInput = {
+      tenantId,
       csvContent: "dummy csv content",
       politicalOrganizationId: "org-123",
     };
@@ -326,6 +336,7 @@ describe("ImportDonorCsvUsecase", () => {
           address: "東京都渋谷区",
           donorType: "individual",
           occupation: "会社員",
+          tenantId,
         },
       ],
       expect.anything(),
@@ -380,6 +391,7 @@ describe("ImportDonorCsvUsecase", () => {
     const usecase = createUsecase();
 
     const input: ImportDonorCsvInput = {
+      tenantId,
       csvContent: "dummy csv content",
       politicalOrganizationId: "org-123",
     };
@@ -407,6 +419,7 @@ describe("ImportDonorCsvUsecase", () => {
     const usecase = createUsecase();
 
     const input: ImportDonorCsvInput = {
+      tenantId,
       csvContent: "dummy csv content",
       politicalOrganizationId: "org-123",
     };
@@ -444,6 +457,7 @@ describe("ImportDonorCsvUsecase", () => {
     const usecase = createUsecase();
 
     const input: ImportDonorCsvInput = {
+      tenantId,
       csvContent: "dummy csv content",
       politicalOrganizationId: "org-123",
     };

--- a/admin/tests/server/contexts/report/application/usecases/manage-counterpart-usecase.test.ts
+++ b/admin/tests/server/contexts/report/application/usecases/manage-counterpart-usecase.test.ts
@@ -13,9 +13,11 @@ import type { Counterpart, CounterpartWithUsage } from "@/server/contexts/report
 
 describe("manage-counterpart-usecase", () => {
   let mockRepository: jest.Mocked<ICounterpartRepository>;
+  const tenantId = BigInt(1);
 
   const createMockCounterpart = (overrides: Partial<Counterpart> = {}): Counterpart => ({
     id: "cp-1",
+    tenantId: "1",
     name: "テスト取引先",
     postalCode: null,
     address: "東京都千代田区",
@@ -53,7 +55,7 @@ describe("manage-counterpart-usecase", () => {
       mockRepository.count.mockResolvedValue(1);
 
       const usecase = new GetCounterpartsUsecase(mockRepository);
-      const result = await usecase.execute({});
+      const result = await usecase.execute({ tenantId });
 
       expect(result.counterparts).toEqual(counterparts);
       expect(result.total).toBe(1);
@@ -64,9 +66,10 @@ describe("manage-counterpart-usecase", () => {
       mockRepository.count.mockResolvedValue(0);
 
       const usecase = new GetCounterpartsUsecase(mockRepository);
-      await usecase.execute({ searchQuery: "テスト", limit: 10, offset: 5 });
+      await usecase.execute({ tenantId, searchQuery: "テスト", limit: 10, offset: 5 });
 
       expect(mockRepository.findAllWithUsage).toHaveBeenCalledWith({
+        tenantId,
         searchQuery: "テスト",
         limit: 10,
         offset: 5,
@@ -80,17 +83,17 @@ describe("manage-counterpart-usecase", () => {
       mockRepository.findById.mockResolvedValue(counterpart);
 
       const usecase = new GetCounterpartByIdUsecase(mockRepository);
-      const result = await usecase.execute("cp-1");
+      const result = await usecase.execute("cp-1", tenantId);
 
       expect(result).toEqual(counterpart);
-      expect(mockRepository.findById).toHaveBeenCalledWith("cp-1");
+      expect(mockRepository.findById).toHaveBeenCalledWith("cp-1", tenantId);
     });
 
     it("存在しない場合はnullを返す", async () => {
       mockRepository.findById.mockResolvedValue(null);
 
       const usecase = new GetCounterpartByIdUsecase(mockRepository);
-      const result = await usecase.execute("non-existent");
+      const result = await usecase.execute("non-existent", tenantId);
 
       expect(result).toBeNull();
     });
@@ -103,7 +106,7 @@ describe("manage-counterpart-usecase", () => {
       mockRepository.create.mockResolvedValue(newCounterpart);
 
       const usecase = new CreateCounterpartUsecase(mockRepository);
-      const result = await usecase.execute({ name: "新規取引先", postalCode: null, address: "東京都" });
+      const result = await usecase.execute({ tenantId, name: "新規取引先", postalCode: null, address: "東京都" });
 
       expect(result.success).toBe(true);
       expect(result.counterpart).toEqual(newCounterpart);
@@ -111,7 +114,7 @@ describe("manage-counterpart-usecase", () => {
 
     it("名前が空の場合はエラーを返す", async () => {
       const usecase = new CreateCounterpartUsecase(mockRepository);
-      const result = await usecase.execute({ name: "", postalCode: null, address: null });
+      const result = await usecase.execute({ tenantId, name: "", postalCode: null, address: null });
 
       expect(result.success).toBe(false);
       expect(result.errors).toContain("名前は必須です");
@@ -121,7 +124,7 @@ describe("manage-counterpart-usecase", () => {
       mockRepository.findByNameAndAddress.mockResolvedValue(createMockCounterpart());
 
       const usecase = new CreateCounterpartUsecase(mockRepository);
-      const result = await usecase.execute({ name: "テスト取引先", postalCode: null, address: "東京都千代田区" });
+      const result = await usecase.execute({ tenantId, name: "テスト取引先", postalCode: null, address: "東京都千代田区" });
 
       expect(result.success).toBe(false);
       expect(result.errors).toContain("同じ名前・住所の組み合わせが既に存在します");
@@ -133,9 +136,10 @@ describe("manage-counterpart-usecase", () => {
       mockRepository.create.mockResolvedValue(newCounterpart);
 
       const usecase = new CreateCounterpartUsecase(mockRepository);
-      await usecase.execute({ name: "  テスト取引先  ", postalCode: "  123-4567  ", address: "  東京都  " });
+      await usecase.execute({ tenantId, name: "  テスト取引先  ", postalCode: "  123-4567  ", address: "  東京都  " });
 
       expect(mockRepository.create).toHaveBeenCalledWith({
+        tenantId,
         name: "テスト取引先",
         postalCode: "123-4567",
         address: "東京都",
@@ -152,7 +156,7 @@ describe("manage-counterpart-usecase", () => {
       mockRepository.update.mockResolvedValue(updated);
 
       const usecase = new UpdateCounterpartUsecase(mockRepository);
-      const result = await usecase.execute("cp-1", { name: "更新後の名前" });
+      const result = await usecase.execute("cp-1", tenantId, { name: "更新後の名前" });
 
       expect(result.success).toBe(true);
       expect(result.counterpart).toEqual(updated);
@@ -162,7 +166,7 @@ describe("manage-counterpart-usecase", () => {
       mockRepository.findById.mockResolvedValue(null);
 
       const usecase = new UpdateCounterpartUsecase(mockRepository);
-      const result = await usecase.execute("non-existent", { name: "新しい名前" });
+      const result = await usecase.execute("non-existent", tenantId, { name: "新しい名前" });
 
       expect(result.success).toBe(false);
       expect(result.errors).toContain("取引先が見つかりません");
@@ -175,7 +179,7 @@ describe("manage-counterpart-usecase", () => {
       mockRepository.findByNameAndAddress.mockResolvedValue(duplicate);
 
       const usecase = new UpdateCounterpartUsecase(mockRepository);
-      const result = await usecase.execute("cp-1", { name: "重複する名前", address: "重複する住所" });
+      const result = await usecase.execute("cp-1", tenantId, { name: "重複する名前", address: "重複する住所" });
 
       expect(result.success).toBe(false);
       expect(result.errors).toContain("同じ名前・住所の組み合わせが既に存在します");
@@ -188,7 +192,7 @@ describe("manage-counterpart-usecase", () => {
       mockRepository.update.mockResolvedValue(existing);
 
       const usecase = new UpdateCounterpartUsecase(mockRepository);
-      const result = await usecase.execute("cp-1", { name: "テスト取引先" });
+      const result = await usecase.execute("cp-1", tenantId, { name: "テスト取引先" });
 
       expect(result.success).toBe(true);
     });
@@ -201,17 +205,17 @@ describe("manage-counterpart-usecase", () => {
       mockRepository.delete.mockResolvedValue();
 
       const usecase = new DeleteCounterpartUsecase(mockRepository);
-      const result = await usecase.execute("cp-1");
+      const result = await usecase.execute("cp-1", tenantId);
 
       expect(result.success).toBe(true);
-      expect(mockRepository.delete).toHaveBeenCalledWith("cp-1");
+      expect(mockRepository.delete).toHaveBeenCalledWith("cp-1", tenantId);
     });
 
     it("存在しない取引先はエラーを返す", async () => {
       mockRepository.findById.mockResolvedValue(null);
 
       const usecase = new DeleteCounterpartUsecase(mockRepository);
-      const result = await usecase.execute("non-existent");
+      const result = await usecase.execute("non-existent", tenantId);
 
       expect(result.success).toBe(false);
       expect(result.errors).toContain("取引先が見つかりません");
@@ -222,7 +226,7 @@ describe("manage-counterpart-usecase", () => {
       mockRepository.getUsageCount.mockResolvedValue(3);
 
       const usecase = new DeleteCounterpartUsecase(mockRepository);
-      const result = await usecase.execute("cp-1");
+      const result = await usecase.execute("cp-1", tenantId);
 
       expect(result.success).toBe(false);
       expect(result.errors?.[0]).toContain("3件のトランザクションで使用されています");
@@ -233,7 +237,7 @@ describe("manage-counterpart-usecase", () => {
       mockRepository.delete.mockResolvedValue();
 
       const usecase = new DeleteCounterpartUsecase(mockRepository, false);
-      const result = await usecase.execute("cp-1");
+      const result = await usecase.execute("cp-1", tenantId);
 
       expect(result.success).toBe(true);
       expect(mockRepository.getUsageCount).not.toHaveBeenCalled();
@@ -262,14 +266,14 @@ describe("manage-counterpart-usecase", () => {
       mockRepository.findAll.mockResolvedValue(allCounterparts);
 
       const usecase = new GetCounterpartDetailUsecase(mockRepository);
-      const result = await usecase.execute("cp-1");
+      const result = await usecase.execute("cp-1", tenantId);
 
       expect(result.counterpart).toEqual(counterpart);
       expect(result.usageCount).toBe(5);
       expect(result.allCounterparts).toEqual(allCounterparts);
-      expect(mockRepository.findById).toHaveBeenCalledWith("cp-1");
+      expect(mockRepository.findById).toHaveBeenCalledWith("cp-1", tenantId);
       expect(mockRepository.getUsageCount).toHaveBeenCalledWith("cp-1");
-      expect(mockRepository.findAll).toHaveBeenCalledWith({ limit: 1000 });
+      expect(mockRepository.findAll).toHaveBeenCalledWith({ tenantId, limit: 1000 });
     });
 
     it("存在しない取引先の場合はcounterpartがnullになる", async () => {
@@ -280,7 +284,7 @@ describe("manage-counterpart-usecase", () => {
       mockRepository.findAll.mockResolvedValue(allCounterparts);
 
       const usecase = new GetCounterpartDetailUsecase(mockRepository);
-      const result = await usecase.execute("non-existent");
+      const result = await usecase.execute("non-existent", tenantId);
 
       expect(result.counterpart).toBeNull();
       expect(result.usageCount).toBe(0);
@@ -297,10 +301,10 @@ describe("manage-counterpart-usecase", () => {
       mockRepository.findAll.mockResolvedValue(counterparts);
 
       const usecase = new GetAllCounterpartsUsecase(mockRepository);
-      const result = await usecase.execute();
+      const result = await usecase.execute({ tenantId });
 
       expect(result).toEqual(counterparts);
-      expect(mockRepository.findAll).toHaveBeenCalledWith({ limit: 1000 });
+      expect(mockRepository.findAll).toHaveBeenCalledWith({ tenantId, limit: 1000 });
     });
 
     it("カスタムlimitを指定して取得する", async () => {
@@ -308,10 +312,10 @@ describe("manage-counterpart-usecase", () => {
       mockRepository.findAll.mockResolvedValue(counterparts);
 
       const usecase = new GetAllCounterpartsUsecase(mockRepository);
-      const result = await usecase.execute({ limit: 500 });
+      const result = await usecase.execute({ tenantId, limit: 500 });
 
       expect(result).toEqual(counterparts);
-      expect(mockRepository.findAll).toHaveBeenCalledWith({ limit: 500 });
+      expect(mockRepository.findAll).toHaveBeenCalledWith({ tenantId, limit: 500 });
     });
   });
 });

--- a/admin/tests/server/contexts/report/application/usecases/preview-donor-csv-usecase.test.ts
+++ b/admin/tests/server/contexts/report/application/usecases/preview-donor-csv-usecase.test.ts
@@ -14,6 +14,8 @@ import type {
 } from "@/server/contexts/report/domain/models/preview-donor-csv-row";
 
 describe("PreviewDonorCsvUsecase", () => {
+  const tenantId = BigInt(1);
+
   const mockCsvLoader: jest.Mocked<DonorCsvLoader> = {
     load: jest.fn(),
   } as unknown as jest.Mocked<DonorCsvLoader>;
@@ -103,6 +105,7 @@ describe("PreviewDonorCsvUsecase", () => {
     );
 
     const input: PreviewDonorCsvInput = {
+      tenantId,
       csvContent: "dummy csv content",
       politicalOrganizationId: "org-123",
     };
@@ -131,6 +134,7 @@ describe("PreviewDonorCsvUsecase", () => {
     );
 
     const input: PreviewDonorCsvInput = {
+      tenantId,
       csvContent: "",
       politicalOrganizationId: "org-123",
     };
@@ -149,6 +153,7 @@ describe("PreviewDonorCsvUsecase", () => {
     const transaction = createMockTransaction();
     const matchingDonor = {
       id: "donor-1",
+      tenantId: "1",
       name: "テスト太郎",
       donorType: "individual" as const,
       address: "東京都渋谷区",
@@ -172,6 +177,7 @@ describe("PreviewDonorCsvUsecase", () => {
     );
 
     const input: PreviewDonorCsvInput = {
+      tenantId,
       csvContent: "dummy csv content",
       politicalOrganizationId: "org-123",
     };
@@ -180,7 +186,7 @@ describe("PreviewDonorCsvUsecase", () => {
 
     expect(result.rows[0].matchingDonor).not.toBeNull();
     expect(result.rows[0].matchingDonor?.id).toBe("donor-1");
-    expect(mockDonorRepository.findByMatchCriteriaBatch).toHaveBeenCalledWith([
+    expect(mockDonorRepository.findByMatchCriteriaBatch).toHaveBeenCalledWith(tenantId, [
       { name: "テスト太郎", address: "東京都渋谷区", donorType: "individual" },
     ]);
   });
@@ -218,6 +224,7 @@ describe("PreviewDonorCsvUsecase", () => {
     );
 
     const input: PreviewDonorCsvInput = {
+      tenantId,
       csvContent: "dummy csv content",
       politicalOrganizationId: "org-123",
     };
@@ -247,6 +254,7 @@ describe("PreviewDonorCsvUsecase", () => {
     );
 
     const input: PreviewDonorCsvInput = {
+      tenantId,
       csvContent: "invalid csv",
       politicalOrganizationId: "org-123",
     };
@@ -274,6 +282,7 @@ describe("PreviewDonorCsvUsecase", () => {
     );
 
     const input: PreviewDonorCsvInput = {
+      tenantId,
       csvContent: "dummy csv content",
       politicalOrganizationId: "org-123",
     };
@@ -281,6 +290,6 @@ describe("PreviewDonorCsvUsecase", () => {
     const result = await usecase.execute(input);
 
     expect(result.rows[0].matchingDonor).toBeNull();
-    expect(mockDonorRepository.findByMatchCriteriaBatch).toHaveBeenCalledWith([]);
+    expect(mockDonorRepository.findByMatchCriteriaBatch).toHaveBeenCalledWith(tenantId, []);
   });
 });

--- a/admin/tests/server/contexts/shared/application/usecases/political-organization-usecases.test.ts
+++ b/admin/tests/server/contexts/shared/application/usecases/political-organization-usecases.test.ts
@@ -21,6 +21,8 @@ describe("Political Organization Usecases", () => {
     mockRepository = {
       findAll: jest.fn(),
       findById: jest.fn(),
+      findBySlug: jest.fn(),
+      findByTenantId: jest.fn(),
       create: jest.fn(),
       update: jest.fn(),
       delete: jest.fn(),


### PR DESCRIPTION
## Summary
- マルチテナント対応の準備として、Counterpart/Donor関連のRepository、UseCase、Server Action層に`tenantId`パラメータを追加
- 現時点では固定値（sample-party: ID=1）を使用し、将来のテナント切り替え機能実装を準備
- 関連するテストケースも更新済み

## 目的
開発者が将来のマルチテナント対応（URLベースのテナント切り替え）をスムーズに実装できるよう、バックエンド層の準備を完了させるため。

## 主な変更
- `CounterpartRepository` / `DonorRepository` に `tenantId` フィルタを追加
- 各UseCase（CRUD操作）で `tenantId` を受け取るように変更
- Server Actionsの引数に `tenantId`（string）を追加
- クライアントコンポーネントで固定 `tenantId` を渡すように変更（TODOコメント付き）

## Test plan
- [x] 型チェック通過
- [x] 単体テスト通過（786件）
- [x] E2Eテスト全件通過（38件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **新機能**
  * マルチテナント対応を追加しました。ドナーとカウンターパートの管理、CSV インポート、検索・提案機能がテナント単位でのスコープに対応するようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->