### PR TITLE
Add bulk delete transactions feature

### DIFF
--- a/admin/src/app/(auth)/bulk-delete-transactions/page.tsx
+++ b/admin/src/app/(auth)/bulk-delete-transactions/page.tsx
@@ -1,0 +1,8 @@
+import { BulkDeleteTransactionsClient } from "@/client/components/transactions/BulkDeleteTransactionsClient";
+import { loadPoliticalOrganizationsData } from "@/server/contexts/shared/presentation/loaders/load-political-organizations-data";
+
+export default async function BulkDeleteTransactionsPage() {
+  const organizations = await loadPoliticalOrganizationsData();
+
+  return <BulkDeleteTransactionsClient organizations={organizations} />;
+}

--- a/admin/src/app/api/transactions/search-by-nos/route.ts
+++ b/admin/src/app/api/transactions/search-by-nos/route.ts
@@ -1,0 +1,31 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { loadTransactionsByNos } from "@/server/contexts/data-import/presentation/loaders/load-transactions-by-nos";
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const orgId = searchParams.get("orgId");
+  const nos = searchParams.get("nos");
+
+  if (!orgId || !nos) {
+    return NextResponse.json(
+      { success: false, error: "orgId and nos are required" },
+      { status: 400 },
+    );
+  }
+
+  const transactionNos = nos
+    .split(",")
+    .map((n) => n.trim())
+    .filter((n) => n.length > 0);
+
+  if (transactionNos.length === 0) {
+    return NextResponse.json(
+      { success: false, error: "At least one transaction number is required" },
+      { status: 400 },
+    );
+  }
+
+  const result = await loadTransactionsByNos(orgId, transactionNos);
+  return NextResponse.json(result);
+}

--- a/admin/src/client/components/counterparts/useAddressSearch.ts
+++ b/admin/src/client/components/counterparts/useAddressSearch.ts
@@ -8,7 +8,7 @@ import type {
   AddressSearchResult,
 } from "@/server/contexts/report/presentation/types/address-search";
 
-export type AddressInputPhase =
+type AddressInputPhase =
   | "initial" // 初期状態（ボタンのみ）
   | "searching" // 検索中
   | "results" // 検索結果表示

