### PR TITLE
Simplify account category mapping for membership fees

### DIFF
--- a/shared/accounting/account-category.ts
+++ b/shared/accounting/account-category.ts
@@ -14,8 +14,7 @@ export const PL_CATEGORIES: Record<string, CategoryMapping> = {
   // 収入項目
   "個人の負担する党費又は会費": {
     key: "membership-fees",
-    category: "機関紙誌+その他事業収入",
-    subcategory: "党費・会費",
+    category: "党費・会費",
     color: "#FED7AA",
     shortLabel: "党費・会費",
     type: "income"


### PR DESCRIPTION
## Summary
Simplified the account category structure for membership fees (党費・会費) by removing the subcategory level and promoting the subcategory value to the main category field.

## Changes
- **Category structure**: Changed from a two-level hierarchy (`category: "機関紙誌+その他事業収入"` + `subcategory: "党費・会費"`) to a single-level structure (`category: "党費・会費"`)
- **Removed field**: Deleted the `subcategory` field from the membership fees category mapping
- **Preserved attributes**: Maintained all other properties (key, color, shortLabel, type)

## Implementation Details
This change simplifies the accounting category taxonomy for the political finance reporting system. The membership fees category now uses a flatter structure, which may improve clarity in the report generation and data visualization layers that consume this category mapping.

https://claude.ai/code/session_018n27dhvVTncXV57pF4we5z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 会計カテゴリの分類を修正しました。党費・会費の計上区分が正確に反映されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->