### PR TITLE
fix: unstable_cacheにtags未指定でキャッシュクリアが効かない問題を修正

### DIFF
--- a/webapp/src/app/api/refresh/route.ts
+++ b/webapp/src/app/api/refresh/route.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { revalidatePath, revalidateTag } from "next/cache";
+import { revalidateTag } from "next/cache";
 import { type NextRequest, NextResponse } from "next/server";
 
 export async function POST(request: NextRequest) {
@@ -20,9 +20,7 @@ export async function POST(request: NextRequest) {
     revalidateTag("transactions-page-data", "max");
     revalidateTag("transactions-for-csv", "max");
     revalidateTag("top-page-data", "max");
-
-    revalidatePath("/transactions");
-    revalidatePath("/");
+    revalidateTag("organizations", "max");
 
     return NextResponse.json({
       success: true,

--- a/webapp/src/server/contexts/public-finance/presentation/loaders/load-organizations.ts
+++ b/webapp/src/server/contexts/public-finance/presentation/loaders/load-organizations.ts
@@ -15,5 +15,6 @@ export const loadOrganizations = unstable_cache(
   ["organizations"],
   {
     revalidate: CACHE_REVALIDATE_SECONDS,
+    tags: ["organizations"],
   },
 );

--- a/webapp/src/server/contexts/public-finance/presentation/loaders/load-top-page-data.ts
+++ b/webapp/src/server/contexts/public-finance/presentation/loaders/load-top-page-data.ts
@@ -98,5 +98,5 @@ export const loadTopPageData = unstable_cache(
     };
   },
   ["top-page-data"],
-  { revalidate: CACHE_REVALIDATE_SECONDS },
+  { revalidate: CACHE_REVALIDATE_SECONDS, tags: ["top-page-data"] },
 );

--- a/webapp/src/server/contexts/public-finance/presentation/loaders/load-transactions-page-data.ts
+++ b/webapp/src/server/contexts/public-finance/presentation/loaders/load-transactions-page-data.ts
@@ -25,6 +25,6 @@ export const loadTransactionsPageData = (params: GetTransactionsBySlugParams) =>
       return await usecase.execute(params);
     },
     cacheKey,
-    { revalidate: CACHE_REVALIDATE_SECONDS },
+    { revalidate: CACHE_REVALIDATE_SECONDS, tags: ["transactions-page-data"] },
   )();
 };


### PR DESCRIPTION
## 目的

管理画面から「ウェブアプリのキャッシュをクリア」ボタンを押しても、webappのキャッシュが更新されない問題を解消するため。

## 原因

`unstable_cache` の第3引数で `tags` オプションが指定されていなかったため、`revalidateTag()` でキャッシュを無効化できなかった。
cache key と tag は別物であり、`revalidateTag()` は明示的に `tags` に登録されたタグのみを対象とする。

## 変更内容

- `loadTransactionsPageData` に `tags: ["transactions-page-data"]` を追加
- `loadTopPageData` に `tags: ["top-page-data"]` を追加
- `loadOrganizations` に `tags: ["organizations"]` を追加
- `/api/refresh` エンドポイントに `organizations` タグの invalidate を追加
- 不要な `revalidatePath` の呼び出しと import を削除

※ `loadTransactionsForCsv` は元々 `tags: ["transactions-for-csv"]` が設定済みだったため変更なし。

## テスト計画

- [ ] CI通過を確認
- [ ] Vercel Preview環境でCSVアップロード後にキャッシュクリアボタンを押して、webappのデータが更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)