### PR TITLE
経常経費のXMLエクスポート閾値を10万円から5万円に変更

### DIFF
--- a/admin/src/client/components/counterpart-assignment/CounterpartAssignmentFilters.tsx
+++ b/admin/src/client/components/counterpart-assignment/CounterpartAssignmentFilters.tsx
@@ -135,7 +135,7 @@ export function CounterpartAssignmentFilters({
                     </ul>
                   </div>
                   <div className="space-y-1">
-                    <p className="font-medium">【経常経費】10万円以上</p>
+                    <p className="font-medium">【経常経費】5万円以上</p>
                     <ul className="list-disc list-inside text-xs">
                       <li>光熱水費</li>
                       <li>備品・消耗品費</li>

--- a/admin/src/client/components/export-report/sections/RegularExpenseSection.tsx
+++ b/admin/src/client/components/export-report/sections/RegularExpenseSection.tsx
@@ -35,7 +35,7 @@ interface ExpenseTableProps {
 
 function ExpenseTable({ rows }: ExpenseTableProps) {
   if (rows.length === 0) {
-    return <p className="text-gray-500 text-sm">10万円以上の明細はありません</p>;
+    return <p className="text-gray-500 text-sm">5万円以上の明細はありません</p>;
   }
 
   return (

--- a/admin/src/client/components/export-report/sections/SectionWrapper.tsx
+++ b/admin/src/client/components/export-report/sections/SectionWrapper.tsx
@@ -19,7 +19,7 @@ export function SectionWrapper({
   formId,
   totalAmount,
   underThresholdAmount,
-  thresholdLabel = "10万円未満の合計",
+  thresholdLabel = "5万円未満の合計",
   isEmpty = false,
   children,
 }: SectionWrapperProps) {

--- a/admin/src/server/contexts/report/domain/models/counterpart-assignment-rules.ts
+++ b/admin/src/server/contexts/report/domain/models/counterpart-assignment-rules.ts
@@ -22,7 +22,7 @@ export const COUNTERPART_REQUIRED_INCOME_CATEGORIES = [
 ] as const;
 
 /**
- * 経常経費カテゴリ（SYUUSHI07_14）- 閾値10万円
+ * 経常経費カテゴリ（SYUUSHI07_14）- 閾値5万円
  */
 export const ROUTINE_EXPENSE_CATEGORIES = [
   // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
@@ -79,11 +79,11 @@ type CounterpartRequiredExpenseCategory = (typeof COUNTERPART_REQUIRED_EXPENSE_C
  * 支払先の氏名・住所を明細に記載する必要があります。
  *
  * 参考: docs/report_format.md
- * - 経常経費（SYUUSHI07_14）: 10万円以上
+ * - 経常経費（SYUUSHI07_14）: 5万円以上
  * - 政治活動費（SYUUSHI07_15）: 5万円以上
  * - 収入（借入金・交付金）: 閾値なし（すべて記載）
  */
-export const ROUTINE_EXPENSE_THRESHOLD = 100_000;
+export const ROUTINE_EXPENSE_THRESHOLD = 50_000;
 export const POLITICAL_ACTIVITY_EXPENSE_THRESHOLD = 50_000;
 
 /**
@@ -148,8 +148,8 @@ function getThresholdForCategory(categoryKey: string): number {
  *
  * @example
  * ```typescript
- * isAboveDetailThreshold('expense_office_expenses', 150_000) // true（経常経費、10万円以上）
- * isAboveDetailThreshold('expense_office_expenses', 50_000)  // false（経常経費、10万円未満）
+ * isAboveDetailThreshold('expense_office_expenses', 150_000) // true（経常経費、5万円以上）
+ * isAboveDetailThreshold('expense_office_expenses', 50_000)  // true（経常経費、5万円以上）
  * isAboveDetailThreshold('expense_organization_activities', 50_000) // true（政治活動費、5万円以上）
  * ```
  */
@@ -173,7 +173,7 @@ export function isAboveDetailThreshold(categoryKey: string, amount: number): boo
  * @example
  * ```typescript
  * requiresCounterpartDetail('expense', 'expense_office_expenses', 150_000) // true
- * requiresCounterpartDetail('expense', 'expense_office_expenses', 50_000)  // false（閾値未満）
+ * requiresCounterpartDetail('expense', 'expense_office_expenses', 50_000)  // true（閾値以上）
  * requiresCounterpartDetail('income', 'income_donation_individual', 150_000) // false（寄附は対象外）
  * ```
  */

--- a/admin/src/server/contexts/report/domain/models/expense-transaction.ts
+++ b/admin/src/server/contexts/report/domain/models/expense-transaction.ts
@@ -10,7 +10,6 @@ import {
   sanitizeText,
   buildBikou,
   isAboveThreshold,
-  TEN_MAN_THRESHOLD,
   FIVE_MAN_THRESHOLD,
 } from "@/server/contexts/report/domain/models/transaction-utils";
 import {
@@ -125,7 +124,7 @@ export interface ExpenseRow {
  */
 export interface UtilityExpenseSection {
   totalAmount: number;
-  underThresholdAmount: number; // その他の支出（10万円未満）
+  underThresholdAmount: number; // その他の支出（5万円未満）
   rows: ExpenseRow[];
 }
 
@@ -134,7 +133,7 @@ export interface UtilityExpenseSection {
  */
 export interface SuppliesExpenseSection {
   totalAmount: number;
-  underThresholdAmount: number; // その他の支出（10万円未満）
+  underThresholdAmount: number; // その他の支出（5万円未満）
   rows: ExpenseRow[];
 }
 
@@ -143,7 +142,7 @@ export interface SuppliesExpenseSection {
  */
 export interface OfficeExpenseSection {
   totalAmount: number;
-  underThresholdAmount: number; // その他の支出（10万円未満）
+  underThresholdAmount: number; // その他の支出（5万円未満）
   rows: ExpenseRow[];
 }
 
@@ -295,10 +294,10 @@ const ExpenseTransactionBase = {
   },
 
   /**
-   * 閾値（10万円）以上かどうかを判定
+   * 閾値（5万円）以上かどうかを判定
    */
   isAboveThreshold: (tx: BaseExpenseTransaction): boolean => {
-    return isAboveThreshold(ExpenseTransactionBase.resolveAmount(tx), TEN_MAN_THRESHOLD);
+    return isAboveThreshold(ExpenseTransactionBase.resolveAmount(tx), FIVE_MAN_THRESHOLD);
   },
 
   /**
@@ -493,8 +492,8 @@ export const UtilityExpenseSection = {
    * トランザクションリストからセクションを構築する
    *
    * Business rules:
-   * - Transactions >= 100,000 yen are listed individually
-   * - Transactions < 100,000 yen are aggregated into underThresholdAmount
+   * - Transactions >= 50,000 yen are listed individually
+   * - Transactions < 50,000 yen are aggregated into underThresholdAmount
    */
   fromTransactions: (transactions: UtilityExpenseTransaction[]): UtilityExpenseSection => {
     return aggregateExpenseSection(transactions);
@@ -523,8 +522,8 @@ export const SuppliesExpenseSection = {
    * トランザクションリストからセクションを構築する
    *
    * Business rules:
-   * - Transactions >= 100,000 yen are listed individually
-   * - Transactions < 100,000 yen are aggregated into underThresholdAmount
+   * - Transactions >= 50,000 yen are listed individually
+   * - Transactions < 50,000 yen are aggregated into underThresholdAmount
    */
   fromTransactions: (transactions: SuppliesExpenseTransaction[]): SuppliesExpenseSection => {
     return aggregateExpenseSection(transactions);
@@ -553,8 +552,8 @@ export const OfficeExpenseSection = {
    * トランザクションリストからセクションを構築する
    *
    * Business rules:
-   * - Transactions >= 100,000 yen are listed individually
-   * - Transactions < 100,000 yen are aggregated into underThresholdAmount
+   * - Transactions >= 50,000 yen are listed individually
+   * - Transactions < 50,000 yen are aggregated into underThresholdAmount
    */
   fromTransactions: (transactions: OfficeExpenseTransaction[]): OfficeExpenseSection => {
     return aggregateExpenseSection(transactions);

--- a/admin/src/server/contexts/report/domain/models/transaction-utils.ts
+++ b/admin/src/server/contexts/report/domain/models/transaction-utils.ts
@@ -43,7 +43,7 @@ export function sanitizeText(value: string | null | undefined, maxLength?: numbe
 }
 
 /**
- * 10万円の閾値（政治資金報告書における明細記載基準：経常経費用）
+ * 10万円の閾値（政治資金報告書における明細記載基準：その他の収入用）
  */
 export const TEN_MAN_THRESHOLD = 100_000;
 

--- a/admin/src/server/contexts/report/domain/models/transaction-with-counterpart.ts
+++ b/admin/src/server/contexts/report/domain/models/transaction-with-counterpart.ts
@@ -18,7 +18,7 @@ export interface TransactionWithCounterpart {
     name: string;
     address: string | null;
   } | null;
-  /** 取引先情報の記載が必要（閾値以上かつ対象カテゴリ）かどうか。閾値は経常経費10万円、政治活動費5万円 */
+  /** 取引先情報の記載が必要（閾値以上かつ対象カテゴリ）かどうか。閾値は経常経費5万円、政治活動費5万円 */
   requiresCounterpart: boolean;
   /** 交付金に係る支出かどうか */
   isGrantExpenditure: boolean;

--- a/admin/src/server/contexts/report/infrastructure/repositories/prisma-report-transaction.repository.ts
+++ b/admin/src/server/contexts/report/infrastructure/repositories/prisma-report-transaction.repository.ts
@@ -752,10 +752,10 @@ export class PrismaReportTransactionRepository implements IReportTransactionRepo
     }
 
     if (requiresCounterpartOnly) {
-      // 経常経費は10万円以上、政治活動費は5万円以上、収入は閾値なし（すべて記載）
+      // 経常経費は5万円以上、政治活動費は5万円以上、収入は閾値なし（すべて記載）
       conditions.push({
         OR: [
-          // 経常経費: 10万円以上
+          // 経常経費: 5万円以上
           {
             categoryKey: { in: [...ROUTINE_EXPENSE_CATEGORIES] },
             debitAmount: { gte: ROUTINE_EXPENSE_THRESHOLD },

--- a/admin/tests/server/contexts/report/application/services/expense-assembler.test.ts
+++ b/admin/tests/server/contexts/report/application/services/expense-assembler.test.ts
@@ -12,7 +12,7 @@ import type { UtilityExpenseTransaction } from "@/server/contexts/report/domain/
  * 1. リポジトリから13種類の経費トランザクションを並列取得
  * 2. 取得したトランザクションを各ドメインモデルに委譲してセクションを構築
  *
- * 注: 閾値ロジック（10万円/5万円）や金額計算はドメインモデルの責務であり、
+ * 注: 閾値ロジック（5万円）や金額計算はドメインモデルの責務であり、
  * expense-transaction.test.ts でテスト済み
  */
 describe("ExpenseAssembler", () => {

--- a/admin/tests/server/contexts/report/domain/models/counterpart-assignment-rules.test.ts
+++ b/admin/tests/server/contexts/report/domain/models/counterpart-assignment-rules.test.ts
@@ -59,8 +59,8 @@ describe("counterpart-assignment-rules", () => {
   });
 
   describe("閾値定数", () => {
-    it("経常経費の閾値は10万円（100,000円）である", () => {
-      expect(ROUTINE_EXPENSE_THRESHOLD).toBe(100_000);
+    it("経常経費の閾値は5万円（50,000円）である", () => {
+      expect(ROUTINE_EXPENSE_THRESHOLD).toBe(50_000);
     });
 
     it("政治活動費の閾値は5万円（50,000円）である", () => {
@@ -144,19 +144,20 @@ describe("counterpart-assignment-rules", () => {
   });
 
   describe("isAboveDetailThreshold", () => {
-    describe("経常経費カテゴリ（10万円閾値）", () => {
+    describe("経常経費カテゴリ（5万円閾値）", () => {
       // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
       const routineCategory = PL_CATEGORIES["事務所費"].key;
 
-      it("10万円以上でtrue", () => {
+      it("5万円以上でtrue", () => {
+        expect(isAboveDetailThreshold(routineCategory, 50_000)).toBe(true);
         expect(isAboveDetailThreshold(routineCategory, 100_000)).toBe(true);
         expect(isAboveDetailThreshold(routineCategory, 150_000)).toBe(true);
         expect(isAboveDetailThreshold(routineCategory, 1_000_000)).toBe(true);
       });
 
-      it("10万円未満でfalse", () => {
-        expect(isAboveDetailThreshold(routineCategory, 99_999)).toBe(false);
-        expect(isAboveDetailThreshold(routineCategory, 50_000)).toBe(false);
+      it("5万円未満でfalse", () => {
+        expect(isAboveDetailThreshold(routineCategory, 49_999)).toBe(false);
+        expect(isAboveDetailThreshold(routineCategory, 10_000)).toBe(false);
         expect(isAboveDetailThreshold(routineCategory, 0)).toBe(false);
       });
     });
@@ -191,19 +192,19 @@ describe("counterpart-assignment-rules", () => {
   });
 
   describe("requiresCounterpartDetail", () => {
-    describe("経常経費（10万円閾値）", () => {
-      it("10万円以上でtrue", () => {
+    describe("経常経費（5万円閾値）", () => {
+      it("5万円以上でtrue", () => {
         // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
-        expect(requiresCounterpartDetail("expense", PL_CATEGORIES["事務所費"].key, 100_000)).toBe(true);
+        expect(requiresCounterpartDetail("expense", PL_CATEGORIES["事務所費"].key, 50_000)).toBe(true);
         // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
         expect(requiresCounterpartDetail("expense", PL_CATEGORIES["光熱水費"].key, 150_000)).toBe(true);
       });
 
-      it("10万円未満でfalse", () => {
+      it("5万円未満でfalse", () => {
         // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
-        expect(requiresCounterpartDetail("expense", PL_CATEGORIES["事務所費"].key, 99_999)).toBe(false);
+        expect(requiresCounterpartDetail("expense", PL_CATEGORIES["事務所費"].key, 49_999)).toBe(false);
         // biome-ignore lint/complexity/useLiteralKeys: 日本語キー
-        expect(requiresCounterpartDetail("expense", PL_CATEGORIES["光熱水費"].key, 50_000)).toBe(false);
+        expect(requiresCounterpartDetail("expense", PL_CATEGORIES["光熱水費"].key, 10_000)).toBe(false);
       });
     });
 

--- a/admin/tests/server/contexts/report/domain/models/expense-transaction.test.ts
+++ b/admin/tests/server/contexts/report/domain/models/expense-transaction.test.ts
@@ -54,7 +54,7 @@ describe("UtilityExpenseSection.fromTransactions", () => {
     });
   });
 
-  it("separates transactions by 100,000 yen threshold", () => {
+  it("separates transactions by 50,000 yen threshold", () => {
     const transactions: UtilityExpenseTransaction[] = [
       createUtilityTransaction({
         transactionNo: "1",
@@ -70,64 +70,65 @@ describe("UtilityExpenseSection.fromTransactions", () => {
       }),
       createUtilityTransaction({
         transactionNo: "4",
-        debitAmount: 99999,
+        debitAmount: 49999,
       }),
     ];
 
     const result = UtilityExpenseSection.fromTransactions(transactions);
 
     // Total includes all transactions
-    expect(result.totalAmount).toBe(399999);
-    // Only < 100,000 in underThreshold
-    expect(result.underThresholdAmount).toBe(149999); // 50000 + 99999
-    // Only >= 100,000 in rows
-    expect(result.rows).toHaveLength(2);
+    expect(result.totalAmount).toBe(349999);
+    // Only < 50,000 in underThreshold
+    expect(result.underThresholdAmount).toBe(49999);
+    // Only >= 50,000 in rows
+    expect(result.rows).toHaveLength(3);
     expect(result.rows[0].kingaku).toBe(150000);
-    expect(result.rows[1].kingaku).toBe(100000);
+    expect(result.rows[1].kingaku).toBe(50000);
+    expect(result.rows[2].kingaku).toBe(100000);
   });
 
   it("rounds decimal amounts consistently in all fields", () => {
     const transactions: UtilityExpenseTransaction[] = [
       createUtilityTransaction({
         transactionNo: "1",
-        debitAmount: 100000.5, // Rounds to 100001
+        debitAmount: 50000.5, // Rounds to 50001
       }),
       createUtilityTransaction({
         transactionNo: "2",
-        debitAmount: 100000.4, // Rounds to 100000
+        debitAmount: 50000.4, // Rounds to 50000
       }),
       createUtilityTransaction({
         transactionNo: "3",
-        debitAmount: 100000.3, // Rounds to 100000
+        debitAmount: 50000.3, // Rounds to 50000
       }),
     ];
 
     const result = UtilityExpenseSection.fromTransactions(transactions);
 
     // All amounts should be rounded
-    expect(result.totalAmount).toBe(300001); // 100001 + 100000 + 100000
+    expect(result.totalAmount).toBe(150001); // 50001 + 50000 + 50000
     expect(result.underThresholdAmount).toBe(0);
     expect(result.rows).toHaveLength(3);
 
     // Sum of kingaku should equal totalAmount
     const kingakuSum = result.rows.reduce((sum, row) => sum + row.kingaku, 0);
     expect(kingakuSum).toBe(result.totalAmount);
-    expect(kingakuSum).toBe(300001);
+    expect(kingakuSum).toBe(150001);
 
-    expect(result.rows[0].kingaku).toBe(100001);
-    expect(result.rows[1].kingaku).toBe(100000);
-    expect(result.rows[2].kingaku).toBe(100000);
+    expect(result.rows[0].kingaku).toBe(50001);
+    expect(result.rows[1].kingaku).toBe(50000);
+    expect(result.rows[2].kingaku).toBe(50000);
   });
 
   it("rounds decimal amounts with under-threshold transactions", () => {
     const transactions: UtilityExpenseTransaction[] = [
       createUtilityTransaction({
         transactionNo: "1",
-        debitAmount: 100000.5, // Rounds to 100001 (above threshold)
+        debitAmount: 50000.5, // Rounds to 50001 (above threshold)
       }),
       createUtilityTransaction({
         transactionNo: "2",
-        debitAmount: 50000.6, // Rounds to 50001 (under threshold)
+        debitAmount: 49999.6, // Rounds to 50000 (above threshold)
       }),
       createUtilityTransaction({
         transactionNo: "3",
@@ -137,9 +138,9 @@ describe("UtilityExpenseSection.fromTransactions", () => {
 
     const result = UtilityExpenseSection.fromTransactions(transactions);
 
-    expect(result.totalAmount).toBe(180002); // 100001 + 50001 + 30000
-    expect(result.underThresholdAmount).toBe(80001); // 50001 + 30000
-    expect(result.rows).toHaveLength(1);
+    expect(result.totalAmount).toBe(130001); // 50001 + 50000 + 30000
+    expect(result.underThresholdAmount).toBe(30000);
+    expect(result.rows).toHaveLength(2);
 
     // Sum of kingaku + underThresholdAmount should equal totalAmount
     const kingakuSum = result.rows.reduce((sum, row) => sum + row.kingaku, 0);
@@ -170,14 +171,14 @@ describe("SuppliesExpenseSection.fromTransactions", () => {
       }),
       createSuppliesTransaction({
         transactionNo: "2",
-        debitAmount: 75000.25,
+        debitAmount: 30000.25,
       }),
     ];
 
     const result = SuppliesExpenseSection.fromTransactions(transactions);
 
-    expect(result.totalAmount).toBe(225001); // 150001 + 75000
-    expect(result.underThresholdAmount).toBe(75000);
+    expect(result.totalAmount).toBe(180001); // 150001 + 30000
+    expect(result.underThresholdAmount).toBe(30000);
     expect(result.rows).toHaveLength(1);
     expect(result.rows[0].kingaku).toBe(150001);
 
@@ -209,14 +210,14 @@ describe("OfficeExpenseSection.fromTransactions", () => {
       }),
       createOfficeTransaction({
         transactionNo: "2",
-        debitAmount: 80000.51, // Rounds to 80001
+        debitAmount: 30000.51, // Rounds to 30001
       }),
     ];
 
     const result = OfficeExpenseSection.fromTransactions(transactions);
 
-    expect(result.totalAmount).toBe(200001); // 120000 + 80001
-    expect(result.underThresholdAmount).toBe(80001);
+    expect(result.totalAmount).toBe(150001); // 120000 + 30001
+    expect(result.underThresholdAmount).toBe(30001);
     expect(result.rows).toHaveLength(1);
     expect(result.rows[0].kingaku).toBe(120000);
 


### PR DESCRIPTION
## Summary
- 経常経費の明細記載閾値を10万円から5万円に変更し、政治活動費と同じ基準に統一
- 定数値（`ROUTINE_EXPENSE_THRESHOLD`, `FIVE_MAN_THRESHOLD`使用箇所）、ドメインロジック、UIラベル、コメント、テストを全て整合性をもって更新
- その他の収入（`TEN_MAN_THRESHOLD`）や政治活動費の閾値は変更なし

## 変更箇所
- `counterpart-assignment-rules.ts`: `ROUTINE_EXPENSE_THRESHOLD` を `100_000` → `50_000`
- `expense-transaction.ts`: `ExpenseTransactionBase.isAboveThreshold` が `FIVE_MAN_THRESHOLD` を使用するよう変更
- `SectionWrapper.tsx`: デフォルトラベル「10万円未満の合計」→「5万円未満の合計」
- `RegularExpenseSection.tsx`: 空状態メッセージ「10万円以上」→「5万円以上」
- `CounterpartAssignmentFilters.tsx`: フィルタ説明文の更新
- `prisma-report-transaction.repository.ts`: コメント更新（定数経由で自動反映）
- 関連テストファイル: 閾値に依存するテストケースを5万円基準に更新

## Test plan
- [x] expense-transaction テスト通過
- [x] counterpart-assignment-rules テスト通過
- [x] transaction-utils テスト通過
- [x] expense-assembler テスト通過
- [x] income-assembler テスト通過（変更なし・影響なしを確認）
- [x] 全テスト（admin 790件 + webapp 115件）通過
- [x] 型チェック・lint・knip・depcruise 全パス

https://claude.ai/code/session_01DMPGfrNeAmEimm9tHf1q86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

**修正**

* 経常経費の詳細表示閾値を100,000円から50,000円に変更しました。
* 50,000円以上の経常経費がレポートで個別に表示されるようになります。
* 取引先情報が必要とされるライン項目の閾値も同様に更新されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->