### PR TITLE
Update e2e tests for organization selector UI changes

### DIFF
--- a/webapp/e2e/tests/organization.spec.ts
+++ b/webapp/e2e/tests/organization.spec.ts
@@ -78,8 +78,8 @@ test.describe("政治団体ページ", () => {
 			const selectorButton = page.getByRole("button", { name: /サンプル党/ });
 			await selectorButton.click();
 
-			// シートが開いて選択肢が表示される
-			await expect(page.getByText("表示する政治団体と年度")).toBeVisible();
+			// ドロップダウンが開いて選択肢が表示される
+			await expect(page.getByText("表示する団体名")).toBeVisible();
 		});
 
 		test("別の政治団体を選択するとページが切り替わる", async ({ page }) => {
@@ -111,8 +111,8 @@ test.describe("政治団体ページ", () => {
 			const selectorButton = page.getByRole("button", { name: /サンプル党/ });
 			await selectorButton.click();
 
-			// 2025年度ボタンをクリック
-			await page.getByRole("button", { name: "2025年度" }).click();
+			// 2025年ボタンをクリック
+			await page.getByRole("button", { name: "2025年" }).click();
 
 			// URLが2025に変わることを確認
 			await expect(page).toHaveURL("/o/sample-party/2025");


### PR DESCRIPTION
## Summary
Updated end-to-end tests to reflect UI changes in the organization selector component, including updated text labels and button naming conventions.

## Key Changes
- Updated selector sheet label from "表示する政治団体と年度" to "表示する団体名" to match new UI text
- Changed comment from "シートが開いて選択肢が表示される" to "ドロップダウンが開いて選択肢が表示される" to reflect component type change
- Updated year selector button text from "2025年度" to "2025年" to match new naming convention
- Updated corresponding comment from "2025年度ボタンをクリック" to "2025年ボタンをクリック"

## Notes
These changes ensure the e2e tests accurately reflect the current UI implementation and maintain test reliability as the organization selector component evolves.

https://claude.ai/code/session_01VwxF7YBvgQKSDTRzLusPHS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 政治団体選択画面のラベル表示を更新しました。団体名と年度表示がより明確になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->