### PR TITLE
feat: カテゴリーフィルタ時に合計金額を表示

### DIFF
--- a/webapp/src/app/o/[slug]/[year]/transactions/page.tsx
+++ b/webapp/src/app/o/[slug]/[year]/transactions/page.tsx
@@ -136,6 +136,7 @@ export default async function TransactionsPage({ params, searchParams }: Transac
               perPage={data.perPage}
               totalPages={data.totalPages}
               selectedCategories={categories}
+              filteredSummary={data.filteredSummary}
             />
           </MainColumnCard>
 

--- a/webapp/src/client/components/top-page/features/transactions-table/InteractiveTransactionTable.tsx
+++ b/webapp/src/client/components/top-page/features/transactions-table/InteractiveTransactionTable.tsx
@@ -3,6 +3,7 @@ import "client-only";
 
 import { useRouter, useSearchParams } from "next/navigation";
 import type { DisplayTransaction } from "@/server/contexts/public-finance/domain/models/display-transaction";
+import type { AmountSummary } from "@/server/contexts/public-finance/domain/repositories/transaction-list-repository.interface";
 import TransactionTable from "./TransactionTable";
 import TransactionTableMobileHeader, { type SortOption } from "./TransactionTableMobileHeader";
 import PCPaginator from "./PCPaginator";
@@ -33,7 +34,12 @@ interface InteractiveTransactionTableProps {
   perPage: number;
   totalPages: number;
   selectedCategories?: string[];
+  filteredSummary?: AmountSummary;
 }
+
+const formatAmount = (amount: number): string => {
+  return amount.toLocaleString("ja-JP");
+};
 
 export default function InteractiveTransactionTable({
   slug,
@@ -44,6 +50,7 @@ export default function InteractiveTransactionTable({
   perPage,
   totalPages,
   selectedCategories,
+  filteredSummary,
 }: InteractiveTransactionTableProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -135,6 +142,22 @@ export default function InteractiveTransactionTable({
           currentSort={getCurrentSortOption()}
         />
       </div>
+
+      {filteredSummary && (
+        <div className="flex items-center gap-4 px-4 py-3 bg-[#F8FAFB] rounded-lg mb-2 text-sm">
+          <span className="text-[#6A7383] font-medium">フィルタ結果:</span>
+          {filteredSummary.incomeTotal > 0 && (
+            <span className="text-[#238778] font-bold">
+              収入合計 +{formatAmount(filteredSummary.incomeTotal)}円
+            </span>
+          )}
+          {filteredSummary.expenseTotal > 0 && (
+            <span className="text-[#C4320A] font-bold">
+              支出合計 -{formatAmount(filteredSummary.expenseTotal)}円
+            </span>
+          )}
+        </div>
+      )}
 
       <TransactionTable
         transactions={transactions}

--- a/webapp/src/client/components/top-page/features/transactions-table/InteractiveTransactionTable.tsx
+++ b/webapp/src/client/components/top-page/features/transactions-table/InteractiveTransactionTable.tsx
@@ -3,7 +3,7 @@ import "client-only";
 
 import { useRouter, useSearchParams } from "next/navigation";
 import type { DisplayTransaction } from "@/server/contexts/public-finance/domain/models/display-transaction";
-import type { AmountSummary } from "@/server/contexts/public-finance/domain/repositories/transaction-list-repository.interface";
+import type { AmountSummary } from "@/types/amount-summary";
 import TransactionTable from "./TransactionTable";
 import TransactionTableMobileHeader, { type SortOption } from "./TransactionTableMobileHeader";
 import PCPaginator from "./PCPaginator";

--- a/webapp/src/server/contexts/public-finance/application/usecases/get-transactions-by-slug-usecase.ts
+++ b/webapp/src/server/contexts/public-finance/application/usecases/get-transactions-by-slug-usecase.ts
@@ -9,6 +9,7 @@ import type {
 import { convertToDisplayTransactions } from "@/server/contexts/public-finance/domain/models/display-transaction";
 import type { IPoliticalOrganizationRepository } from "@/server/contexts/public-finance/domain/repositories/political-organization-repository.interface";
 import type {
+  AmountSummary,
   ITransactionListRepository,
   PaginationOptions,
 } from "@/server/contexts/public-finance/domain/repositories/transaction-list-repository.interface";
@@ -34,6 +35,7 @@ interface GetTransactionsBySlugResult {
   totalPages: number;
   politicalOrganizations: PoliticalOrganization[];
   lastUpdatedAt: string | null;
+  filteredSummary?: AmountSummary;
 }
 
 export class GetTransactionsBySlugUsecase {
@@ -83,9 +85,14 @@ export class GetTransactionsBySlugUsecase {
         order: params.order,
       };
 
-      const [transactionResult, lastUpdatedAt] = await Promise.all([
+      const hasFilters = filters.category_keys && filters.category_keys.length > 0;
+
+      const [transactionResult, lastUpdatedAt, filteredSummary] = await Promise.all([
         this.transactionRepository.findWithPagination(filters, pagination),
         this.transactionRepository.getLastUpdatedAt(),
+        hasFilters
+          ? this.transactionRepository.getAmountSummary(filters)
+          : Promise.resolve(undefined),
       ]);
 
       const transactions = convertToDisplayTransactions(transactionResult.items);
@@ -100,6 +107,7 @@ export class GetTransactionsBySlugUsecase {
         totalPages,
         politicalOrganizations,
         lastUpdatedAt: lastUpdatedAt?.toISOString() ?? null,
+        filteredSummary: filteredSummary || undefined,
       };
     } catch (error) {
       throw new Error(

--- a/webapp/src/server/contexts/public-finance/domain/repositories/transaction-list-repository.interface.ts
+++ b/webapp/src/server/contexts/public-finance/domain/repositories/transaction-list-repository.interface.ts
@@ -1,5 +1,8 @@
 import type { Transaction } from "@/shared/models/transaction";
 import type { TransactionFilters } from "@/types/transaction-filters";
+import type { AmountSummary } from "@/types/amount-summary";
+
+export type { AmountSummary };
 
 /**
  * ページネーション結果
@@ -36,14 +39,6 @@ export interface SortOptions {
  * Interface Segregation Principle に基づき、
  * ITransactionRepository から取引一覧取得機能を分離したインターフェース。
  */
-/**
- * フィルタ後の金額集計結果
- */
-export interface AmountSummary {
-  incomeTotal: number;
-  expenseTotal: number;
-}
-
 export interface ITransactionListRepository {
   /**
    * フィルター条件とページネーションオプションに基づいて取引を取得する

--- a/webapp/src/server/contexts/public-finance/domain/repositories/transaction-list-repository.interface.ts
+++ b/webapp/src/server/contexts/public-finance/domain/repositories/transaction-list-repository.interface.ts
@@ -36,6 +36,14 @@ export interface SortOptions {
  * Interface Segregation Principle に基づき、
  * ITransactionRepository から取引一覧取得機能を分離したインターフェース。
  */
+/**
+ * フィルタ後の金額集計結果
+ */
+export interface AmountSummary {
+  incomeTotal: number;
+  expenseTotal: number;
+}
+
 export interface ITransactionListRepository {
   /**
    * フィルター条件とページネーションオプションに基づいて取引を取得する
@@ -61,4 +69,11 @@ export interface ITransactionListRepository {
    * @returns 最終更新日時（存在しない場合はnull）
    */
   getLastUpdatedAt(): Promise<Date | null>;
+
+  /**
+   * フィルター条件に合致する取引の収入合計・支出合計を取得する
+   * @param filters フィルター条件
+   * @returns 収入合計・支出合計
+   */
+  getAmountSummary(filters: TransactionFilters): Promise<AmountSummary>;
 }

--- a/webapp/src/server/contexts/public-finance/infrastructure/repositories/prisma-transaction.repository.ts
+++ b/webapp/src/server/contexts/public-finance/infrastructure/repositories/prisma-transaction.repository.ts
@@ -11,7 +11,10 @@ import type {
   SankeyCategoryAggregationResult,
   TransactionCategoryAggregation,
 } from "@/server/contexts/public-finance/domain/repositories/transaction-repository.interface";
-import type { ITransactionListRepository } from "@/server/contexts/public-finance/domain/repositories/transaction-list-repository.interface";
+import type {
+  AmountSummary,
+  ITransactionListRepository,
+} from "@/server/contexts/public-finance/domain/repositories/transaction-list-repository.interface";
 
 export class PrismaTransactionRepository
   implements ITransactionRepository, ITransactionListRepository
@@ -191,6 +194,26 @@ export class PrismaTransactionRepository
 
     const updatedAt = result._max.updatedAt;
     return updatedAt ? new Date(updatedAt) : null;
+  }
+
+  async getAmountSummary(filters: TransactionFilters): Promise<AmountSummary> {
+    const baseWhere = this.buildWhereClause(filters);
+
+    const [incomeResult, expenseResult] = await Promise.all([
+      this.prisma.transaction.aggregate({
+        where: { ...baseWhere, transactionType: "income" },
+        _sum: { creditAmount: true },
+      }),
+      this.prisma.transaction.aggregate({
+        where: { ...baseWhere, transactionType: "expense" },
+        _sum: { debitAmount: true },
+      }),
+    ]);
+
+    return {
+      incomeTotal: Number(incomeResult._sum.creditAmount || 0),
+      expenseTotal: Number(expenseResult._sum.debitAmount || 0),
+    };
   }
 
   async findAllWithPoliticalOrganizationName(

--- a/webapp/src/types/amount-summary.ts
+++ b/webapp/src/types/amount-summary.ts
@@ -1,0 +1,7 @@
+/**
+ * フィルタ後の金額集計結果
+ */
+export interface AmountSummary {
+  incomeTotal: number;
+  expenseTotal: number;
+}

--- a/webapp/tests/server/contexts/public-finance/application/usecases/get-transactions-by-slug-usecase.test.ts
+++ b/webapp/tests/server/contexts/public-finance/application/usecases/get-transactions-by-slug-usecase.test.ts
@@ -27,6 +27,8 @@ const createMockTransaction = (overrides: Partial<Transaction> = {}): Transactio
 const mockTransactionRepository = {
   findWithPagination: jest.fn(),
   getLastUpdatedAt: jest.fn(),
+  findAll: jest.fn(),
+  getAmountSummary: jest.fn(),
 } as unknown as ITransactionListRepository;
 
 const mockPoliticalOrganizationRepository = {

--- a/webapp/tests/server/contexts/public-finance/application/usecases/get-transactions-by-slug-usecase.test.ts
+++ b/webapp/tests/server/contexts/public-finance/application/usecases/get-transactions-by-slug-usecase.test.ts
@@ -267,4 +267,98 @@ describe("GetTransactionsBySlugUsecase", () => {
       expect.any(Object),
     );
   });
+
+  it("should request filtered summary when categories are specified", async () => {
+    const mockOrganizations = [{ id: "1", slug: "test-org" }];
+    const mockPaginatedResult: PaginatedResult<Transaction> = {
+      items: [],
+      total: 0,
+      page: 1,
+      perPage: 50,
+      totalPages: 0,
+    };
+    const mockSummary = {
+      incomeTotal: 120000,
+      expenseTotal: 34000,
+    };
+
+    (mockPoliticalOrganizationRepository.findBySlugs as jest.Mock).mockResolvedValue(
+      mockOrganizations,
+    );
+    (mockTransactionRepository.findWithPagination as jest.Mock).mockResolvedValue(
+      mockPaginatedResult,
+    );
+    (mockTransactionRepository.getLastUpdatedAt as jest.Mock).mockResolvedValue(null);
+    (mockTransactionRepository.getAmountSummary as jest.Mock).mockResolvedValue(mockSummary);
+
+    const result = await usecase.execute({
+      slugs: ["test-org"],
+      financialYear: 2025,
+      categories: ["donation-personal"],
+    });
+
+    expect(mockTransactionRepository.getAmountSummary).toHaveBeenCalledWith(
+      expect.objectContaining({
+        political_organization_ids: ["1"],
+        category_keys: ["donation-personal"],
+        financial_year: 2025,
+      }),
+    );
+    expect(result.filteredSummary).toEqual(mockSummary);
+  });
+
+  it("should not request filtered summary when categories are not specified", async () => {
+    const mockOrganizations = [{ id: "1", slug: "test-org" }];
+    const mockPaginatedResult: PaginatedResult<Transaction> = {
+      items: [],
+      total: 0,
+      page: 1,
+      perPage: 50,
+      totalPages: 0,
+    };
+
+    (mockPoliticalOrganizationRepository.findBySlugs as jest.Mock).mockResolvedValue(
+      mockOrganizations,
+    );
+    (mockTransactionRepository.findWithPagination as jest.Mock).mockResolvedValue(
+      mockPaginatedResult,
+    );
+    (mockTransactionRepository.getLastUpdatedAt as jest.Mock).mockResolvedValue(null);
+
+    const result = await usecase.execute({
+      slugs: ["test-org"],
+      financialYear: 2025,
+    });
+
+    expect(mockTransactionRepository.getAmountSummary).not.toHaveBeenCalled();
+    expect(result.filteredSummary).toBeUndefined();
+  });
+
+  it("should not request filtered summary when categories are empty", async () => {
+    const mockOrganizations = [{ id: "1", slug: "test-org" }];
+    const mockPaginatedResult: PaginatedResult<Transaction> = {
+      items: [],
+      total: 0,
+      page: 1,
+      perPage: 50,
+      totalPages: 0,
+    };
+
+    (mockPoliticalOrganizationRepository.findBySlugs as jest.Mock).mockResolvedValue(
+      mockOrganizations,
+    );
+    (mockTransactionRepository.findWithPagination as jest.Mock).mockResolvedValue(
+      mockPaginatedResult,
+    );
+    (mockTransactionRepository.getLastUpdatedAt as jest.Mock).mockResolvedValue(null);
+
+    const result = await usecase.execute({
+      slugs: ["test-org"],
+      financialYear: 2025,
+      categories: [],
+    });
+
+    expect(mockTransactionRepository.getAmountSummary).not.toHaveBeenCalled();
+    expect(result.filteredSummary).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
カテゴリーフィルタ適用時に、取引一覧の上部に収入合計・支出合計を表示するバーを追加しました。

- フィルタ未適用時はバーを非表示
- 収入のみ/支出のみのフィルタ時は該当する合計のみ表示
- 収入+支出の複合フィルタ時は両方の合計を表示

## Related Issue
Closes #248

## 変更内容

### バックエンド
- `ITransactionListRepository` に `getAmountSummary()` メソッドを追加
- `PrismaTransactionRepository` で Prisma の `aggregate` を使い、既存の `buildWhereClause()` を再利用して収入・支出を集計
- `GetTransactionsBySlugUsecase` でカテゴリーフィルタが指定されている場合のみ集計を実行し、`filteredSummary` として返却
- 依存関係ルール遵守のため `AmountSummary` 型を `webapp/src/types/amount-summary.ts` に配置

### フロントエンド
- `InteractiveTransactionTable` にフィルタ結果の合計金額バーを追加
- 既存のデザイントーンに合わせたスタイリング（収入: 緑、支出: 赤）

### テスト
- カテゴリー指定時に `getAmountSummary` が呼ばれ `filteredSummary` が返ること
- カテゴリー未指定時は呼ばれず `undefined` であること
- 空配列指定時も呼ばれず `undefined` であること

## 変更ファイル
- `webapp/src/types/amount-summary.ts` (新規)
- `webapp/src/server/contexts/public-finance/domain/repositories/transaction-list-repository.interface.ts`
- `webapp/src/server/contexts/public-finance/infrastructure/repositories/prisma-transaction.repository.ts`
- `webapp/src/server/contexts/public-finance/application/usecases/get-transactions-by-slug-usecase.ts`
- `webapp/src/app/o/[slug]/[year]/transactions/page.tsx`
- `webapp/src/client/components/top-page/features/transactions-table/InteractiveTransactionTable.tsx`
- `webapp/tests/server/contexts/public-finance/application/usecases/get-transactions-by-slug-usecase.test.ts`

## Test plan
- [x] `pnpm run typecheck` 通過
- [x] `pnpm run lint` 通過
- [x] `pnpm run test` 通過（118 tests）
- [x] `pnpm run depcruise` 依存関係チェック通過
- [x] カテゴリーフィルタで「個人寄附」を選択 → 収入合計が表示される
- [x] 収入+支出の複合フィルタ → 両方の合計が表示される
- [x] フィルタ解除 → 合計バーが非表示になる

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * トランザクション一覧にフィルター結果サマリーを追加しました。カテゴリフィルターを適用すると、フィルター条件に一致する取引の収入合計と支出合計が「フィルタ結果」として表示されるようになりました。金額は日本円形式でフォーマットされ、0より大きい項目のみが表示されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->