### PR TITLE
Add financial year filtering to getCurrentLiabilities method

### DIFF
--- a/webapp/src/server/contexts/public-finance/application/usecases/get-balance-sheet-usecase.ts
+++ b/webapp/src/server/contexts/public-finance/application/usecases/get-balance-sheet-usecase.ts
@@ -7,6 +7,7 @@ import type { BalanceSheetData } from "@/types/balance-sheet";
 
 interface GetBalanceSheetParams {
   slugs: string[];
+  financialYear: number;
 }
 
 interface GetBalanceSheetResult {
@@ -42,7 +43,7 @@ export class GetBalanceSheetUsecase {
           this.balanceSheetRepository.getCurrentAssets(orgIds),
           this.balanceSheetRepository.getBorrowingIncome(orgIds),
           this.balanceSheetRepository.getBorrowingExpense(orgIds),
-          this.balanceSheetRepository.getCurrentLiabilities(orgIds),
+          this.balanceSheetRepository.getCurrentLiabilities(orgIds, params.financialYear),
         ]);
 
       const balanceSheetData = BalanceSheet.fromInput({

--- a/webapp/src/server/contexts/public-finance/application/usecases/get-sankey-aggregation-usecase.ts
+++ b/webapp/src/server/contexts/public-finance/application/usecases/get-sankey-aggregation-usecase.ts
@@ -57,7 +57,10 @@ export class GetSankeyAggregationUsecase {
           organizationIdsAsString,
           params.financialYear,
         ),
-        this.balanceSheetRepository.getCurrentLiabilities(organizationIdsAsString),
+        this.balanceSheetRepository.getCurrentLiabilities(
+          organizationIdsAsString,
+          params.financialYear,
+        ),
       ]);
 
       // 3. ドメインモデルで変換処理

--- a/webapp/src/server/contexts/public-finance/domain/repositories/balance-sheet-repository.interface.ts
+++ b/webapp/src/server/contexts/public-finance/domain/repositories/balance-sheet-repository.interface.ts
@@ -21,7 +21,7 @@ export interface IBalanceSheetRepository {
   getBorrowingExpense(organizationIds: string[]): Promise<number>;
 
   /**
-   * 流動負債を取得（全期間の負債勘定の貸方 - 借方）
+   * 流動負債を取得（指定年度の負債勘定の貸方 - 借方）
    */
-  getCurrentLiabilities(organizationIds: string[]): Promise<number>;
+  getCurrentLiabilities(organizationIds: string[], financialYear: number): Promise<number>;
 }

--- a/webapp/src/server/contexts/public-finance/infrastructure/repositories/prisma-balance-sheet.repository.ts
+++ b/webapp/src/server/contexts/public-finance/infrastructure/repositories/prisma-balance-sheet.repository.ts
@@ -91,10 +91,12 @@ export class PrismaBalanceSheetRepository implements IBalanceSheetRepository {
     return Number(result._sum.debitAmount) || 0;
   }
 
-  async getCurrentLiabilities(organizationIds: string[]): Promise<number> {
+  async getCurrentLiabilities(organizationIds: string[], financialYear: number): Promise<number> {
     if (LIABILITY_ACCOUNTS.length === 0) {
       return 0;
     }
+
+    const orgIds = organizationIds.map((id) => BigInt(id));
 
     const debitResult = await this.prisma.transaction.aggregate({
       _sum: {
@@ -102,11 +104,12 @@ export class PrismaBalanceSheetRepository implements IBalanceSheetRepository {
       },
       where: {
         politicalOrganizationId: {
-          in: organizationIds.map((id) => BigInt(id)),
+          in: orgIds,
         },
         debitAccount: {
           in: LIABILITY_ACCOUNTS,
         },
+        financialYear,
       },
     });
 
@@ -116,11 +119,12 @@ export class PrismaBalanceSheetRepository implements IBalanceSheetRepository {
       },
       where: {
         politicalOrganizationId: {
-          in: organizationIds.map((id) => BigInt(id)),
+          in: orgIds,
         },
         creditAccount: {
           in: LIABILITY_ACCOUNTS,
         },
+        financialYear,
       },
     });
 

--- a/webapp/src/server/contexts/public-finance/presentation/loaders/load-top-page-data.ts
+++ b/webapp/src/server/contexts/public-finance/presentation/loaders/load-top-page-data.ts
@@ -71,6 +71,7 @@ export const loadTopPageData = unstable_cache(
       }),
       balanceSheetUsecase.execute({
         slugs: params.slugs,
+        financialYear: params.financialYear,
       }),
     ]);
 

