### PR TITLE
fix(webapp): 貸借対照表の負債計算を全期間累積に修正

### DIFF
--- a/webapp/src/server/contexts/public-finance/application/usecases/get-balance-sheet-usecase.ts
+++ b/webapp/src/server/contexts/public-finance/application/usecases/get-balance-sheet-usecase.ts
@@ -7,7 +7,6 @@ import type { BalanceSheetData } from "@/types/balance-sheet";
 
 interface GetBalanceSheetParams {
   slugs: string[];
-  financialYear: number;
 }
 
 interface GetBalanceSheetResult {
@@ -41,9 +40,9 @@ export class GetBalanceSheetUsecase {
       const [currentAssets, borrowingIncome, borrowingExpense, currentLiabilities] =
         await Promise.all([
           this.balanceSheetRepository.getCurrentAssets(orgIds),
-          this.balanceSheetRepository.getBorrowingIncome(orgIds, params.financialYear),
-          this.balanceSheetRepository.getBorrowingExpense(orgIds, params.financialYear),
-          this.balanceSheetRepository.getCurrentLiabilities(orgIds, params.financialYear),
+          this.balanceSheetRepository.getBorrowingIncome(orgIds),
+          this.balanceSheetRepository.getBorrowingExpense(orgIds),
+          this.balanceSheetRepository.getCurrentLiabilities(orgIds),
         ]);
 
       const balanceSheetData = BalanceSheet.fromInput({

--- a/webapp/src/server/contexts/public-finance/application/usecases/get-sankey-aggregation-usecase.ts
+++ b/webapp/src/server/contexts/public-finance/application/usecases/get-sankey-aggregation-usecase.ts
@@ -57,10 +57,7 @@ export class GetSankeyAggregationUsecase {
           organizationIdsAsString,
           params.financialYear,
         ),
-        this.balanceSheetRepository.getCurrentLiabilities(
-          organizationIdsAsString,
-          params.financialYear,
-        ),
+        this.balanceSheetRepository.getCurrentLiabilities(organizationIdsAsString),
       ]);
 
       // 3. ドメインモデルで変換処理

--- a/webapp/src/server/contexts/public-finance/domain/repositories/balance-sheet-repository.interface.ts
+++ b/webapp/src/server/contexts/public-finance/domain/repositories/balance-sheet-repository.interface.ts
@@ -11,17 +11,17 @@ export interface IBalanceSheetRepository {
   getCurrentAssets(organizationIds: string[]): Promise<number>;
 
   /**
-   * 借入金収入を取得（借入金勘定の貸方合計）
+   * 借入金収入を取得（全期間の借入金勘定の貸方合計）
    */
-  getBorrowingIncome(organizationIds: string[], financialYear: number): Promise<number>;
+  getBorrowingIncome(organizationIds: string[]): Promise<number>;
 
   /**
-   * 借入金支出を取得（借入金勘定の借方合計）
+   * 借入金支出を取得（全期間の借入金勘定の借方合計）
    */
-  getBorrowingExpense(organizationIds: string[], financialYear: number): Promise<number>;
+  getBorrowingExpense(organizationIds: string[]): Promise<number>;
 
   /**
-   * 流動負債を取得（負債勘定の貸方 - 借方）
+   * 流動負債を取得（全期間の負債勘定の貸方 - 借方）
    */
-  getCurrentLiabilities(organizationIds: string[], financialYear: number): Promise<number>;
+  getCurrentLiabilities(organizationIds: string[]): Promise<number>;
 }

--- a/webapp/src/server/contexts/public-finance/infrastructure/repositories/prisma-balance-sheet.repository.ts
+++ b/webapp/src/server/contexts/public-finance/infrastructure/repositories/prisma-balance-sheet.repository.ts
@@ -57,7 +57,7 @@ export class PrismaBalanceSheetRepository implements IBalanceSheetRepository {
     return Number(result[0]?.total_balance || 0);
   }
 
-  async getBorrowingIncome(organizationIds: string[], financialYear: number): Promise<number> {
+  async getBorrowingIncome(organizationIds: string[]): Promise<number> {
     const result = await this.prisma.transaction.aggregate({
       _sum: {
         creditAmount: true,
@@ -66,7 +66,6 @@ export class PrismaBalanceSheetRepository implements IBalanceSheetRepository {
         politicalOrganizationId: {
           in: organizationIds.map((id) => BigInt(id)),
         },
-        financialYear,
         creditAccount: ACCOUNT_NAMES.LOAN,
         transactionType: "income",
       },
@@ -75,7 +74,7 @@ export class PrismaBalanceSheetRepository implements IBalanceSheetRepository {
     return Number(result._sum.creditAmount) || 0;
   }
 
-  async getBorrowingExpense(organizationIds: string[], financialYear: number): Promise<number> {
+  async getBorrowingExpense(organizationIds: string[]): Promise<number> {
     const result = await this.prisma.transaction.aggregate({
       _sum: {
         debitAmount: true,
@@ -84,7 +83,6 @@ export class PrismaBalanceSheetRepository implements IBalanceSheetRepository {
         politicalOrganizationId: {
           in: organizationIds.map((id) => BigInt(id)),
         },
-        financialYear,
         debitAccount: ACCOUNT_NAMES.LOAN,
         transactionType: "expense",
       },
@@ -93,7 +91,7 @@ export class PrismaBalanceSheetRepository implements IBalanceSheetRepository {
     return Number(result._sum.debitAmount) || 0;
   }
 
-  async getCurrentLiabilities(organizationIds: string[], financialYear: number): Promise<number> {
+  async getCurrentLiabilities(organizationIds: string[]): Promise<number> {
     if (LIABILITY_ACCOUNTS.length === 0) {
       return 0;
     }
@@ -106,7 +104,6 @@ export class PrismaBalanceSheetRepository implements IBalanceSheetRepository {
         politicalOrganizationId: {
           in: organizationIds.map((id) => BigInt(id)),
         },
-        financialYear,
         debitAccount: {
           in: LIABILITY_ACCOUNTS,
         },
@@ -121,7 +118,6 @@ export class PrismaBalanceSheetRepository implements IBalanceSheetRepository {
         politicalOrganizationId: {
           in: organizationIds.map((id) => BigInt(id)),
         },
-        financialYear,
         creditAccount: {
           in: LIABILITY_ACCOUNTS,
         },

--- a/webapp/src/server/contexts/public-finance/presentation/loaders/load-top-page-data.ts
+++ b/webapp/src/server/contexts/public-finance/presentation/loaders/load-top-page-data.ts
@@ -71,7 +71,6 @@ export const loadTopPageData = unstable_cache(
       }),
       balanceSheetUsecase.execute({
         slugs: params.slugs,
-        financialYear: params.financialYear,
       }),
     ]);
 

--- a/webapp/tests/server/usecases/get-balance-sheet-usecase.test.ts
+++ b/webapp/tests/server/usecases/get-balance-sheet-usecase.test.ts
@@ -37,7 +37,6 @@ describe("GetBalanceSheetUsecase", () => {
 
     const result = await usecase.execute({
       slugs: ["test-org"],
-      financialYear: 2025,
     });
 
     expect(result.balanceSheetData.left.currentAssets).toBe(1000000);
@@ -61,7 +60,6 @@ describe("GetBalanceSheetUsecase", () => {
 
     const result = await usecase.execute({
       slugs: ["test-org"],
-      financialYear: 2025,
     });
 
     expect(result.balanceSheetData.left.currentAssets).toBe(100000);
@@ -85,7 +83,6 @@ describe("GetBalanceSheetUsecase", () => {
 
     const result = await usecase.execute({
       slugs: ["test-org"],
-      financialYear: 2025,
     });
 
     expect(result.balanceSheetData.right.netAssets).toBe(0);
@@ -108,7 +105,6 @@ describe("GetBalanceSheetUsecase", () => {
 
     const result = await usecase.execute({
       slugs: ["org-1", "org-2"],
-      financialYear: 2025,
     });
 
     expect(result.balanceSheetData.left.currentAssets).toBe(2000000);
@@ -121,7 +117,6 @@ describe("GetBalanceSheetUsecase", () => {
     await expect(
       usecase.execute({
         slugs: ["non-existent-org"],
-        financialYear: 2025,
       }),
     ).rejects.toThrow('Political organizations with slugs "non-existent-org" not found');
   });
@@ -132,7 +127,6 @@ describe("GetBalanceSheetUsecase", () => {
     await expect(
       usecase.execute({
         slugs: ["org-1", "org-2"],
-        financialYear: 2025,
       }),
     ).rejects.toThrow('Political organizations with slugs "org-1, org-2" not found');
   });

--- a/webapp/tests/server/usecases/get-sankey-aggregation-usecase.test.ts
+++ b/webapp/tests/server/usecases/get-sankey-aggregation-usecase.test.ts
@@ -239,7 +239,7 @@ describe("GetSankeyAggregationUsecase", () => {
     });
 
     expect(result.sankeyData).toBeDefined();
-    expect(mockBalanceSheetRepository.getCurrentLiabilities).toHaveBeenCalledWith(["1"], 2025);
+    expect(mockBalanceSheetRepository.getCurrentLiabilities).toHaveBeenCalledWith(["1"]);
 
     const unpaidExpenseNode = result.sankeyData.nodes.find((node) => node.label === "未払費用");
     expect(unpaidExpenseNode).toBeDefined();


### PR DESCRIPTION
## 目的

webappの貸借対照表（バランスシート）を閲覧するユーザーが、負債が該当年度の取引のみで計算され正しい累積残高が表示されない状態を解消するため。

## 変更内容

- `getBorrowingIncome` / `getBorrowingExpense` / `getCurrentLiabilities` から `financialYear` フィルタを削除
- インターフェース・リポジトリ実装・ユースケース・ローダーの呼び出しを一貫して修正
- 流動資産（`getCurrentAssets`）はもともと全期間の最新スナップショットを取得しており変更なし

## 背景

| 項目 | 修正前 | 修正後 |
|------|--------|--------|
| 流動資産 | 全期間（最新スナップショット）✅ | 変更なし |
| 借入金収入/支出 | 該当年度のみ ❌ | 全期間の累積 ✅ |
| 流動負債 | 該当年度のみ ❌ | 全期間の累積 ✅ |

## Test plan

- [x] `get-balance-sheet-usecase` テスト通過
- [x] `get-sankey-aggregation-usecase` テスト通過
- [x] 全テスト通過（115 passed）
- [x] typecheck 通過
- [x] lint 通過
- [x] knip 通過
- [ ] 本番データで貸借対照表の負債が正しく累積表示されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 変更内容

* **Bug Fixes**
  * 貸借対照表のデータ取得仕様を変更しました。これまで特定の会計年度を指定して借入金収入、借入金支出、流動負債を取得していましたが、会計年度の指定を削除し、全期間のデータを組織IDのみで取得するようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->