### PR TITLE
feat: 非現金BS科目（未払金・仮払金・仮受金）の取引を収支として認識する

### DIFF
--- a/admin/src/server/contexts/data-import/domain/services/transaction-validator.ts
+++ b/admin/src/server/contexts/data-import/domain/services/transaction-validator.ts
@@ -97,11 +97,8 @@ export class TransactionValidator {
       transaction.debit_account === OFFSET_EXPENSE_ACCOUNT ||
       transaction.credit_account === OFFSET_INCOME_ACCOUNT;
 
-    const isNonCashTransaction = transaction.transaction_type === "non_cash_journal";
-
     if (
       !isOffsetTransaction &&
-      !isNonCashTransaction &&
       (!transaction.friendly_category || transaction.friendly_category.trim() === "")
     ) {
       return "独自のカテゴリが設定されていません";

--- a/admin/src/server/contexts/data-import/infrastructure/mf/mf-record-converter.ts
+++ b/admin/src/server/contexts/data-import/infrastructure/mf/mf-record-converter.ts
@@ -143,9 +143,12 @@ export class MfRecordConverter {
     if (isDebitPL && isCreditBS && this.isCashEquivalent(creditAccount)) {
       return "expense";
     }
-    // 非現金仕訳: PL科目とBS科目の組み合わせ（現金を含まない）
-    if ((isDebitPL && isCreditBS) || (isDebitBS && isCreditPL)) {
-      return "non_cash_journal";
+    // 発生主義: PL科目が登場した仕訳タイミングで収支を認識（現金を含まない場合）
+    if (isDebitPL && isCreditBS) {
+      return "expense";
+    }
+    if (isDebitBS && isCreditPL) {
+      return "income";
     }
 
     return null;

--- a/admin/tests/server/contexts/data-import/infrastructure/mf/mf-record-converter.test.ts
+++ b/admin/tests/server/contexts/data-import/infrastructure/mf/mf-record-converter.test.ts
@@ -256,7 +256,7 @@ describe("MfRecordConverter", () => {
       expect(result.transaction_type).toBe("expense");
     });
 
-    it("should set transaction_type to non_cash_journal when PL and 仮払金 are mixed", () => {
+    it("should set transaction_type to expense when PL and 仮払金 are mixed", () => {
       const record = createMockRecord({
         debit_account: "事務所費",
         credit_account: "仮払金",
@@ -264,10 +264,10 @@ describe("MfRecordConverter", () => {
 
       const result = converter.convertRow(record, "test-org-id");
 
-      expect(result.transaction_type).toBe("non_cash_journal");
+      expect(result.transaction_type).toBe("expense");
     });
 
-    it("should set transaction_type to non_cash_journal when PL and 立替金 are mixed", () => {
+    it("should set transaction_type to expense when PL and 立替金 are mixed", () => {
       const record = createMockRecord({
         debit_account: "事務所費",
         credit_account: "立替金",
@@ -275,7 +275,7 @@ describe("MfRecordConverter", () => {
 
       const result = converter.convertRow(record, "test-org-id");
 
-      expect(result.transaction_type).toBe("non_cash_journal");
+      expect(result.transaction_type).toBe("expense");
     });
 
 

--- a/admin/tests/server/contexts/data-import/infrastructure/mf/mf-record-converter.test.ts
+++ b/admin/tests/server/contexts/data-import/infrastructure/mf/mf-record-converter.test.ts
@@ -190,7 +190,7 @@ describe("MfRecordConverter", () => {
       expect(result.transaction_type).toBe(null);
     });
 
-    it("should set transaction_type to non_cash_journal when PL and BS accounts are mixed without cash", () => {
+    it("should set transaction_type to expense when PL expense account is debit and non-cash BS account is credit", () => {
       const record = createMockRecord({
         debit_account: "事務所費",
         credit_account: "未払金/未払費用",
@@ -198,7 +198,40 @@ describe("MfRecordConverter", () => {
 
       const result = converter.convertRow(record, "test-org-id");
 
-      expect(result.transaction_type).toBe("non_cash_journal");
+      expect(result.transaction_type).toBe("expense");
+    });
+
+    it("should set transaction_type to income when non-cash BS account is debit and PL income account is credit", () => {
+      const record = createMockRecord({
+        debit_account: "仮受金",
+        credit_account: "個人からの寄附",
+      });
+
+      const result = converter.convertRow(record, "test-org-id");
+
+      expect(result.transaction_type).toBe("income");
+    });
+
+    it("should set transaction_type to expense when PL expense account is debit and 仮払金 is credit", () => {
+      const record = createMockRecord({
+        debit_account: "事務所費",
+        credit_account: "仮払金",
+      });
+
+      const result = converter.convertRow(record, "test-org-id");
+
+      expect(result.transaction_type).toBe("expense");
+    });
+
+    it("should set transaction_type to null when both accounts are non-cash BS categories", () => {
+      const record = createMockRecord({
+        debit_account: "仮払金",
+        credit_account: "未払金/未払費用",
+      });
+
+      const result = converter.convertRow(record, "test-org-id");
+
+      expect(result.transaction_type).toBe(null);
     });
 
     it("should set transaction_type to income when debit_account is 現金 and credit_account is PL category", () => {

--- a/prisma/migrations/migrate-non-cash-journal.sql
+++ b/prisma/migrations/migrate-non-cash-journal.sql
@@ -40,7 +40,7 @@ WHERE transaction_type = 'non_cash_journal'
     '政治資金パーティー開催事業費','その他の事業費','調査研究費',
     '寄附・交付金','その他の経費'
   )
-  AND credit_account IN ('未払金/未払費用','仮払金','仮受金');
+  AND credit_account IN ('未払金/未払費用','仮払金','仮受金','立替金');
 
 -- ③ income に更新: 非CASH BS（借方） / PL収益科目（貸方）
 UPDATE transactions

--- a/prisma/migrations/migrate-non-cash-journal.sql
+++ b/prisma/migrations/migrate-non-cash-journal.sql
@@ -1,0 +1,63 @@
+-- non_cash_journal レコードを income / expense に再判定して更新する。
+-- Supabase SQL Editor で実行すること。
+-- 実行前に SELECT 文でレコード数を確認しておくことを推奨。
+
+-- ① 確認用: 対象レコード数
+SELECT
+  CASE
+    WHEN debit_account IN (
+      '人件費','光熱水費','備品・消耗品費','事務所費',
+      '組織活動費','選挙関係費','機関紙誌の発行事業費','宣伝事業費',
+      '政治資金パーティー開催事業費','その他の事業費','調査研究費',
+      '寄附・交付金','その他の経費'
+    )
+    AND credit_account IN ('未払金/未払費用','仮払金','仮受金')
+    THEN 'expense に更新'
+    WHEN debit_account IN ('未払金/未払費用','仮払金','仮受金')
+    AND credit_account IN (
+      '個人の負担する党費又は会費','個人からの寄附','個人からの寄附（特定寄附）',
+      '法人その他の団体からの寄附','政治団体からの寄附','政党匿名寄附',
+      '機関紙誌の発行その他の事業による収入','借入金',
+      '本部又は支部から供与された交付金に係る収入',
+      '政治資金パーティーの対価に係る収入','寄附のあっせんによるもの',
+      '政治資金パーティー対価のあっせんによるもの','その他の収入'
+    )
+    THEN 'income に更新'
+    ELSE 'その他（要確認）'
+  END AS 更新種別,
+  COUNT(*) AS 件数
+FROM transactions
+WHERE transaction_type = 'non_cash_journal'
+GROUP BY 更新種別;
+
+-- ② expense に更新: PL費用科目（借方） / 非CASH BS（貸方）
+UPDATE transactions
+SET transaction_type = 'expense'
+WHERE transaction_type = 'non_cash_journal'
+  AND debit_account IN (
+    '人件費','光熱水費','備品・消耗品費','事務所費',
+    '組織活動費','選挙関係費','機関紙誌の発行事業費','宣伝事業費',
+    '政治資金パーティー開催事業費','その他の事業費','調査研究費',
+    '寄附・交付金','その他の経費'
+  )
+  AND credit_account IN ('未払金/未払費用','仮払金','仮受金');
+
+-- ③ income に更新: 非CASH BS（借方） / PL収益科目（貸方）
+UPDATE transactions
+SET transaction_type = 'income'
+WHERE transaction_type = 'non_cash_journal'
+  AND debit_account IN ('未払金/未払費用','仮払金','仮受金')
+  AND credit_account IN (
+    '個人の負担する党費又は会費','個人からの寄附','個人からの寄附（特定寄附）',
+    '法人その他の団体からの寄附','政治団体からの寄附','政党匿名寄附',
+    '機関紙誌の発行その他の事業による収入','借入金',
+    '本部又は支部から供与された交付金に係る収入',
+    '政治資金パーティーの対価に係る収入','寄附のあっせんによるもの',
+    '政治資金パーティー対価のあっせんによるもの','その他の収入'
+  );
+
+-- ④ 残存確認: 0件であれば完了
+SELECT id, debit_account, credit_account
+FROM transactions
+WHERE transaction_type = 'non_cash_journal'
+LIMIT 20;

--- a/shared/accounting/account-category.ts
+++ b/shared/accounting/account-category.ts
@@ -237,9 +237,6 @@ export const BS_CATEGORIES: Record<string, { type: "asset" | "liability" | "net_
   "未払金/未払費用": {
     type: "liability"
   },
-  "仮払金": {
-    type: "asset"
-  },
   "仮受金": {
     type: "liability"
   },

--- a/shared/accounting/account-category.ts
+++ b/shared/accounting/account-category.ts
@@ -237,6 +237,12 @@ export const BS_CATEGORIES: Record<string, { type: "asset" | "liability" | "net_
   "未払金/未払費用": {
     type: "liability"
   },
+  "仮払金": {
+    type: "asset"
+  },
+  "仮受金": {
+    type: "liability"
+  },
 };
 
 /**


### PR DESCRIPTION
## 目的

会計担当者がクレジットカード払いや仮払い・仮受けを含む取引をインポートした際に、webapp のサンキー図・トランザクション一覧に正しく収支として表示されるようにする。

## 背景

これまで `CASH_ACCOUNTS`（普通預金）を伴わない PL/BS 仕訳は `non_cash_journal` として判定され、フロントエンドに表示されなかった。クレジットカード購入（例: 事務所費 / 未払金）や仮払精算（例: 事務所費 / 仮払金）がこれに該当し、支出として表示されないという問題があった。

## 変更内容

- **発生主義に基づく判定ロジックの変更**: PL科目が登場した仕訳タイミングで収支を認識する
  - `PL費用科目（借方） / 非CASH BS（貸方）` → `expense`
  - `非CASH BS（借方） / PL収益科目（貸方）` → `income`
  - `BS / BS`（引き落とし・振替等）→ `null`（非表示、従来通り）
- **BS_CATEGORIES に仮払金・仮受金を追加**
- **transaction-validator の `non_cash_journal` 免除条件を削除**（不要になったため）

## マイグレーション（手動実行が必要）

既存の `non_cash_journal` レコードを更新するSQLを用意した。**PRマージ後、Supabase SQL Editor で手動実行すること。**

`prisma/migrations/migrate-non-cash-journal.sql`

## Test plan

- [ ] `pnpm test` 全テスト通過を確認
- [ ] `pnpm typecheck` 型エラーなしを確認
- [ ] `pnpm lint` lint警告なし（既存のものを除く）を確認
- [ ] マージ後、`prisma/migrations/migrate-non-cash-journal.sql` を Supabase SQL Editor で実行し、既存データを更新する
- [ ] webapp のサンキー図・トランザクション一覧で未払金・仮払金を使った取引が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 「仮受金」を貸借科目の分類対象に追加しました。  
* **バグ修正**
  * 損益科目・貸借科目の組み合わせに基づく取引種別の判定を調整しました。あわせて、相殺以外の取引でカテゴリ入力の必須判定条件を見直しました。  
* **データ移行**
  * 既存の「非現金仕訳」を新しい判定ロジックに基づいて再判定し、expense / income に更新する手順を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->