### PR TITLE
Reverse political organizations sort order to descending

### DIFF
--- a/webapp/src/server/contexts/public-finance/infrastructure/repositories/prisma-political-organization.repository.ts
+++ b/webapp/src/server/contexts/public-finance/infrastructure/repositories/prisma-political-organization.repository.ts
@@ -36,7 +36,7 @@ export class PrismaPoliticalOrganizationRepository implements IPoliticalOrganiza
 
   async findAll(): Promise<PoliticalOrganization[]> {
     const organizations = await this.prisma.politicalOrganization.findMany({
-      orderBy: { displayName: "asc" },
+      orderBy: { displayName: "desc" },
     });
 
     return organizations.map((org) => this.mapToPoliticalOrganization(org));


### PR DESCRIPTION
## Summary
Changed the sort order of political organizations from ascending to descending alphabetically by display name.

## Changes
- Modified `PrismaPoliticalOrganizationRepository.findAll()` to sort political organizations by `displayName` in descending order (`"desc"`) instead of ascending order (`"asc"`)

## Details
This change affects the `findAll()` method in the political organization repository, which retrieves all political organizations from the database. Organizations will now be returned in reverse alphabetical order by their display name, rather than alphabetical order.

https://claude.ai/code/session_01RPZibL75itZziC7gJZbuUV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 政治団体の一覧表示の並び順を変更しました。表示名による昇順から降順での表示となります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->