### PR TITLE
Improve hover interactions in OrganizationYearSheet

### DIFF
--- a/webapp/src/client/components/layout/header/OrganizationYearSheet.tsx
+++ b/webapp/src/client/components/layout/header/OrganizationYearSheet.tsx
@@ -114,7 +114,7 @@ export default function OrganizationYearSheet({
                     key={org.slug}
                     type="button"
                     onClick={() => handleOrganizationSelect(org.slug)}
-                    className="flex items-center gap-2 h-9 pl-6 text-left cursor-pointer"
+                    className="flex items-center gap-2 h-9 pl-6 text-left cursor-pointer rounded-md hover:bg-gray-100 transition-colors"
                   >
                     <span className="w-3 flex items-center justify-center">
                       {currentSlug === org.slug && (
@@ -160,7 +160,7 @@ export default function OrganizationYearSheet({
                     key={year}
                     type="button"
                     onClick={() => handleYearSelect(year)}
-                    className={`px-3 py-1.5 rounded-full text-[11px] leading-none transition-colors cursor-pointer ${
+                    className={`px-3 py-1.5 rounded-full text-[11px] leading-none transition-all cursor-pointer hover:opacity-70 ${
                       currentYear === year ? "font-bold text-[#238778]" : "bg-[#ececec] text-black"
                     }`}
                     style={


### PR DESCRIPTION
## Summary
Enhanced the user experience in the OrganizationYearSheet component by adding visual feedback for interactive elements through improved hover states and transitions.

## Key Changes
- **Organization selector buttons**: Added `rounded-md hover:bg-gray-100 transition-colors` to provide a subtle background color change on hover with smooth color transition
- **Year selector buttons**: Updated transition from `transition-colors` to `transition-all` and added `hover:opacity-70` to create a fade effect on hover, improving visual feedback for interactive elements

## Implementation Details
These changes maintain consistency with the existing design system while providing clearer affordances for interactive elements. The hover states use subtle visual cues (background color for organization buttons, opacity change for year buttons) that enhance usability without being intrusive.

https://claude.ai/code/session_01LZp2sxjK9CEna2LwcDFA8o

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * 組織選択ドロップダウンのUI操作性が向上しました。
  * 選択ボタンに丸みを帯びたコーナーとホバー時の視覚フィードバックが追加されました。
  * 年度選択ボタンのインタラクション効果が改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->