### PR TITLE
fix: CSV内のtransaction_no重複時にエラーメッセージを表示

### DIFF
--- a/admin/src/server/contexts/data-import/application/usecases/save-preview-transactions-usecase.ts
+++ b/admin/src/server/contexts/data-import/application/usecases/save-preview-transactions-usecase.ts
@@ -53,6 +53,17 @@ export class SavePreviewTransactionsUsecase {
       const insertTransactions = saveableTransactions.filter((t) => t.status === "insert");
       const updateTransactions = saveableTransactions.filter((t) => t.status === "update");
 
+      // CSV内で同じ transaction_no が重複していないかチェック
+      const duplicateTransactionNos = findDuplicateTransactionNos(insertTransactions);
+      if (duplicateTransactionNos.length > 0) {
+        const displayNos = duplicateTransactionNos.slice(0, 5).join(", ");
+        const suffix = duplicateTransactionNos.length > 5 ? ` 他${duplicateTransactionNos.length - 5}件` : "";
+        result.errors.push(
+          `CSV内に同じ取引No（transaction_no）が重複しています: ${displayNos}${suffix}。重複行を削除してから再度インポートしてください。`,
+        );
+        return result;
+      }
+
       let savedCount = 0;
 
       // bulk insert
@@ -90,4 +101,16 @@ export class SavePreviewTransactionsUsecase {
 
     return result;
   }
+}
+
+function findDuplicateTransactionNos(transactions: PreviewTransaction[]): string[] {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const t of transactions) {
+    if (seen.has(t.transaction_no)) {
+      duplicates.add(t.transaction_no);
+    }
+    seen.add(t.transaction_no);
+  }
+  return [...duplicates];
 }

--- a/admin/src/server/contexts/data-import/application/usecases/save-preview-transactions-usecase.ts
+++ b/admin/src/server/contexts/data-import/application/usecases/save-preview-transactions-usecase.ts
@@ -57,7 +57,8 @@ export class SavePreviewTransactionsUsecase {
       const duplicateTransactionNos = findDuplicateTransactionNos(insertTransactions);
       if (duplicateTransactionNos.length > 0) {
         const displayNos = duplicateTransactionNos.slice(0, 5).join(", ");
-        const suffix = duplicateTransactionNos.length > 5 ? ` 他${duplicateTransactionNos.length - 5}件` : "";
+        const suffix =
+          duplicateTransactionNos.length > 5 ? ` 他${duplicateTransactionNos.length - 5}件` : "";
         result.errors.push(
           `CSV内に同じ取引No（transaction_no）が重複しています: ${displayNos}${suffix}。重複行を削除してから再度インポートしてください。`,
         );

--- a/admin/src/server/contexts/data-import/application/usecases/save-preview-transactions-usecase.ts
+++ b/admin/src/server/contexts/data-import/application/usecases/save-preview-transactions-usecase.ts
@@ -53,18 +53,6 @@ export class SavePreviewTransactionsUsecase {
       const insertTransactions = saveableTransactions.filter((t) => t.status === "insert");
       const updateTransactions = saveableTransactions.filter((t) => t.status === "update");
 
-      // CSV内で同じ transaction_no が重複していないかチェック
-      const duplicateTransactionNos = findDuplicateTransactionNos(insertTransactions);
-      if (duplicateTransactionNos.length > 0) {
-        const displayNos = duplicateTransactionNos.slice(0, 5).join(", ");
-        const suffix =
-          duplicateTransactionNos.length > 5 ? ` 他${duplicateTransactionNos.length - 5}件` : "";
-        result.errors.push(
-          `CSV内に同じ取引No（transaction_no）が重複しています: ${displayNos}${suffix}。重複行を削除してから再度インポートしてください。`,
-        );
-        return result;
-      }
-
       let savedCount = 0;
 
       // bulk insert
@@ -102,16 +90,4 @@ export class SavePreviewTransactionsUsecase {
 
     return result;
   }
-}
-
-function findDuplicateTransactionNos(transactions: PreviewTransaction[]): string[] {
-  const seen = new Set<string>();
-  const duplicates = new Set<string>();
-  for (const t of transactions) {
-    if (seen.has(t.transaction_no)) {
-      duplicates.add(t.transaction_no);
-    }
-    seen.add(t.transaction_no);
-  }
-  return [...duplicates];
 }

--- a/admin/src/server/contexts/data-import/domain/services/transaction-validator.ts
+++ b/admin/src/server/contexts/data-import/domain/services/transaction-validator.ts
@@ -10,9 +10,21 @@ export class TransactionValidator {
     transactions: PreviewTransaction[],
     existingTransactions: Transaction[] = [],
   ): PreviewTransaction[] {
-    return transactions.map((transaction) =>
-      this.validateSingleTransaction(transaction, existingTransactions),
-    );
+    const duplicateNos = findDuplicateTransactionNos(transactions);
+
+    return transactions.map((transaction) => {
+      if (duplicateNos.has(transaction.transaction_no)) {
+        return {
+          ...transaction,
+          status: "invalid" as const,
+          errors: [
+            ...transaction.errors,
+            `CSV内で取引No "${transaction.transaction_no}" が重複しています`,
+          ],
+        };
+      }
+      return this.validateSingleTransaction(transaction, existingTransactions);
+    });
   }
 
   private validateSingleTransaction(
@@ -109,4 +121,18 @@ export class TransactionValidator {
 
     return null;
   }
+}
+
+function findDuplicateTransactionNos(
+  transactions: PreviewTransaction[],
+): Set<string> {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const t of transactions) {
+    if (seen.has(t.transaction_no)) {
+      duplicates.add(t.transaction_no);
+    }
+    seen.add(t.transaction_no);
+  }
+  return duplicates;
 }


### PR DESCRIPTION
## Summary

- CSVインポート時、CSV内に同じ `transaction_no` が複数存在する場合に、重複する取引Noを含む具体的なエラーメッセージをUIに表示するようにした
- これまでは Prisma の `P2002` ユニーク制約エラーが発生し、「データの保存中にエラーが発生しました」という汎用メッセージしか表示されなかった

## 背景

ハッシュ計算のカラム追加（`79b34c6`）により、既存レコードのハッシュと新規計算のハッシュが不一致になり、本来 "skip" になるべきレコードが "update" として扱われるケースが発生。加えて、CSV内で同一 `transaction_no` が重複している場合、`createMany` のバッチ内でユニーク制約違反（`P2002`）が起きていた。

## 変更内容

`save-preview-transactions-usecase.ts` の `createMany` 実行前に、insert対象のトランザクション内で `transaction_no` の重複をチェック。重複がある場合は具体的な取引Noを含むエラーメッセージを返して処理を中断する。

## Test plan

- [ ] CSV内に同じ `transaction_no` の行が複数ある場合、重複する取引Noがエラーメッセージに表示されること
- [ ] CSV内に重複がない場合、従来通り正常にインポートできること

https://claude.ai/code/session_018TgM5sx7uxyrxMhTXQnBr5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * CSVインポート時のトランザクションデータの重複検出機能を改善しました。同じトランザクション番号を持つレコードは無効として処理され、適切なエラーメッセージが表示されるようになります。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->