--- a/webapp/tests/server/usecases/get-balance-sheet-usecase.test.ts
+++ b/webapp/tests/server/usecases/get-balance-sheet-usecase.test.ts
@@ -37,6 +37,7 @@ describe("GetBalanceSheetUsecase", () => {
 
     const result = await usecase.execute({
       slugs: ["test-org"],
+      financialYear: 2025,
     });
 
     expect(result.balanceSheetData.left.currentAssets).toBe(1000000);
@@ -60,6 +61,7 @@ describe("GetBalanceSheetUsecase", () => {
 
     const result = await usecase.execute({
       slugs: ["test-org"],
+      financialYear: 2025,
     });
 
     expect(result.balanceSheetData.left.currentAssets).toBe(100000);
@@ -83,6 +85,7 @@ describe("GetBalanceSheetUsecase", () => {
 
     const result = await usecase.execute({
       slugs: ["test-org"],
+      financialYear: 2025,
     });
 
     expect(result.balanceSheetData.right.netAssets).toBe(0);
@@ -105,6 +108,7 @@ describe("GetBalanceSheetUsecase", () => {
 
     const result = await usecase.execute({
       slugs: ["org-1", "org-2"],
+      financialYear: 2025,
     });
 
     expect(result.balanceSheetData.left.currentAssets).toBe(2000000);
@@ -117,6 +121,7 @@ describe("GetBalanceSheetUsecase", () => {
     await expect(
       usecase.execute({
         slugs: ["non-existent-org"],
+      financialYear: 2025,
       }),
     ).rejects.toThrow('Political organizations with slugs "non-existent-org" not found');
   });

--- a/webapp/tests/server/usecases/get-balance-sheet-usecase.test.ts
+++ b/webapp/tests/server/usecases/get-balance-sheet-usecase.test.ts
@@ -132,6 +132,7 @@ describe("GetBalanceSheetUsecase", () => {
     await expect(
       usecase.execute({
         slugs: ["org-1", "org-2"],
+        financialYear: 2025,
       }),
     ).rejects.toThrow('Political organizations with slugs "org-1, org-2" not found');
   });

--- a/webapp/tests/server/usecases/get-sankey-aggregation-usecase.test.ts
+++ b/webapp/tests/server/usecases/get-sankey-aggregation-usecase.test.ts
@@ -239,7 +239,7 @@ describe("GetSankeyAggregationUsecase", () => {
     });
 
     expect(result.sankeyData).toBeDefined();
-    expect(mockBalanceSheetRepository.getCurrentLiabilities).toHaveBeenCalledWith(["1"]);
+    expect(mockBalanceSheetRepository.getCurrentLiabilities).toHaveBeenCalledWith(["1"], 2025);
 
     const unpaidExpenseNode = result.sankeyData.nodes.find((node) => node.label === "未払費用");
     expect(unpaidExpenseNode).toBeDefined();


### PR DESCRIPTION
## Summary
This PR adds financial year filtering to the `getCurrentLiabilities` method across the balance sheet repository and related use cases. Previously, the method retrieved liabilities for all periods; now it filters results by a specific financial year.

## Key Changes
- **Repository Interface & Implementation**: Updated `IBalanceSheetRepository.getCurrentLiabilities()` to accept a `financialYear` parameter and modified `PrismaBalanceSheetRepository` to filter transactions by financial year in both debit and credit aggregations
- **Use Cases**: Updated `GetBalanceSheetUsecase` and `GetSankeyAggregationUsecase` to pass the financial year parameter when calling `getCurrentLiabilities()`
- **Data Loading**: Modified `loadTopPageData` to pass the financial year parameter to the balance sheet use case
- **Tests**: Updated all test cases to include the `financialYear` parameter in use case executions and mock assertions

## Implementation Details
- The financial year parameter is now required in `GetBalanceSheetParams` interface
- The `PrismaBalanceSheetRepository` now includes `financialYear` in the `where` clause for both debit and credit transaction aggregations
- Organization IDs are converted to `BigInt` once and reused to avoid redundant conversions
- Updated JSDoc comment to reflect that liabilities are now retrieved for a specific financial year rather than all periods

https://claude.ai/code/session_01YSQrWsEXQJdVjeTpH7xx7z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 貸借対照表と負債データを指定した会計年度で取得できるようになりました。ユーザーが選んだ会計年度に基づき、表示される貸借対照表や負債残高がその年度に沿って正しく反映されます。
  * トップページのデータ取得も選択会計年度に対応しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->