### PR TITLE
Add transaction deletion functionality with confirmation dialog

### DIFF
--- a/admin/src/client/components/transactions/DeleteTransactionButton.tsx
+++ b/admin/src/client/components/transactions/DeleteTransactionButton.tsx
@@ -1,0 +1,101 @@
+"use client";
+import "client-only";
+
+import { useState } from "react";
+import { Trash2 } from "lucide-react";
+import { toast } from "sonner";
+import { deleteTransactionAction } from "@/server/contexts/data-import/presentation/actions/delete-transaction";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+} from "@/client/components/ui";
+import type { TransactionWithOrganization } from "@/server/contexts/shared/domain/transaction";
+
+interface DeleteTransactionButtonProps {
+  transaction: TransactionWithOrganization;
+  onDeleted?: () => void;
+}
+
+function formatDate(date: Date | string) {
+  return new Date(date).toLocaleDateString("ja-JP");
+}
+
+function formatAmount(amount: number) {
+  return `¥${amount.toLocaleString()}`;
+}
+
+export function DeleteTransactionButton({ transaction, onDeleted }: DeleteTransactionButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  const handleDelete = async () => {
+    try {
+      setDeleting(true);
+      const result = await deleteTransactionAction(transaction.id);
+
+      if (result.success) {
+        toast.success("取引を削除しました");
+        setOpen(false);
+        onDeleted?.();
+      } else {
+        toast.error(`削除に失敗しました: ${result.error}`);
+      }
+    } catch (err) {
+      toast.error(`エラー: ${err instanceof Error ? err.message : "Unknown error"}`);
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8 text-muted-foreground hover:text-destructive"
+        onClick={() => setOpen(true)}
+      >
+        <Trash2 className="h-4 w-4" />
+      </Button>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>取引を削除しますか？</DialogTitle>
+          <DialogDescription>この操作は取り消せません。</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-2 text-sm">
+          <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1">
+            <span className="text-muted-foreground">取引日</span>
+            <span>{formatDate(transaction.transaction_date)}</span>
+            <span className="text-muted-foreground">借方</span>
+            <span>
+              {transaction.debit_account} {formatAmount(transaction.debit_amount)}
+            </span>
+            <span className="text-muted-foreground">貸方</span>
+            <span>
+              {transaction.credit_account} {formatAmount(transaction.credit_amount)}
+            </span>
+            {transaction.description && (
+              <>
+                <span className="text-muted-foreground">摘要</span>
+                <span>{transaction.description}</span>
+              </>
+            )}
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => setOpen(false)} disabled={deleting}>
+            キャンセル
+          </Button>
+          <Button variant="destructive" onClick={handleDelete} disabled={deleting}>
+            {deleting ? "削除中..." : "削除する"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/admin/src/client/components/transactions/TransactionRow.tsx
+++ b/admin/src/client/components/transactions/TransactionRow.tsx
@@ -4,9 +4,11 @@ import "client-only";
 import type { TransactionWithOrganization } from "@/server/contexts/shared/domain/transaction";
 import { PL_CATEGORIES } from "@/shared/accounting/account-category";
 import type { TransactionType } from "@/shared/models/transaction";
+import { DeleteTransactionButton } from "@/client/components/transactions/DeleteTransactionButton";
 
 interface TransactionRowProps {
   transaction: TransactionWithOrganization;
+  onDeleted?: () => void;
 }
 
 const DEFAULT_CATEGORY_COLOR = "#64748B"; // slate-500 as default fallback color
@@ -117,7 +119,7 @@ function getTypeBadgeClass(type: string): string {
   }
 }
 
-export function TransactionRow({ transaction }: TransactionRowProps) {
+export function TransactionRow({ transaction, onDeleted }: TransactionRowProps) {
   const formatDate = (date: Date | string) => {
     return new Date(date).toLocaleDateString("ja-JP");
   };
@@ -175,6 +177,9 @@ export function TransactionRow({ transaction }: TransactionRowProps) {
         {transaction.label && (
           <div className="text-blue-400 text-xs mt-1">ラベル: {transaction.label}</div>
         )}
+      </td>
+      <td className="px-2 py-3 text-sm text-center">
+        <DeleteTransactionButton transaction={transaction} onDeleted={onDeleted} />
       </td>
     </tr>
   );

--- a/admin/src/client/components/transactions/TransactionsClient.tsx
+++ b/admin/src/client/components/transactions/TransactionsClient.tsx
@@ -53,6 +53,14 @@ export function TransactionsClient({ organizations }: TransactionsClientProps) {
         }
 
         const result: GetTransactionsResult = await response.json();
+
+        // 最終ページの最後の1件を削除した場合、前のページに補正
+        if (result.transactions.length === 0 && result.total > 0 && currentPage > 1) {
+          const correctedPage = Math.min(currentPage, result.totalPages) || 1;
+          router.replace(`/transactions?page=${correctedPage}`);
+          return;
+        }
+
         setData(result);
         setError(null);
       } catch (err) {

--- a/admin/src/client/components/transactions/TransactionsClient.tsx
+++ b/admin/src/client/components/transactions/TransactionsClient.tsx
@@ -70,7 +70,7 @@ export function TransactionsClient({ organizations }: TransactionsClientProps) {
         setFetching(false);
       }
     },
-    [currentPage],
+    [currentPage, router],
   );
 
   useEffect(() => {

--- a/admin/src/client/components/transactions/TransactionsClient.tsx
+++ b/admin/src/client/components/transactions/TransactionsClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { TransactionRow } from "./TransactionRow";
 import { StaticPagination } from "@/client/components/ui/StaticPagination";
@@ -23,13 +23,12 @@ export function TransactionsClient({ organizations }: TransactionsClientProps) {
   const [error, setError] = useState<string | null>(null);
   const [selectedOrgId, setSelectedOrgId] = useState<string>(organizations[0]?.id ?? "");
   const isInitialLoad = useRef(true);
-  const [refreshKey, setRefreshKey] = useState(0);
 
   const currentPage = parseInt(searchParams.get("page") || "1", 10);
   const perPage = 50;
 
-  useEffect(() => {
-    const fetchTransactions = async (orgId: string) => {
+  const fetchTransactions = useCallback(
+    async (orgId: string) => {
       try {
         // 初回ロードはloading、以降はfetching
         if (isInitialLoad.current) {
@@ -62,10 +61,13 @@ export function TransactionsClient({ organizations }: TransactionsClientProps) {
         setLoading(false);
         setFetching(false);
       }
-    };
+    },
+    [currentPage],
+  );
 
+  useEffect(() => {
     fetchTransactions(selectedOrgId);
-  }, [currentPage, selectedOrgId, refreshKey]);
+  }, [fetchTransactions, selectedOrgId]);
 
   const handleOrgFilterChange = (orgId: string) => {
     setSelectedOrgId(orgId);
@@ -170,7 +172,7 @@ export function TransactionsClient({ organizations }: TransactionsClientProps) {
                   <TransactionRow
                     key={transaction.id}
                     transaction={transaction}
-                    onDeleted={() => setRefreshKey((k) => k + 1)}
+                    onDeleted={() => fetchTransactions(selectedOrgId)}
                   />
                 ))}
               </tbody>

--- a/admin/src/client/components/transactions/TransactionsClient.tsx
+++ b/admin/src/client/components/transactions/TransactionsClient.tsx
@@ -23,6 +23,7 @@ export function TransactionsClient({ organizations }: TransactionsClientProps) {
   const [error, setError] = useState<string | null>(null);
   const [selectedOrgId, setSelectedOrgId] = useState<string>(organizations[0]?.id ?? "");
   const isInitialLoad = useRef(true);
+  const [refreshKey, setRefreshKey] = useState(0);
 
   const currentPage = parseInt(searchParams.get("page") || "1", 10);
   const perPage = 50;
@@ -64,7 +65,7 @@ export function TransactionsClient({ organizations }: TransactionsClientProps) {
     };
 
     fetchTransactions(selectedOrgId);
-  }, [currentPage, selectedOrgId]);
+  }, [currentPage, selectedOrgId, refreshKey]);
 
   const handleOrgFilterChange = (orgId: string) => {
     setSelectedOrgId(orgId);
@@ -159,11 +160,18 @@ export function TransactionsClient({ organizations }: TransactionsClientProps) {
                   <th className="px-2 py-3 text-left text-sm font-semibold text-white">
                     摘要 <span className="text-xs font-normal">※サービスには表示されません</span>
                   </th>
+                  <th className="px-2 py-3 text-center text-sm font-semibold text-white w-16">
+                    操作
+                  </th>
                 </tr>
               </thead>
               <tbody>
                 {data.transactions.map((transaction) => (
-                  <TransactionRow key={transaction.id} transaction={transaction} />
+                  <TransactionRow
+                    key={transaction.id}
+                    transaction={transaction}
+                    onDeleted={() => setRefreshKey((k) => k + 1)}
+                  />
                 ))}
               </tbody>
             </table>

--- a/admin/src/client/components/ui/dialog.tsx
+++ b/admin/src/client/components/ui/dialog.tsx
@@ -115,4 +115,4 @@ function DialogDescription({
   );
 }
 
-export { Dialog, DialogContent, DialogHeader, DialogTitle };
+export { Dialog, DialogContent, DialogHeader, DialogFooter, DialogTitle, DialogDescription };

--- a/admin/src/client/components/ui/index.ts
+++ b/admin/src/client/components/ui/index.ts
@@ -20,7 +20,9 @@ export {
   Dialog,
   DialogContent,
   DialogHeader,
+  DialogFooter,
   DialogTitle,
+  DialogDescription,
 } from "@/client/components/ui/dialog";
 export {
   Table,

--- a/admin/src/server/contexts/data-import/presentation/actions/delete-transaction.ts
+++ b/admin/src/server/contexts/data-import/presentation/actions/delete-transaction.ts
@@ -1,0 +1,24 @@
+"use server";
+
+import { updateTag } from "next/cache";
+import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
+import { PrismaTransactionRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-transaction.repository";
+
+export async function deleteTransactionAction(id: string): Promise<{
+  success: boolean;
+  error?: string;
+}> {
+  try {
+    const repository = new PrismaTransactionRepository(prisma);
+    await repository.delete(id);
+
+    updateTag("transactions-data");
+
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+}

--- a/admin/src/server/contexts/shared/domain/repositories/transaction-repository.interface.ts
+++ b/admin/src/server/contexts/shared/domain/repositories/transaction-repository.interface.ts
@@ -30,6 +30,7 @@ export interface ITransactionRepository {
       update: UpdateTransactionInput;
     }>,
   ): Promise<Transaction[]>;
+  delete(id: string): Promise<void>;
   deleteAll(filters?: TransactionFilters): Promise<number>;
   createMany(inputs: CreateTransactionInput[]): Promise<Transaction[]>;
   findByTransactionNos(

--- a/admin/src/server/contexts/shared/infrastructure/repositories/prisma-transaction.repository.ts
+++ b/admin/src/server/contexts/shared/infrastructure/repositories/prisma-transaction.repository.ts
@@ -158,6 +158,12 @@ export class PrismaTransactionRepository implements ITransactionRepository {
     return Promise.all(updatePromises);
   }
 
+  async delete(id: string): Promise<void> {
+    await this.prisma.transaction.delete({
+      where: { id: BigInt(id) },
+    });
+  }
+
   async deleteAll(filters?: TransactionFilters): Promise<number> {
     const where = this.buildWhereClause(filters);
 

--- a/admin/tests/server/contexts/data-import/application/usecases/delete-all-transactions-usecase.test.ts
+++ b/admin/tests/server/contexts/data-import/application/usecases/delete-all-transactions-usecase.test.ts
@@ -9,6 +9,7 @@ describe("DeleteAllTransactionsUsecase", () => {
     mockRepository = {
       findWithPagination: jest.fn(),
       updateMany: jest.fn(),
+      delete: jest.fn(),
       deleteAll: jest.fn(),
       createMany: jest.fn(),
       findByTransactionNos: jest.fn(),

--- a/admin/tests/server/contexts/data-import/application/usecases/get-transactions-usecase.test.ts
+++ b/admin/tests/server/contexts/data-import/application/usecases/get-transactions-usecase.test.ts
@@ -52,6 +52,7 @@ describe("GetTransactionsUsecase", () => {
     mockRepository = {
       findWithPagination: jest.fn(),
       updateMany: jest.fn(),
+      delete: jest.fn(),
       deleteAll: jest.fn(),
       createMany: jest.fn(),
       findByTransactionNos: jest.fn(),

--- a/admin/tests/server/contexts/data-import/application/usecases/preview-mf-csv-usecase.test.ts
+++ b/admin/tests/server/contexts/data-import/application/usecases/preview-mf-csv-usecase.test.ts
@@ -11,6 +11,7 @@ describe("PreviewMfCsvUsecase", () => {
   const mockTransactionRepository: jest.Mocked<ITransactionRepository> = {
     findWithPagination: jest.fn(),
     updateMany: jest.fn(),
+    delete: jest.fn(),
     deleteAll: jest.fn(),
     createMany: jest.fn(),
     findByTransactionNos: jest.fn(),


### PR DESCRIPTION
## Summary
This PR adds the ability to delete individual transactions from the admin interface with a confirmation dialog that displays transaction details before deletion.

## Key Changes
- **New DeleteTransactionButton component**: A client-side component that renders a trash icon button and manages a confirmation dialog. The dialog displays transaction details (date, debit/credit accounts with amounts, and description) before allowing deletion.
- **New deleteTransactionAction server action**: Handles the actual deletion of transactions via the repository layer and invalidates the transactions cache tag.
- **Repository method**: Added `delete(id: string)` method to `PrismaTransactionRepository` to support single transaction deletion.
- **TransactionRow integration**: Updated to include the delete button in a new "操作" (Operations) column and accept an `onDeleted` callback.
- **TransactionsClient refresh mechanism**: Added `refreshKey` state that increments when a transaction is deleted, triggering a refetch of the transaction list.
- **UI exports**: Exported `DialogFooter` and `DialogDescription` components from the dialog UI module to support the new confirmation dialog.

## Implementation Details
- The delete button uses a destructive variant and is disabled during the deletion process
- Toast notifications provide user feedback for success and error states
- The confirmation dialog prevents accidental deletions by requiring explicit confirmation
- Cache invalidation via `updateTag("transactions-data")` ensures the UI reflects the deletion
- Japanese localization is used throughout for UI text and date/amount formatting

https://claude.ai/code/session_01NJx9LCnNygrhnHbpvpxTw1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 行ごとの取引削除ボタンと確認ダイアログを追加。削除実行後に一覧を自動更新し、成功／失敗のトースト通知を表示。

* **UI**
  * 取引一覧に「操作」列を追加。ダイアログのフッター／説明コンポーネントを公開して再利用可能に。

* **サーバー**
  * サーバー側に単一取引削除の処理を追加し、削除後に一覧キャッシュを更新。

* **テスト**
  * 既存テストのリポジトリモックに削除メソッドを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->