### PR TITLE
Add security policy document (SECURITY.md)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# セキュリティポリシー
+
+## 脆弱性の報告
+
+team-mirai/marumie におけるセキュリティ脆弱性を発見された場合は、
+GitHub の Private Vulnerability Reporting よりご報告ください。
+
+報告フォーム: https://github.com/team-mirai/marumie/security/advisories/new
+
+公開 Issue や Pull Request、SNS 等で詳細を共有する前に、
+上記の非公開チャネルからご連絡いただけますと幸いです。
+
+## 対応の流れ
+
+1. 報告を受領次第、メンテナが内容を確認します (初回応答の目安: 5 営業日以内)
+2. 影響範囲・再現性の確認、修正方針の検討を行います
+3. 修正をリリースし、必要に応じて Security Advisory を公開します
+
+## 対象範囲
+
+本ポリシーは team-mirai/marumie リポジトリおよび、
+本リポジトリのコードからデプロイされている公開アプリケーションを対象とします。
+
+## 謝辞
+
+責任ある開示にご協力いただいた報告者の方々に感謝いたします。


### PR DESCRIPTION
## Summary
This PR adds a security policy document to establish clear guidelines for reporting and handling security vulnerabilities in the marumie project.

## Changes
- **Added SECURITY.md**: A comprehensive security policy document in Japanese that includes:
  - Instructions for reporting vulnerabilities via GitHub's Private Vulnerability Reporting feature
  - Clear guidance to avoid public disclosure before responsible notification
  - Response timeline expectations (initial response within 5 business days)
  - Process flow for vulnerability handling (confirmation → assessment → fix → advisory)
  - Scope definition (applies to the repository and deployed public applications)
  - Acknowledgment of responsible disclosure contributors

## Details
The security policy follows GitHub's recommended practices for vulnerability disclosure by:
- Directing reporters to use the private vulnerability reporting channel
- Providing a direct link to the advisory creation form
- Setting clear expectations for response and resolution timelines
- Establishing a formal process for handling reported issues

https://claude.ai/code/session_016ihrAqHnM6T6Xs8pR8AGG4