### PR TITLE
Update Slack invitation link to action board redirect

### DIFF
--- a/webapp/src/client/components/common/ExplanationSection.tsx
+++ b/webapp/src/client/components/common/ExplanationSection.tsx
@@ -22,14 +22,14 @@ export default function ExplanationSection() {
             </a>
             にて無償公開中であり、政党や所属を問わず利用可能な形で提供しております。開発コミュニティにご興味のある方は
             <a
-              href="https://join.slack.com/t/team-mirai-volunteer/shared_invite/zt-3n6h3a45j-yfNpEPXFcKTcmXZlmRGsyw"
+              href="https://action.team-mir.ai/missions/join-slack"
               target="_blank"
               rel="noopener noreferrer"
               className="font-bold text-[#238778] underline hover:no-underline"
             >
-              こちらのSlack
+              アクションボード
             </a>
-            をご覧ください。
+            からSlackにご参加ください。
           </p>
         </div>
 


### PR DESCRIPTION
## Summary
Updated the Slack community invitation link in the ExplanationSection component to use a redirect URL through the action board instead of a direct Slack invite link.

## Changes
- Changed Slack invite URL from direct invite link (`https://join.slack.com/t/team-mirai-volunteer/shared_invite/zt-3n6h3a45j-yfNpEPXFcKTcmXZlmRGsyw`) to action board redirect (`https://action.team-mir.ai/missions/join-slack`)
- Updated link text from "こちらのSlack" (This Slack) to "アクションボード" (Action Board)
- Updated accompanying text from "をご覧ください" (Please view) to "からSlackにご参加ください" (Please join Slack from here)

## Rationale
This change provides a more maintainable approach to managing the Slack invitation link by routing through the action board, which allows for easier updates to the invitation URL without requiring code changes in the future.

https://claude.ai/code/session_019perJaERQmxUUMaZUMQFdr