### PR TITLE
Include transaction metadata in preview transaction hash

### DIFF
--- a/admin/src/server/contexts/data-import/domain/models/preview-transaction.ts
+++ b/admin/src/server/contexts/data-import/domain/models/preview-transaction.ts
@@ -38,6 +38,7 @@ export const PreviewTransaction = {
     const hashData = {
       transaction_no: transaction.transaction_no,
       transaction_date: normalizeDate(transaction.transaction_date),
+      transaction_type: transaction.transaction_type || "",
       debit_account: transaction.debit_account,
       debit_sub_account: transaction.debit_sub_account || "",
       debit_amount: transaction.debit_amount,
@@ -45,6 +46,9 @@ export const PreviewTransaction = {
       credit_sub_account: transaction.credit_sub_account || "",
       credit_amount: transaction.credit_amount,
       description: transaction.description || "",
+      label: transaction.label || "",
+      friendly_category: transaction.friendly_category || "",
+      category_key: transaction.category_key || "",
     };
 
     const jsonString = JSON.stringify(hashData, Object.keys(hashData).sort());

--- a/admin/tests/server/contexts/data-import/domain/models/preview-transaction.test.ts
+++ b/admin/tests/server/contexts/data-import/domain/models/preview-transaction.test.ts
@@ -98,6 +98,26 @@ describe("PreviewTransaction.generateHash", () => {
       input1: { debit_account: "政治活動費" },
       input2: { debit_account: "組織活動費" },
     },
+    {
+      description: "different friendly_category",
+      input1: { friendly_category: "支出" },
+      input2: { friendly_category: "収入" },
+    },
+    {
+      description: "different label",
+      input1: { label: "ラベルA" },
+      input2: { label: "ラベルB" },
+    },
+    {
+      description: "different transaction_type",
+      input1: { transaction_type: "expense" },
+      input2: { transaction_type: "income" },
+    },
+    {
+      description: "different category_key",
+      input1: { category_key: "political-activity" },
+      input2: { category_key: "organization-activity" },
+    },
   ];
 
   it.each(differentDataCases)("should generate different hash for $description", ({ input1, input2 }) => {
@@ -114,8 +134,6 @@ describe("PreviewTransaction.generateHash", () => {
     const base = createMockPreviewTransaction();
     const withDifferentFields = createMockPreviewTransaction({
       political_organization_id: "different-org",
-      label: "different label",
-      friendly_category: "different category",
       status: "update",
       errors: ["some error"],
       hash: "different-hash",
@@ -132,11 +150,13 @@ describe("PreviewTransaction.generateHash", () => {
       debit_sub_account: undefined,
       credit_sub_account: undefined,
       description: undefined,
+      label: undefined,
     });
     const withEmptyString = createMockPreviewTransaction({
       debit_sub_account: "",
       credit_sub_account: "",
       description: "",
+      label: "",
     });
 
     const hash1 = PreviewTransaction.generateHash(withUndefined);

--- a/admin/tests/server/contexts/data-import/domain/models/preview-transaction.test.ts
+++ b/admin/tests/server/contexts/data-import/domain/models/preview-transaction.test.ts
@@ -100,8 +100,8 @@ describe("PreviewTransaction.generateHash", () => {
     },
     {
       description: "different friendly_category",
-      input1: { friendly_category: "支出" },
-      input2: { friendly_category: "収入" },
+      input1: { friendly_category: "ポスター印刷費" },
+      input2: { friendly_category: "ビラ印刷費" },
     },
     {
       description: "different label",


### PR DESCRIPTION
## Summary
Updated the `PreviewTransaction.generateHash()` method to include additional transaction fields in the hash calculation, ensuring that changes to transaction metadata are properly detected.

## Key Changes
- **Added fields to hash calculation**: `transaction_type`, `label`, `friendly_category`, and `category_key` are now included in the hash generation
- **Updated test cases**: Added test cases to verify that different values for the newly included fields produce different hashes
- **Removed redundant test assertions**: Removed `label` and `friendly_category` from the "should ignore non-hash fields" test since they are now part of the hash
- **Extended edge case coverage**: Added `label` to the undefined and empty string test cases to ensure consistent handling

## Implementation Details
- All new fields are normalized with empty string defaults (consistent with existing pattern for optional fields)
- The hash calculation maintains alphabetical ordering of fields via `Object.keys(hashData).sort()`
- This ensures that transactions differing only in these metadata fields will be properly identified as different during import preview

https://claude.ai/code/session_01CzmgPjVqs3HdFmqVh4WdDM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * トランザクション識別メカニズムを強化しました。カテゴリー、ラベル、トランザクションタイプなどのメタデータが識別プロセスに組み込まれ、より正確な重複検出とトランザクション管理が実現されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->