### PR TITLE
docs: add SECURITY.md with vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# セキュリティポリシー
+
+## 脆弱性の報告
+
+team-mirai/marumie におけるセキュリティ脆弱性を発見された場合は、
+GitHub の Private Vulnerability Reporting よりご報告ください。
+
+報告フォーム: https://github.com/team-mirai/marumie/security/advisories/new
+
+公開 Issue や Pull Request、SNS 等で詳細を共有する前に、
+上記の非公開チャネルからご連絡いただけますと幸いです。
+
+## 対応の流れ
+
+1. 報告を受領次第、メンテナが内容を確認します (初回応答の目安: 5 営業日以内)
+2. 影響範囲・再現性の確認、修正方針の検討を行います
+3. 修正をリリースし、必要に応じて Security Advisory を公開します
+
+## 対象範囲
+
+本ポリシーは team-mirai/marumie リポジトリおよび、
+本リポジトリのコードからデプロイされている公開アプリケーションを対象とします。
+
+## 謝辞
+
+責任ある開示にご協力いただいた報告者の方々に感謝いたします。


### PR DESCRIPTION
## Summary

- SECURITY.md をリポジトリのルートに追加
- GitHub の Private Vulnerability Reporting を使用した脆弱性報告フローを明文化
- 対応の流れ・対象範囲・謝辞を記載

develop ブランチに先行マージされた内容と同一のファイルを main にも反映するための PR です（関連: #1202）。

## Test plan

- [ ] SECURITY.md の文面が意図通りであることを確認
- [ ] GitHub 上で SECURITY タブに反映されることを確認

https://claude.ai/code/session_016ihrAqHnM6T6Xs8pR8AGG4

---
_Generated by [Claude Code](https://claude.ai/code/session_016ihrAqHnM6T6Xs8pR8AGG4)_