--- a/admin/src/client/components/layout/Sidebar.tsx
+++ b/admin/src/client/components/layout/Sidebar.tsx
@@ -46,6 +46,7 @@ export default function Sidebar({
       title: "データ取り込み",
       items: [
         { href: "/transactions", label: "取引一覧" },
+        { href: "/bulk-delete-transactions", label: "取引一括削除" },
         { href: "/upload-csv", label: "CSVアップロード" },
         { href: "/balance-snapshots", label: "残高登録" },
       ],

--- a/admin/src/client/components/transactions/BulkDeleteTransactionsClient.tsx
+++ b/admin/src/client/components/transactions/BulkDeleteTransactionsClient.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useState } from "react";
+import type { PoliticalOrganization } from "@/shared/models/political-organization";
+import { PoliticalOrganizationSelect } from "@/client/components/political-organizations/PoliticalOrganizationSelect";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Input,
+  Label,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/client/components/ui";
+import {
+  searchTransactionsForBulkDeleteAction,
+  bulkDeleteTransactionsAction,
+} from "@/server/contexts/data-import/presentation/actions/bulk-delete-transactions";
+import type { BulkDeleteSearchResult } from "@/server/contexts/data-import/presentation/actions/bulk-delete-transactions";
+
+export function BulkDeleteTransactionsClient({
+  organizations,
+}: {
+  organizations: PoliticalOrganization[];
+}) {
+  const [selectedOrgId, setSelectedOrgId] = useState("");
+  const [transactionNosInput, setTransactionNosInput] = useState("");
+  const [searchResult, setSearchResult] = useState<BulkDeleteSearchResult | null>(null);
+  const [isSearching, setIsSearching] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [showConfirmDialog, setShowConfirmDialog] = useState(false);
+  const [deleteResult, setDeleteResult] = useState<{
+    success: boolean;
+    deletedCount?: number;
+    error?: string;
+  } | null>(null);
+
+  const handleSearch = async () => {
+    if (!selectedOrgId || !transactionNosInput.trim()) return;
+
+    const nos = transactionNosInput
+      .split(",")
+      .map((n) => n.trim())
+      .filter((n) => n.length > 0);
+
+    if (nos.length === 0) return;
+
+    setIsSearching(true);
+    setSearchResult(null);
+    setDeleteResult(null);
+
+    const result = await searchTransactionsForBulkDeleteAction(selectedOrgId, nos);
+    setSearchResult(result);
+    setIsSearching(false);
+  };
+
+  const handleDelete = async () => {
+    if (!searchResult?.foundTransactions?.length) return;
+
+    setIsDeleting(true);
+    const ids = searchResult.foundTransactions.map((t) => t.id);
+    const result = await bulkDeleteTransactionsAction(ids);
+    setDeleteResult(result);
+    setShowConfirmDialog(false);
+    setIsDeleting(false);
+
+    if (result.success) {
+      setSearchResult(null);
+      setTransactionNosInput("");
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">取引一括削除</h1>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>検索条件</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <PoliticalOrganizationSelect
+            organizations={organizations}
+            value={selectedOrgId}
+            onValueChange={(value) => {
+              setSelectedOrgId(value);
+              setSearchResult(null);
+              setDeleteResult(null);
+            }}
+            required
+          />
+
+          <div className="space-y-2">
+            <Label>取引番号（カンマ区切り）</Label>
+            <Input
+              placeholder="例: 1,5,8,20"
+              value={transactionNosInput}
+              onChange={(e) => setTransactionNosInput(e.target.value)}
+            />
+          </div>
+
+          <Button
+            onClick={handleSearch}
+            disabled={!selectedOrgId || !transactionNosInput.trim() || isSearching}
+          >
+            {isSearching ? "検索中..." : "検索"}
+          </Button>
+        </CardContent>
+      </Card>
+
+      {deleteResult && (
+        <Card>
+          <CardContent className="pt-6">
+            {deleteResult.success ? (
+              <p className="text-green-600 font-medium">
+                {deleteResult.deletedCount}件の取引を削除しました。
+              </p>
+            ) : (
+              <p className="text-red-600 font-medium">エラー: {deleteResult.error}</p>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      {searchResult && !searchResult.success && (
+        <Card>
+          <CardContent className="pt-6">
+            <p className="text-red-600 font-medium">エラー: {searchResult.error}</p>
+          </CardContent>
+        </Card>
+      )}
+
+      {searchResult?.success && (
+        <>
+          {searchResult.notFoundNos && searchResult.notFoundNos.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-amber-600">
+                  該当なし ({searchResult.notFoundNos.length}件)
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-muted-foreground">
+                  以下の取引番号は見つかりませんでした:{" "}
+                  <span className="font-mono">{searchResult.notFoundNos.join(", ")}</span>
+                </p>
+              </CardContent>
+            </Card>
+          )}
+
+          {searchResult.foundTransactions && searchResult.foundTransactions.length > 0 && (
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between">
+                <CardTitle>
+                  削除対象 ({searchResult.foundTransactions.length}件)
+                </CardTitle>
+                <Button
+                  variant="destructive"
+                  onClick={() => setShowConfirmDialog(true)}
+                >
+                  削除
+                </Button>
+              </CardHeader>
+              <CardContent>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>取引番号</TableHead>
+                      <TableHead>取引日</TableHead>
+                      <TableHead>摘要</TableHead>
+                      <TableHead className="text-right">借方金額</TableHead>
+                      <TableHead className="text-right">貸方金額</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {searchResult.foundTransactions.map((t) => (
+                      <TableRow key={t.id}>
+                        <TableCell className="font-mono">{t.transactionNo}</TableCell>
+                        <TableCell>{t.transactionDate}</TableCell>
+                        <TableCell>{t.description}</TableCell>
+                        <TableCell className="text-right">
+                          {t.debitAmount.toLocaleString()}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          {t.creditAmount.toLocaleString()}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </CardContent>
+            </Card>
+          )}
+
+          {searchResult.foundTransactions?.length === 0 &&
+            searchResult.notFoundNos?.length === 0 && (
+              <Card>
+                <CardContent className="pt-6">
+                  <p className="text-muted-foreground">該当する取引はありません。</p>
+                </CardContent>
+              </Card>
+            )}
+        </>
+      )}
+
+      <Dialog open={showConfirmDialog} onOpenChange={setShowConfirmDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>取引の一括削除</DialogTitle>
+            <DialogDescription>
+              {searchResult?.foundTransactions?.length}件の取引を削除します。この操作は取り消せません。
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowConfirmDialog(false)}>
+              キャンセル
+            </Button>
+            <Button variant="destructive" onClick={handleDelete} disabled={isDeleting}>
+              {isDeleting ? "削除中..." : "削除する"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/admin/src/client/components/transactions/BulkDeleteTransactionsClient.tsx
+++ b/admin/src/client/components/transactions/BulkDeleteTransactionsClient.tsx
@@ -24,11 +24,8 @@ import {
   DialogDescription,
   DialogFooter,
 } from "@/client/components/ui";
-import {
-  searchTransactionsForBulkDeleteAction,
-  bulkDeleteTransactionsAction,
-} from "@/server/contexts/data-import/presentation/actions/bulk-delete-transactions";
-import type { BulkDeleteSearchResult } from "@/server/contexts/data-import/presentation/actions/bulk-delete-transactions";
+import { bulkDeleteTransactionsAction } from "@/server/contexts/data-import/presentation/actions/bulk-delete-transactions";
+import type { BulkDeleteSearchResult } from "@/server/contexts/data-import/presentation/types";
 
 export function BulkDeleteTransactionsClient({
   organizations,
@@ -61,7 +58,12 @@ export function BulkDeleteTransactionsClient({
     setSearchResult(null);
     setDeleteResult(null);
 
-    const result = await searchTransactionsForBulkDeleteAction(selectedOrgId, nos);
+    const params = new URLSearchParams({
+      orgId: selectedOrgId,
+      nos: nos.join(","),
+    });
+    const response = await fetch(`/api/transactions/search-by-nos?${params}`);
+    const result: BulkDeleteSearchResult = await response.json();
     setSearchResult(result);
     setIsSearching(false);
   };

--- a/admin/src/client/components/transactions/BulkDeleteTransactionsClient.tsx
+++ b/admin/src/client/components/transactions/BulkDeleteTransactionsClient.tsx
@@ -163,13 +163,8 @@ export function BulkDeleteTransactionsClient({
           {searchResult.foundTransactions && searchResult.foundTransactions.length > 0 && (
             <Card>
               <CardHeader className="flex flex-row items-center justify-between">
-                <CardTitle>
-                  削除対象 ({searchResult.foundTransactions.length}件)
-                </CardTitle>
-                <Button
-                  variant="destructive"
-                  onClick={() => setShowConfirmDialog(true)}
-                >
+                <CardTitle>削除対象 ({searchResult.foundTransactions.length}件)</CardTitle>
+                <Button variant="destructive" onClick={() => setShowConfirmDialog(true)}>
                   削除
                 </Button>
               </CardHeader>
@@ -220,7 +215,8 @@ export function BulkDeleteTransactionsClient({
           <DialogHeader>
             <DialogTitle>取引の一括削除</DialogTitle>
             <DialogDescription>
-              {searchResult?.foundTransactions?.length}件の取引を削除します。この操作は取り消せません。
+              {searchResult?.foundTransactions?.length}
+              件の取引を削除します。この操作は取り消せません。
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/admin/src/client/components/transactions/BulkDeleteTransactionsClient.tsx
+++ b/admin/src/client/components/transactions/BulkDeleteTransactionsClient.tsx
@@ -96,7 +96,6 @@ export function BulkDeleteTransactionsClient({
             onValueChange={(value) => {
               setSelectedOrgId(value);
               setSearchResult(null);
-              setDeleteResult(null);
             }}
             required
           />

--- a/admin/src/client/components/transactions/BulkDeleteTransactionsClient.tsx
+++ b/admin/src/client/components/transactions/BulkDeleteTransactionsClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { toast } from "sonner";
 import type { PoliticalOrganization } from "@/shared/models/political-organization";
 import { PoliticalOrganizationSelect } from "@/client/components/political-organizations/PoliticalOrganizationSelect";
 import {
@@ -38,11 +39,6 @@ export function BulkDeleteTransactionsClient({
   const [isSearching, setIsSearching] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
-  const [deleteResult, setDeleteResult] = useState<{
-    success: boolean;
-    deletedCount?: number;
-    error?: string;
-  } | null>(null);
 
   const handleSearch = async () => {
     if (!selectedOrgId || !transactionNosInput.trim()) return;
@@ -56,7 +52,6 @@ export function BulkDeleteTransactionsClient({
 
     setIsSearching(true);
     setSearchResult(null);
-    setDeleteResult(null);
 
     const params = new URLSearchParams({
       orgId: selectedOrgId,
@@ -74,13 +69,15 @@ export function BulkDeleteTransactionsClient({
     setIsDeleting(true);
     const ids = searchResult.foundTransactions.map((t) => t.id);
     const result = await bulkDeleteTransactionsAction(ids);
-    setDeleteResult(result);
     setShowConfirmDialog(false);
     setIsDeleting(false);
 
     if (result.success) {
+      toast.success(`${result.deletedCount}件の取引を削除しました。`);
       setSearchResult(null);
       setTransactionNosInput("");
+    } else {
+      toast.error(`削除に失敗しました: ${result.error}`);
     }
   };
 
@@ -121,20 +118,6 @@ export function BulkDeleteTransactionsClient({
           </Button>
         </CardContent>
       </Card>
-
-      {deleteResult && (
-        <Card>
-          <CardContent className="pt-6">
-            {deleteResult.success ? (
-              <p className="text-green-600 font-medium">
-                {deleteResult.deletedCount}件の取引を削除しました。
-              </p>
-            ) : (
-              <p className="text-red-600 font-medium">エラー: {deleteResult.error}</p>
-            )}
-          </CardContent>
-        </Card>
-      )}
 
       {searchResult && !searchResult.success && (
         <Card>

--- a/admin/src/client/components/transactions/TransactionRow.tsx
+++ b/admin/src/client/components/transactions/TransactionRow.tsx
@@ -126,6 +126,7 @@ export function TransactionRow({ transaction, onDeleted }: TransactionRowProps) 
 
   return (
     <tr className="border-b border-border">
+      <td className="px-2 py-3 text-sm text-white font-mono">{transaction.transaction_no}</td>
       <td className="px-2 py-3 text-sm text-white">{formatDate(transaction.transaction_date)}</td>
       <td className="px-2 py-3 text-sm text-white">
         {transaction.political_organization_name || "-"}

--- a/admin/src/client/components/transactions/TransactionsClient.tsx
+++ b/admin/src/client/components/transactions/TransactionsClient.tsx
@@ -151,6 +151,7 @@ export function TransactionsClient({ organizations }: TransactionsClientProps) {
             <table className="w-full border-collapse">
               <thead>
                 <tr className="border-b border-border">
+                  <th className="px-2 py-3 text-left text-sm font-semibold text-white">取引No</th>
                   <th className="px-2 py-3 text-left text-sm font-semibold text-white">取引日</th>
                   <th className="px-2 py-3 text-left text-sm font-semibold text-white">政治団体</th>
                   <th className="px-2 py-3 text-left text-sm font-semibold text-white">

--- a/admin/src/server/contexts/auth/application/usecases/exchange-code-for-session-usecase.ts
+++ b/admin/src/server/contexts/auth/application/usecases/exchange-code-for-session-usecase.ts
@@ -7,7 +7,7 @@ import type {
 } from "@/server/contexts/shared/domain/repositories/user-repository.interface";
 import { AuthError } from "@/server/contexts/auth/domain/errors/auth-error";
 
-export interface ExchangeCodeResult {
+interface ExchangeCodeResult {
   user: User;
   isNewUser: boolean;
 }

--- a/admin/src/server/contexts/data-import/application/usecases/delete-all-transactions-usecase.ts
+++ b/admin/src/server/contexts/data-import/application/usecases/delete-all-transactions-usecase.ts
@@ -1,7 +1,7 @@
 import type { ITransactionRepository } from "@/server/contexts/shared/domain/repositories/transaction-repository.interface";
 import type { TransactionFilters } from "@/server/contexts/shared/domain/transaction";
 
-export interface DeleteAllTransactionsResult {
+interface DeleteAllTransactionsResult {
   deletedCount: number;
 }
 

--- a/admin/src/server/contexts/data-import/application/usecases/get-transactions-usecase.ts
+++ b/admin/src/server/contexts/data-import/application/usecases/get-transactions-usecase.ts
@@ -7,7 +7,7 @@ import type {
   PaginationOptions,
 } from "@/server/contexts/shared/domain/repositories/transaction-repository.interface";
 
-export interface GetTransactionsParams {
+interface GetTransactionsParams {
   page?: number;
   perPage?: number;
   politicalOrganizationIds?: string[];

--- a/admin/src/server/contexts/data-import/application/usecases/save-preview-transactions-usecase.ts
+++ b/admin/src/server/contexts/data-import/application/usecases/save-preview-transactions-usecase.ts
@@ -9,7 +9,7 @@ export interface SavePreviewTransactionsInput {
   politicalOrganizationId: string;
 }
 
-export interface SavePreviewTransactionsResult {
+interface SavePreviewTransactionsResult {
   processedCount: number;
   savedCount: number;
   skippedCount: number;

--- a/admin/src/server/contexts/data-import/presentation/actions/bulk-delete-transactions.ts
+++ b/admin/src/server/contexts/data-import/presentation/actions/bulk-delete-transactions.ts
@@ -1,0 +1,81 @@
+"use server";
+
+import "server-only";
+import { updateTag } from "next/cache";
+import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
+import { PrismaTransactionRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-transaction.repository";
+
+export type BulkDeleteSearchResult = {
+  success: boolean;
+  foundTransactions?: Array<{
+    id: string;
+    transactionNo: string;
+    description: string;
+    debitAmount: number;
+    creditAmount: number;
+    transactionDate: string;
+  }>;
+  notFoundNos?: string[];
+  error?: string;
+};
+
+export async function searchTransactionsForBulkDeleteAction(
+  organizationId: string,
+  transactionNos: string[],
+): Promise<BulkDeleteSearchResult> {
+  try {
+    const repository = new PrismaTransactionRepository(prisma);
+    const found = await repository.findByTransactionNos(transactionNos, [organizationId]);
+
+    const foundNos = new Set(found.map((t) => t.transaction_no));
+    const notFoundNos = transactionNos.filter((no) => !foundNos.has(no));
+
+    return {
+      success: true,
+      foundTransactions: found.map((t) => ({
+        id: t.id,
+        transactionNo: t.transaction_no,
+        description: t.description || "",
+        debitAmount: t.debit_amount,
+        creditAmount: t.credit_amount,
+        transactionDate: new Date(t.transaction_date).toLocaleDateString("ja-JP"),
+      })),
+      notFoundNos,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "検索中にエラーが発生しました",
+    };
+  }
+}
+
+export async function bulkDeleteTransactionsAction(
+  ids: string[],
+): Promise<{
+  success: boolean;
+  deletedCount?: number;
+  error?: string;
+}> {
+  try {
+    const deletedCount = await prisma.transaction.deleteMany({
+      where: {
+        id: {
+          in: ids.map((id) => BigInt(id)),
+        },
+      },
+    });
+
+    updateTag("transactions-data");
+
+    return {
+      success: true,
+      deletedCount: deletedCount.count,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "削除中にエラーが発生しました",
+    };
+  }
+}

--- a/admin/src/server/contexts/data-import/presentation/actions/bulk-delete-transactions.ts
+++ b/admin/src/server/contexts/data-import/presentation/actions/bulk-delete-transactions.ts
@@ -3,52 +3,6 @@
 import "server-only";
 import { updateTag } from "next/cache";
 import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
-import { PrismaTransactionRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-transaction.repository";
-
-export type BulkDeleteSearchResult = {
-  success: boolean;
-  foundTransactions?: Array<{
-    id: string;
-    transactionNo: string;
-    description: string;
-    debitAmount: number;
-    creditAmount: number;
-    transactionDate: string;
-  }>;
-  notFoundNos?: string[];
-  error?: string;
-};
-
-export async function searchTransactionsForBulkDeleteAction(
-  organizationId: string,
-  transactionNos: string[],
-): Promise<BulkDeleteSearchResult> {
-  try {
-    const repository = new PrismaTransactionRepository(prisma);
-    const found = await repository.findByTransactionNos(transactionNos, [organizationId]);
-
-    const foundNos = new Set(found.map((t) => t.transaction_no));
-    const notFoundNos = transactionNos.filter((no) => !foundNos.has(no));
-
-    return {
-      success: true,
-      foundTransactions: found.map((t) => ({
-        id: t.id,
-        transactionNo: t.transaction_no,
-        description: t.description || "",
-        debitAmount: t.debit_amount,
-        creditAmount: t.credit_amount,
-        transactionDate: new Date(t.transaction_date).toLocaleDateString("ja-JP"),
-      })),
-      notFoundNos,
-    };
-  } catch (error) {
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : "検索中にエラーが発生しました",
-    };
-  }
-}
 
 export async function bulkDeleteTransactionsAction(ids: string[]): Promise<{
   success: boolean;

--- a/admin/src/server/contexts/data-import/presentation/actions/bulk-delete-transactions.ts
+++ b/admin/src/server/contexts/data-import/presentation/actions/bulk-delete-transactions.ts
@@ -50,9 +50,7 @@ export async function searchTransactionsForBulkDeleteAction(
   }
 }
 
-export async function bulkDeleteTransactionsAction(
-  ids: string[],
-): Promise<{
+export async function bulkDeleteTransactionsAction(ids: string[]): Promise<{
   success: boolean;
   deletedCount?: number;
   error?: string;

--- a/admin/src/server/contexts/data-import/presentation/loaders/load-transactions-by-nos.ts
+++ b/admin/src/server/contexts/data-import/presentation/loaders/load-transactions-by-nos.ts
@@ -1,0 +1,49 @@
+import "server-only";
+
+import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
+import { PrismaTransactionRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-transaction.repository";
+
+export type BulkDeleteSearchResult = {
+  success: boolean;
+  foundTransactions?: Array<{
+    id: string;
+    transactionNo: string;
+    description: string;
+    debitAmount: number;
+    creditAmount: number;
+    transactionDate: string;
+  }>;
+  notFoundNos?: string[];
+  error?: string;
+};
+
+export async function loadTransactionsByNos(
+  organizationId: string,
+  transactionNos: string[],
+): Promise<BulkDeleteSearchResult> {
+  try {
+    const repository = new PrismaTransactionRepository(prisma);
+    const found = await repository.findByTransactionNos(transactionNos, [organizationId]);
+
+    const foundNos = new Set(found.map((t) => t.transaction_no));
+    const notFoundNos = transactionNos.filter((no) => !foundNos.has(no));
+
+    return {
+      success: true,
+      foundTransactions: found.map((t) => ({
+        id: t.id,
+        transactionNo: t.transaction_no,
+        description: t.description || "",
+        debitAmount: t.debit_amount,
+        creditAmount: t.credit_amount,
+        transactionDate: new Date(t.transaction_date).toLocaleDateString("ja-JP"),
+      })),
+      notFoundNos,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "検索中にエラーが発生しました",
+    };
+  }
+}

--- a/admin/src/server/contexts/data-import/presentation/types/index.ts
+++ b/admin/src/server/contexts/data-import/presentation/types/index.ts
@@ -9,3 +9,6 @@ export type { PreviewMfCsvResult } from "@/server/contexts/data-import/applicati
 
 // トランザクション取得関連
 export type { GetTransactionsResult } from "@/server/contexts/data-import/application/usecases/get-transactions-usecase";
+
+// 取引番号検索関連
+export type { BulkDeleteSearchResult } from "@/server/contexts/data-import/presentation/loaders/load-transactions-by-nos";

--- a/admin/src/server/contexts/report/application/services/counterpart-suggester.ts
+++ b/admin/src/server/contexts/report/application/services/counterpart-suggester.ts
@@ -15,7 +15,7 @@ export interface SuggestionContext {
   repository: ICounterpartRepository;
 }
 
-export interface SuggestionStrategy {
+interface SuggestionStrategy {
   suggest(
     transaction: TransactionWithCounterpart,
     context: SuggestionContext,

--- a/admin/src/server/contexts/report/application/services/donation-assembler.ts
+++ b/admin/src/server/contexts/report/application/services/donation-assembler.ts
@@ -21,7 +21,7 @@ export interface DonationAssemblerInput {
   financialYear: number;
 }
 
-export interface DonationData {
+interface DonationData {
   personalDonations: PersonalDonationSectionInterface;
 }
 

--- a/admin/src/server/contexts/report/application/usecases/assign-donor-usecase.ts
+++ b/admin/src/server/contexts/report/application/usecases/assign-donor-usecase.ts
@@ -5,12 +5,12 @@ import type { ITransactionDonorRepository } from "@/server/contexts/report/domai
 import type { ITransactionWithDonorRepository } from "@/server/contexts/report/domain/repositories/transaction-with-donor-repository.interface";
 import { isDonorTypeAllowedForCategory } from "@/server/contexts/report/domain/models/donor-assignment-rules";
 
-export interface BulkAssignDonorInput {
+interface BulkAssignDonorInput {
   transactionIds: string[];
   donorId: string;
 }
 
-export interface BulkAssignDonorResult {
+interface BulkAssignDonorResult {
   success: boolean;
   assignedCount?: number;
   errors?: string[];

--- a/admin/src/server/contexts/report/application/usecases/bulk-assign-counterpart-usecase.ts
+++ b/admin/src/server/contexts/report/application/usecases/bulk-assign-counterpart-usecase.ts
@@ -4,12 +4,12 @@ import type { ITransactionWithCounterpartRepository } from "@/server/contexts/re
 import type { ICounterpartRepository } from "@/server/contexts/report/domain/repositories/counterpart-repository.interface";
 import type { ITransactionCounterpartRepository } from "@/server/contexts/report/domain/repositories/transaction-counterpart-repository.interface";
 
-export interface BulkAssignCounterpartInput {
+interface BulkAssignCounterpartInput {
   transactionIds: string[];
   counterpartId: string;
 }
 
-export interface BulkAssignCounterpartResult {
+interface BulkAssignCounterpartResult {
   success: boolean;
   successCount: number;
   failedIds: string[];

--- a/admin/src/server/contexts/report/application/usecases/get-organization-profile-usecase.ts
+++ b/admin/src/server/contexts/report/application/usecases/get-organization-profile-usecase.ts
@@ -3,7 +3,7 @@ import "server-only";
 import type { OrganizationReportProfile } from "@/server/contexts/report/domain/models/organization-report-profile";
 import type { IOrganizationReportProfileRepository } from "@/server/contexts/report/domain/repositories/organization-report-profile-repository.interface";
 
-export interface GetOrganizationProfileInput {
+interface GetOrganizationProfileInput {
   politicalOrganizationId: string;
   financialYear: number;
 }

--- a/admin/src/server/contexts/report/application/usecases/import-donor-csv-usecase.ts
+++ b/admin/src/server/contexts/report/application/usecases/import-donor-csv-usecase.ts
@@ -23,7 +23,7 @@ export interface ImportDonorCsvInput {
   politicalOrganizationId: string;
 }
 
-export interface ImportDonorCsvOutput {
+interface ImportDonorCsvOutput {
   importedCount: number;
   createdDonorCount: number;
 }

--- a/admin/src/server/contexts/report/application/usecases/manage-counterpart-usecase.ts
+++ b/admin/src/server/contexts/report/application/usecases/manage-counterpart-usecase.ts
@@ -12,13 +12,13 @@ import type {
   ICounterpartRepository,
 } from "@/server/contexts/report/domain/repositories/counterpart-repository.interface";
 
-export interface GetCounterpartsInput {
+interface GetCounterpartsInput {
   searchQuery?: string;
   limit?: number;
   offset?: number;
 }
 
-export interface GetCounterpartsResult {
+interface GetCounterpartsResult {
   counterparts: CounterpartWithUsage[];
   total: number;
 }
@@ -50,7 +50,7 @@ export class GetCounterpartByIdUsecase {
   }
 }
 
-export interface CreateCounterpartResult {
+interface CreateCounterpartResult {
   success: boolean;
   counterpart?: Counterpart;
   errors?: string[];
@@ -89,7 +89,7 @@ export class CreateCounterpartUsecase {
   }
 }
 
-export interface UpdateCounterpartResult {
+interface UpdateCounterpartResult {
   success: boolean;
   counterpart?: Counterpart;
   errors?: string[];
@@ -139,7 +139,7 @@ export class UpdateCounterpartUsecase {
   }
 }
 
-export interface DeleteCounterpartResult {
+interface DeleteCounterpartResult {
   success: boolean;
   errors?: string[];
 }
@@ -181,13 +181,13 @@ export class GetCounterpartUsageUsecase {
   }
 }
 
-export interface GetCounterpartDetailResult {
+interface GetCounterpartDetailResult {
   counterpart: Counterpart | null;
   usageCount: number;
   allCounterparts: Counterpart[];
 }
 
-export interface GetAllCounterpartsInput {
+interface GetAllCounterpartsInput {
   limit?: number;
 }
 

--- a/admin/src/server/contexts/report/application/usecases/manage-donor-usecase.ts
+++ b/admin/src/server/contexts/report/application/usecases/manage-donor-usecase.ts
@@ -13,14 +13,14 @@ import type {
   IDonorRepository,
 } from "@/server/contexts/report/domain/repositories/donor-repository.interface";
 
-export interface GetDonorsInput {
+interface GetDonorsInput {
   searchQuery?: string;
   donorType?: DonorType;
   limit?: number;
   offset?: number;
 }
 
-export interface GetDonorsResult {
+interface GetDonorsResult {
   donors: DonorWithUsage[];
   total: number;
 }
@@ -45,7 +45,7 @@ export class GetDonorsUsecase {
   }
 }
 
-export interface CreateDonorResult {
+interface CreateDonorResult {
   success: boolean;
   donor?: Donor;
   errors?: string[];
@@ -86,7 +86,7 @@ export class CreateDonorUsecase {
   }
 }
 
-export interface UpdateDonorResult {
+interface UpdateDonorResult {
   success: boolean;
   donor?: Donor;
   errors?: string[];
@@ -150,7 +150,7 @@ export class UpdateDonorUsecase {
   }
 }
 
-export interface DeleteDonorResult {
+interface DeleteDonorResult {
   success: boolean;
   errors?: string[];
 }

--- a/admin/src/server/contexts/report/application/usecases/save-organization-profile-usecase.ts
+++ b/admin/src/server/contexts/report/application/usecases/save-organization-profile-usecase.ts
@@ -7,7 +7,7 @@ import type {
 } from "@/server/contexts/report/domain/models/organization-report-profile";
 import type { IOrganizationReportProfileRepository } from "@/server/contexts/report/domain/repositories/organization-report-profile-repository.interface";
 
-export interface SaveOrganizationProfileInput {
+interface SaveOrganizationProfileInput {
   id?: string;
   politicalOrganizationId: string;
   financialYear: number;

--- a/admin/src/server/contexts/report/application/usecases/suggest-counterpart-usecase.ts
+++ b/admin/src/server/contexts/report/application/usecases/suggest-counterpart-usecase.ts
@@ -7,7 +7,7 @@ import {
   createDefaultSuggester,
 } from "@/server/contexts/report/application/services/counterpart-suggester";
 
-export interface SuggestCounterpartInput {
+interface SuggestCounterpartInput {
   transactionId: string;
   politicalOrganizationId: string;
   limit?: number;

--- a/admin/src/server/contexts/report/application/usecases/update-grant-expenditure-flag-usecase.ts
+++ b/admin/src/server/contexts/report/application/usecases/update-grant-expenditure-flag-usecase.ts
@@ -3,12 +3,12 @@ import "server-only";
 import type { ITransactionWithCounterpartRepository } from "@/server/contexts/report/domain/repositories/report-transaction-repository.interface";
 import { validateGrantExpenditureFlagUpdate } from "@/server/contexts/report/domain/models/grant-expenditure-rules";
 
-export interface UpdateGrantExpenditureFlagInput {
+interface UpdateGrantExpenditureFlagInput {
   transactionId: string;
   isGrantExpenditure: boolean;
 }
 
-export interface UpdateGrantExpenditureFlagResult {
+interface UpdateGrantExpenditureFlagResult {
   success: boolean;
   errors?: string[];
 }

--- a/admin/src/server/contexts/report/application/usecases/xml-export-usecase.ts
+++ b/admin/src/server/contexts/report/application/usecases/xml-export-usecase.ts
@@ -18,12 +18,12 @@ import type { IOrganizationReportProfileRepository } from "@/server/contexts/rep
 // Re-export for consumers
 export { KNOWN_FORM_IDS };
 
-export interface XmlExportInput {
+interface XmlExportInput {
   politicalOrganizationId: string;
   financialYear: number;
 }
 
-export interface XmlExportResult {
+interface XmlExportResult {
   xml: string;
   shiftJisBuffer: Buffer;
   filename: string;

--- a/admin/src/server/contexts/report/domain/models/counterpart-assignment-rules.ts
+++ b/admin/src/server/contexts/report/domain/models/counterpart-assignment-rules.ts
@@ -68,11 +68,9 @@ export const COUNTERPART_REQUIRED_EXPENSE_CATEGORIES = [
   ...POLITICAL_ACTIVITY_EXPENSE_CATEGORIES,
 ] as const;
 
-export type CounterpartRequiredIncomeCategory =
-  (typeof COUNTERPART_REQUIRED_INCOME_CATEGORIES)[number];
+type CounterpartRequiredIncomeCategory = (typeof COUNTERPART_REQUIRED_INCOME_CATEGORIES)[number];
 
-export type CounterpartRequiredExpenseCategory =
-  (typeof COUNTERPART_REQUIRED_EXPENSE_CATEGORIES)[number];
+type CounterpartRequiredExpenseCategory = (typeof COUNTERPART_REQUIRED_EXPENSE_CATEGORIES)[number];
 
 /**
  * Counterpart明細記載が必要な金額閾値（円）

--- a/admin/src/server/contexts/report/domain/models/donor-assignment-rules.ts
+++ b/admin/src/server/contexts/report/domain/models/donor-assignment-rules.ts
@@ -55,7 +55,7 @@ export const DONOR_REQUIRED_CATEGORIES = [
   ...ALL_DONOR_TYPE_CATEGORIES,
 ] as const;
 
-export type DonorRequiredCategory = (typeof DONOR_REQUIRED_CATEGORIES)[number];
+type DonorRequiredCategory = (typeof DONOR_REQUIRED_CATEGORIES)[number];
 
 /**
  * カテゴリごとに許可されるdonor_typeのマッピング

--- a/admin/src/server/contexts/report/presentation/actions/bulk-assign-counterpart.ts
+++ b/admin/src/server/contexts/report/presentation/actions/bulk-assign-counterpart.ts
@@ -7,7 +7,7 @@ import { PrismaReportTransactionRepository } from "@/server/contexts/report/infr
 import { PrismaCounterpartRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-counterpart.repository";
 import { PrismaTransactionCounterpartRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-transaction-counterpart.repository";
 
-export interface BulkAssignCounterpartActionResult {
+interface BulkAssignCounterpartActionResult {
   success: boolean;
   successCount: number;
   failedIds: string[];

--- a/admin/src/server/contexts/report/presentation/actions/bulk-assign-donor.ts
+++ b/admin/src/server/contexts/report/presentation/actions/bulk-assign-donor.ts
@@ -7,7 +7,7 @@ import { PrismaTransactionDonorRepository } from "@/server/contexts/report/infra
 import { PrismaTransactionWithDonorRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-transaction-with-donor.repository";
 import { BulkAssignDonorUsecase } from "@/server/contexts/report/application/usecases/assign-donor-usecase";
 
-export interface BulkAssignDonorActionResult {
+interface BulkAssignDonorActionResult {
   success: boolean;
   assignedCount?: number;
   errors?: string[];

--- a/admin/src/server/contexts/report/presentation/actions/create-counterpart.ts
+++ b/admin/src/server/contexts/report/presentation/actions/create-counterpart.ts
@@ -6,7 +6,7 @@ import { PrismaCounterpartRepository } from "@/server/contexts/report/infrastruc
 import { CreateCounterpartUsecase } from "@/server/contexts/report/application/usecases/manage-counterpart-usecase";
 import type { CreateCounterpartInput } from "@/server/contexts/report/domain/models/counterpart";
 
-export interface CreateCounterpartActionResult {
+interface CreateCounterpartActionResult {
   success: boolean;
   counterpartId?: string;
   errors?: string[];

--- a/admin/src/server/contexts/report/presentation/actions/create-donor.ts
+++ b/admin/src/server/contexts/report/presentation/actions/create-donor.ts
@@ -6,7 +6,7 @@ import { PrismaDonorRepository } from "@/server/contexts/report/infrastructure/r
 import { CreateDonorUsecase } from "@/server/contexts/report/application/usecases/manage-donor-usecase";
 import type { CreateDonorInput } from "@/server/contexts/report/domain/models/donor";
 
-export interface CreateDonorActionResult {
+interface CreateDonorActionResult {
   success: boolean;
   donorId?: string;
   errors?: string[];

--- a/admin/src/server/contexts/report/presentation/actions/delete-counterpart.ts
+++ b/admin/src/server/contexts/report/presentation/actions/delete-counterpart.ts
@@ -7,7 +7,7 @@ import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaCounterpartRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-counterpart.repository";
 import { DeleteCounterpartUsecase } from "@/server/contexts/report/application/usecases/manage-counterpart-usecase";
 
-export interface DeleteCounterpartActionResult {
+interface DeleteCounterpartActionResult {
   success: boolean;
   errors?: string[];
 }

--- a/admin/src/server/contexts/report/presentation/actions/delete-donor.ts
+++ b/admin/src/server/contexts/report/presentation/actions/delete-donor.ts
@@ -7,7 +7,7 @@ import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaDonorRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-donor.repository";
 import { DeleteDonorUsecase } from "@/server/contexts/report/application/usecases/manage-donor-usecase";
 
-export interface DeleteDonorActionResult {
+interface DeleteDonorActionResult {
   success: boolean;
   errors?: string[];
 }

--- a/admin/src/server/contexts/report/presentation/actions/save-organization-profile.ts
+++ b/admin/src/server/contexts/report/presentation/actions/save-organization-profile.ts
@@ -6,7 +6,7 @@ import { PrismaOrganizationReportProfileRepository } from "@/server/contexts/rep
 import { SaveOrganizationProfileUsecase } from "@/server/contexts/report/application/usecases/save-organization-profile-usecase";
 import type { OrganizationReportProfileDetails } from "@/server/contexts/report/domain/models/organization-report-profile";
 
-export interface SaveOrganizationProfileData {
+interface SaveOrganizationProfileData {
   id?: string;
   politicalOrganizationId: string;
   financialYear: number;

--- a/admin/src/server/contexts/report/presentation/actions/update-counterpart.ts
+++ b/admin/src/server/contexts/report/presentation/actions/update-counterpart.ts
@@ -6,7 +6,7 @@ import { PrismaCounterpartRepository } from "@/server/contexts/report/infrastruc
 import { UpdateCounterpartUsecase } from "@/server/contexts/report/application/usecases/manage-counterpart-usecase";
 import type { UpdateCounterpartInput } from "@/server/contexts/report/domain/models/counterpart";
 
-export interface UpdateCounterpartActionResult {
+interface UpdateCounterpartActionResult {
   success: boolean;
   errors?: string[];
 }

--- a/admin/src/server/contexts/report/presentation/actions/update-donor.ts
+++ b/admin/src/server/contexts/report/presentation/actions/update-donor.ts
@@ -6,7 +6,7 @@ import { PrismaDonorRepository } from "@/server/contexts/report/infrastructure/r
 import { UpdateDonorUsecase } from "@/server/contexts/report/application/usecases/manage-donor-usecase";
 import type { UpdateDonorInput } from "@/server/contexts/report/domain/models/donor";
 
-export interface UpdateDonorActionResult {
+interface UpdateDonorActionResult {
   success: boolean;
   errors?: string[];
 }

--- a/admin/src/server/contexts/report/presentation/actions/update-grant-expenditure-flag.ts
+++ b/admin/src/server/contexts/report/presentation/actions/update-grant-expenditure-flag.ts
@@ -7,7 +7,7 @@ import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { UpdateGrantExpenditureFlagUsecase } from "@/server/contexts/report/application/usecases/update-grant-expenditure-flag-usecase";
 import { PrismaReportTransactionRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-report-transaction.repository";
 
-export interface UpdateGrantExpenditureFlagActionResult {
+interface UpdateGrantExpenditureFlagActionResult {
   success: boolean;
   errors?: string[];
 }

--- a/admin/src/server/contexts/report/presentation/loaders/counterpart-detail-loader.ts
+++ b/admin/src/server/contexts/report/presentation/loaders/counterpart-detail-loader.ts
@@ -11,9 +11,9 @@ import {
 
 const CACHE_REVALIDATE_SECONDS = 60;
 
-export type LoadCounterpartTransactionsInput = GetCounterpartTransactionsInput;
+type LoadCounterpartTransactionsInput = GetCounterpartTransactionsInput;
 
-export type LoadCounterpartTransactionsResult = GetCounterpartTransactionsResult;
+type LoadCounterpartTransactionsResult = GetCounterpartTransactionsResult;
 
 export async function loadCounterpartTransactionsData(
   input: LoadCounterpartTransactionsInput,

--- a/admin/src/server/contexts/report/presentation/loaders/counterparts-loader.ts
+++ b/admin/src/server/contexts/report/presentation/loaders/counterparts-loader.ts
@@ -15,13 +15,13 @@ import type {
 
 const CACHE_REVALIDATE_SECONDS = 60;
 
-export interface LoadCounterpartsInput {
+interface LoadCounterpartsInput {
   searchQuery?: string;
   page?: number;
   perPage?: number;
 }
 
-export interface LoadCounterpartsResult {
+interface LoadCounterpartsResult {
   counterparts: CounterpartWithUsage[];
   total: number;
   page: number;
@@ -62,7 +62,7 @@ export async function loadCounterpartsData(
   return cachedLoader(searchQuery, page, perPage);
 }
 
-export interface LoadCounterpartDetailPageResult {
+interface LoadCounterpartDetailPageResult {
   counterpart: Counterpart | null;
   usageCount: number;
   allCounterparts: Counterpart[];

--- a/admin/src/server/contexts/report/presentation/loaders/donors-loader.ts
+++ b/admin/src/server/contexts/report/presentation/loaders/donors-loader.ts
@@ -12,14 +12,14 @@ import type {
 
 const CACHE_REVALIDATE_SECONDS = 60;
 
-export interface LoadDonorsInput {
+interface LoadDonorsInput {
   searchQuery?: string;
   donorType?: DonorType;
   page?: number;
   perPage?: number;
 }
 
-export interface LoadDonorsResult {
+interface LoadDonorsResult {
   donors: DonorWithUsage[];
   total: number;
   page: number;

--- a/admin/src/server/contexts/report/presentation/loaders/transactions-with-counterparts-loader.ts
+++ b/admin/src/server/contexts/report/presentation/loaders/transactions-with-counterparts-loader.ts
@@ -11,9 +11,9 @@ import {
 
 const CACHE_REVALIDATE_SECONDS = 60;
 
-export type LoadTransactionsWithCounterpartsInput = GetTransactionsWithCounterpartsInput;
+type LoadTransactionsWithCounterpartsInput = GetTransactionsWithCounterpartsInput;
 
-export type LoadTransactionsWithCounterpartsResult = GetTransactionsWithCounterpartsResult;
+type LoadTransactionsWithCounterpartsResult = GetTransactionsWithCounterpartsResult;
 
 export async function loadTransactionsWithCounterpartsData(
   input: LoadTransactionsWithCounterpartsInput,

--- a/admin/src/server/contexts/report/presentation/loaders/transactions-with-donors-loader.ts
+++ b/admin/src/server/contexts/report/presentation/loaders/transactions-with-donors-loader.ts
@@ -11,9 +11,9 @@ import {
 
 const CACHE_REVALIDATE_SECONDS = 60;
 
-export type LoadTransactionsWithDonorsInput = GetTransactionsWithDonorsInput;
+type LoadTransactionsWithDonorsInput = GetTransactionsWithDonorsInput;
 
-export type LoadTransactionsWithDonorsResult = GetTransactionsWithDonorsResult;
+type LoadTransactionsWithDonorsResult = GetTransactionsWithDonorsResult;
 
 export async function loadTransactionsWithDonorsData(
   input: LoadTransactionsWithDonorsInput,

--- a/admin/src/server/contexts/shared/application/usecases/clear-webapp-cache-usecase.ts
+++ b/admin/src/server/contexts/shared/application/usecases/clear-webapp-cache-usecase.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import type { ICacheInvalidator } from "@/server/contexts/shared/domain/services/cache-invalidator.interface";
 
-export interface ClearWebappCacheResult {
+interface ClearWebappCacheResult {
   success: boolean;
   message: string;
 }

--- a/admin/src/server/contexts/shared/presentation/actions/clear-webapp-cache.ts
+++ b/admin/src/server/contexts/shared/presentation/actions/clear-webapp-cache.ts
@@ -3,7 +3,7 @@
 import { WebappCacheInvalidator } from "@/server/contexts/shared/infrastructure/services/webapp-cache-invalidator";
 import { ClearWebappCacheUsecase } from "@/server/contexts/shared/application/usecases/clear-webapp-cache-usecase";
 
-export interface ClearWebappCacheResponse {
+interface ClearWebappCacheResponse {
   success: boolean;
   message: string;
 }

--- a/admin/src/server/contexts/shared/presentation/actions/create-balance-snapshot.ts
+++ b/admin/src/server/contexts/shared/presentation/actions/create-balance-snapshot.ts
@@ -4,7 +4,7 @@ import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaBalanceSnapshotRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-balance-snapshot.repository";
 import { CreateBalanceSnapshotUsecase } from "@/server/contexts/shared/application/usecases/create-balance-snapshot-usecase";
 
-export interface CreateBalanceSnapshotData {
+interface CreateBalanceSnapshotData {
   politicalOrganizationId: string;
   snapshotDate: string;
   balance: number;

--- a/webapp/src/client/components/top-page/features/charts/MonthlyChart.tsx
+++ b/webapp/src/client/components/top-page/features/charts/MonthlyChart.tsx
@@ -111,10 +111,11 @@ export default function MonthlyChart({ data }: MonthlyChartProps) {
         enabled: false,
       },
       events: {
-        beforeMount: (chartContext: { el: HTMLElement }) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        beforeMount: (chart: any) => {
           // チャートコンテナのタッチイベントを親要素に委譲
           if (typeof window !== "undefined" && "ontouchstart" in window) {
-            const chartEl = chartContext.el;
+            const chartEl = chart.el as HTMLElement;
             chartEl.style.touchAction = "pan-x pan-y";
           }
         },

--- a/webapp/src/server/contexts/public-finance/application/usecases/get-all-transactions-by-slug-usecase.ts
+++ b/webapp/src/server/contexts/public-finance/application/usecases/get-all-transactions-by-slug-usecase.ts
@@ -10,7 +10,7 @@ import { convertToDisplayTransactions } from "@/server/contexts/public-finance/d
 import type { IPoliticalOrganizationRepository } from "@/server/contexts/public-finance/domain/repositories/political-organization-repository.interface";
 import type { ITransactionListRepository } from "@/server/contexts/public-finance/domain/repositories/transaction-list-repository.interface";
 
-export interface GetAllTransactionsBySlugParams {
+interface GetAllTransactionsBySlugParams {
   slugs: string[];
   transactionType?: DisplayTransactionType;
   dateFrom?: Date;
@@ -21,7 +21,7 @@ export interface GetAllTransactionsBySlugParams {
   categories?: string[];
 }
 
-export interface GetAllTransactionsBySlugResult {
+interface GetAllTransactionsBySlugResult {
   transactions: DisplayTransaction[];
   total: number;
   politicalOrganizations: PoliticalOrganization[];

--- a/webapp/src/server/contexts/public-finance/application/usecases/get-balance-sheet-usecase.ts
+++ b/webapp/src/server/contexts/public-finance/application/usecases/get-balance-sheet-usecase.ts
@@ -5,12 +5,12 @@ import type { IBalanceSheetRepository } from "@/server/contexts/public-finance/d
 import type { IPoliticalOrganizationRepository } from "@/server/contexts/public-finance/domain/repositories/political-organization-repository.interface";
 import type { BalanceSheetData } from "@/types/balance-sheet";
 
-export interface GetBalanceSheetParams {
+interface GetBalanceSheetParams {
   slugs: string[];
   financialYear: number;
 }
 
-export interface GetBalanceSheetResult {
+interface GetBalanceSheetResult {
   balanceSheetData: BalanceSheetData;
 }
 

--- a/webapp/src/server/contexts/public-finance/application/usecases/get-monthly-aggregation-usecase.ts
+++ b/webapp/src/server/contexts/public-finance/application/usecases/get-monthly-aggregation-usecase.ts
@@ -7,12 +7,12 @@ import {
 import type { IMonthlyAggregationRepository } from "@/server/contexts/public-finance/domain/repositories/monthly-aggregation-repository.interface";
 import type { IPoliticalOrganizationRepository } from "@/server/contexts/public-finance/domain/repositories/political-organization-repository.interface";
 
-export interface GetMonthlyAggregationParams {
+interface GetMonthlyAggregationParams {
   slugs: string[];
   financialYear: number;
 }
 
-export interface GetMonthlyAggregationResult {
+interface GetMonthlyAggregationResult {
   monthlyData: MonthlyAggregation[];
 }
 

--- a/webapp/src/server/contexts/public-finance/application/usecases/get-sankey-aggregation-usecase.ts
+++ b/webapp/src/server/contexts/public-finance/application/usecases/get-sankey-aggregation-usecase.ts
@@ -11,13 +11,13 @@ import {
 } from "@/server/contexts/public-finance/domain/models/category-aggregation";
 import { SankeyDataBuilder } from "@/server/contexts/public-finance/domain/services/sankey-data-builder";
 
-export interface GetSankeyAggregationParams {
+interface GetSankeyAggregationParams {
   slugs: string[];
   financialYear: number;
   categoryType?: "political-category" | "friendly-category";
 }
 
-export interface GetSankeyAggregationResult {
+interface GetSankeyAggregationResult {
   sankeyData: SankeyData;
 }
 

--- a/webapp/src/server/contexts/public-finance/application/usecases/get-transactions-by-slug-usecase.ts
+++ b/webapp/src/server/contexts/public-finance/application/usecases/get-transactions-by-slug-usecase.ts
@@ -26,7 +26,7 @@ export interface GetTransactionsBySlugParams {
   categories?: string[];
 }
 
-export interface GetTransactionsBySlugResult {
+interface GetTransactionsBySlugResult {
   transactions: DisplayTransaction[];
   total: number;
   page: number;

--- a/webapp/src/server/contexts/public-finance/application/usecases/get-transactions-for-csv-usecase.ts
+++ b/webapp/src/server/contexts/public-finance/application/usecases/get-transactions-for-csv-usecase.ts
@@ -10,7 +10,7 @@ export interface GetTransactionsForCsvParams {
   financialYear: number;
 }
 
-export interface GetTransactionsForCsvResult {
+interface GetTransactionsForCsvResult {
   transactions: Array<Transaction & { political_organization_name: string }>;
   total: number;
 }


### PR DESCRIPTION
## Summary
This PR adds a new bulk delete transactions feature that allows users to search for and delete multiple transactions by their transaction numbers in a single operation.

## Key Changes
- **New Client Component**: `BulkDeleteTransactionsClient` - A React component that provides a UI for searching and bulk deleting transactions
  - Search interface with organization selection and comma-separated transaction number input
  - Results display showing found and not-found transactions in a table format
  - Confirmation dialog before deletion to prevent accidental data loss
  - Success/error feedback messages

- **New Server Actions**: `bulk-delete-transactions.ts` - Server-side actions for transaction operations
  - `searchTransactionsForBulkDeleteAction()` - Searches for transactions by their numbers within a specific organization
  - `bulkDeleteTransactionsAction()` - Performs the actual deletion of multiple transactions by ID
  - Proper error handling and result formatting for both operations

- **New Page**: `/bulk-delete-transactions` - Route handler that loads political organizations and renders the client component

- **Updated Navigation**: Added "取引一括削除" (Bulk Delete Transactions) link to the sidebar under the data import section

## Implementation Details
- Uses Next.js server actions for secure backend operations
- Integrates with existing `PrismaTransactionRepository` for database queries
- Displays transaction details (number, date, description, debit/credit amounts) before deletion
- Handles edge cases like transactions not found and provides clear user feedback
- Updates the "transactions-data" cache tag after successful deletion
- All UI text is in Japanese to match the application's localization

https://claude.ai/code/session_01A7weBTi9SaNpDEVYtffES3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 取引を選択した組織で取引番号をコンマ区切り入力して検索・確認し、一括削除できる画面を追加しました。検索は見つかった取引・未検出番号・エラーを明示表示し、削除は確認ダイアログで確定、完了／失敗は通知で報告します。
  * 管理画面のサイドバーに「取引一括削除」メニューを追加しました。
* **改善**
  * 取引一覧に「取引No」列を追加し、取引番号を表示するようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->