### PR TITLE
fix(webapp): OrganizationYearSheetのドロップダウン内ボタンにcursor-pointerを追加

### DIFF
--- a/webapp/src/client/components/layout/header/OrganizationYearSheet.tsx
+++ b/webapp/src/client/components/layout/header/OrganizationYearSheet.tsx
@@ -114,7 +114,7 @@ export default function OrganizationYearSheet({
                     key={org.slug}
                     type="button"
                     onClick={() => handleOrganizationSelect(org.slug)}
-                    className="flex items-center gap-2 h-9 pl-6 text-left"
+                    className="flex items-center gap-2 h-9 pl-6 text-left cursor-pointer"
                   >
                     <span className="w-3 flex items-center justify-center">
                       {currentSlug === org.slug && (
@@ -160,7 +160,7 @@ export default function OrganizationYearSheet({
                     key={year}
                     type="button"
                     onClick={() => handleYearSelect(year)}
-                    className={`px-3 py-1.5 rounded-full text-[11px] leading-none transition-colors ${
+                    className={`px-3 py-1.5 rounded-full text-[11px] leading-none transition-colors cursor-pointer ${
                       currentYear === year ? "font-bold text-[#238778]" : "bg-[#ececec] text-black"
                     }`}
                     style={
@@ -186,7 +186,7 @@ export default function OrganizationYearSheet({
               <button
                 type="button"
                 onClick={() => setIsOpen(false)}
-                className="text-xs font-bold text-[#238778]"
+                className="text-xs font-bold text-[#238778] cursor-pointer"
               >
                 閉じる
               </button>


### PR DESCRIPTION
## 目的

ユーザーがOrganizationYearSheetのドロップダウン内のクリック可能な要素（団体選択・年選択・閉じるボタン）にホバーした際にポインターカーソルが表示されず、クリックできることが分かりにくい状態を解消するため。

## 変更内容

- 団体選択ボタンに `cursor-pointer` を追加
- 年選択ボタンに `cursor-pointer` を追加
- 閉じるボタンに `cursor-pointer` を追加

## Test plan

- [ ] ドロップダウンを開き、団体名にホバーしてポインターカーソルになることを確認
- [ ] 年選択ボタンにホバーしてポインターカーソルになることを確認
- [ ] 閉じるボタンにホバーしてポインターカーソルになることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## スタイル
  * インタラクティブなボタン要素のカーソル表示を改善し、クリック可能な操作要素を視覚的にわかりやすくしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->