### PR TITLE
docs: 技術スタックのNext.jsバージョン表記を15から16に修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 
 - webapp（公開用フロントエンド）は既に稼働中
 - admin（管理画面）では政治資金報告書XML生成機能を開発中
-- 技術スタック: Next.js 15 (App Router) / Prisma / Supabase (PostgreSQL) / Vercel / pnpm
+- 技術スタック: Next.js 16 (App Router) / Prisma / Supabase (PostgreSQL) / Vercel / pnpm
 - 詳細は [README.md](README.md) を参照
 
 ## コード構成

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ marumie/
 
 ## 技術スタック
 
-- **Frontend**: Next.js 15, React 19, TypeScript
+- **Frontend**: Next.js 16, React 19, TypeScript
 - **Backend**: Prisma ORM, Supabase
 - **Styling**: Tailwind CSS v4
 - **Charts**: Recharts, ApexCharts, Nivo


### PR DESCRIPTION
## 目的（Why）

新規参加者や閲覧者が技術スタックを正しく把握できるよう、ドキュメントと実装の
Next.js バージョン不一致を解消します。README / CLAUDE.md に「Next.js 15」と
記載されていますが、実際の依存は Next.js 16 系であり、事実と異なります。

## 変更内容

`Next.js 15` → `Next.js 16` の表記修正（2箇所）

- `README.md`（技術スタック節）
- `CLAUDE.md`（アプリケーション概要）

## 根拠

実装は Next.js 16 系で固定されており、ドキュメントのみが取り残されています。

| 観点 | 根拠 | 事実 |
|------|------|------|
| 依存定義 | `webapp/package.json`, `admin/package.json` | 両アプリとも `"next": "16.1.1"`（キャレットなしの正確固定） |
| 解決済みバージョン | `pnpm-lock.yaml` | 実際にインストールされる版も `next@16.1.1` |
| 表記の整合性 | README 既存記法 | 隣接の「React 19」も実体 19.2.3 のメジャーのみ表記。同規則なら `Next.js 16` が一貫 |

メジャーバージョン番号を含まない言及（バッジ、"Next.js App Router"）は対象外です。

## テスト計画

- [x] ドキュメントのみの変更（コード変更なし）
- [x] `Next.js 15` の残存が無いことを確認済み