### PR TITLE
fix: トランザクション削除時にwebappのキャッシュも無効化する

### DIFF
--- a/admin/src/server/contexts/data-import/presentation/actions/bulk-delete-transactions.ts
+++ b/admin/src/server/contexts/data-import/presentation/actions/bulk-delete-transactions.ts
@@ -3,6 +3,7 @@
 import "server-only";
 import { updateTag } from "next/cache";
 import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
+import { WebappCacheInvalidator } from "@/server/contexts/shared/infrastructure/services/webapp-cache-invalidator";
 
 export async function bulkDeleteTransactionsAction(ids: string[]): Promise<{
   success: boolean;
@@ -19,6 +20,10 @@ export async function bulkDeleteTransactionsAction(ids: string[]): Promise<{
     });
 
     updateTag("transactions-data");
+    updateTag("transactions-for-csv");
+
+    const cacheInvalidator = new WebappCacheInvalidator();
+    await cacheInvalidator.invalidateWebappCache();
 
     return {
       success: true,

--- a/admin/src/server/contexts/data-import/presentation/actions/delete-all-transactions.ts
+++ b/admin/src/server/contexts/data-import/presentation/actions/delete-all-transactions.ts
@@ -4,6 +4,7 @@ import { updateTag } from "next/cache";
 import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaTransactionRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-transaction.repository";
 import { DeleteAllTransactionsUsecase } from "@/server/contexts/data-import/application/usecases/delete-all-transactions-usecase";
+import { WebappCacheInvalidator } from "@/server/contexts/shared/infrastructure/services/webapp-cache-invalidator";
 
 export async function deleteAllTransactionsAction(organizationId?: string): Promise<{
   success: boolean;
@@ -18,6 +19,10 @@ export async function deleteAllTransactionsAction(organizationId?: string): Prom
 
     // データキャッシュを無効化してトランザクション一覧を更新
     updateTag("transactions-data");
+    updateTag("transactions-for-csv");
+
+    const cacheInvalidator = new WebappCacheInvalidator();
+    await cacheInvalidator.invalidateWebappCache();
 
     return {
       success: true,

--- a/admin/src/server/contexts/data-import/presentation/actions/delete-transaction.ts
+++ b/admin/src/server/contexts/data-import/presentation/actions/delete-transaction.ts
@@ -3,6 +3,7 @@
 import { updateTag } from "next/cache";
 import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaTransactionRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-transaction.repository";
+import { WebappCacheInvalidator } from "@/server/contexts/shared/infrastructure/services/webapp-cache-invalidator";
 
 export async function deleteTransactionAction(id: string): Promise<{
   success: boolean;
@@ -13,6 +14,10 @@ export async function deleteTransactionAction(id: string): Promise<{
     await repository.delete(id);
 
     updateTag("transactions-data");
+    updateTag("transactions-for-csv");
+
+    const cacheInvalidator = new WebappCacheInvalidator();
+    await cacheInvalidator.invalidateWebappCache();
 
     return { success: true };
   } catch (error) {


### PR DESCRIPTION
## Summary
- adminでトランザクションを削除した際、webappのキャッシュが無効化されず、削除済み・付け替え済みのデータがCSVダウンロードに残り続けるバグを修正
- 個別削除・一括削除・全削除の3つのアクションに `WebappCacheInvalidator` と `transactions-for-csv` タグの無効化を追加

## 原因
削除アクションは `updateTag("transactions-data")` でadmin側のキャッシュのみ更新していたが、webapp側の `/api/refresh` エンドポイントを呼んでいなかった。そのため、webappのCSVデータ（TTL: 本番3600秒）が古いまま配信され続けていた。

## Test plan
- [ ] adminでトランザクションを削除後、webappのCSVダウンロードに削除済みデータが含まれないことを確認
- [ ] adminでトランザクションを一括削除後、同様にCSVが更新されることを確認
- [ ] 収支の流れ（Sankeyチャート）とCSVの表示が一致することを確認

https://claude.ai/code/session_01JQuF55Xftnq17owLLeDgk9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * トランザクション削除操作（単一、全削除、一括削除）のキャッシュ無効化を改善しました。削除後のデータ表示がより迅速に更新されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->