### PR TITLE
fix: サンキー図でBS科目（仮払金等）を収入・支出ノードから除外

### DIFF
--- a/admin/src/server/contexts/data-import/infrastructure/mf/mf-record-converter.ts
+++ b/admin/src/server/contexts/data-import/infrastructure/mf/mf-record-converter.ts
@@ -105,8 +105,8 @@ export class MfRecordConverter {
   }
 
   private determineCategoryKey(debitAccount: string, creditAccount: string): string {
-    const isDebitPL = debitAccount in PL_CATEGORIES;
-    const isCreditPL = creditAccount in PL_CATEGORIES;
+    const isDebitPL = Object.hasOwn(PL_CATEGORIES, debitAccount);
+    const isCreditPL = Object.hasOwn(PL_CATEGORIES, creditAccount);
 
     if (isDebitPL) {
       const mapping = PL_CATEGORIES[debitAccount];
@@ -130,10 +130,10 @@ export class MfRecordConverter {
       return "offset_income";
     }
 
-    const isDebitBS = debitAccount in BS_CATEGORIES;
-    const isCreditBS = creditAccount in BS_CATEGORIES;
-    const isDebitPL = debitAccount in PL_CATEGORIES;
-    const isCreditPL = creditAccount in PL_CATEGORIES;
+    const isDebitBS = Object.hasOwn(BS_CATEGORIES, debitAccount);
+    const isCreditBS = Object.hasOwn(BS_CATEGORIES, creditAccount);
+    const isDebitPL = Object.hasOwn(PL_CATEGORIES, debitAccount);
+    const isCreditPL = Object.hasOwn(PL_CATEGORIES, creditAccount);
 
     // 現金収入: 現金類(借方) + PL科目(貸方)
     if (isDebitBS && isCreditPL && this.isCashEquivalent(debitAccount)) {

--- a/webapp/src/server/contexts/public-finance/infrastructure/repositories/prisma-transaction.repository.ts
+++ b/webapp/src/server/contexts/public-finance/infrastructure/repositories/prisma-transaction.repository.ts
@@ -3,7 +3,7 @@ import type { Prisma, PrismaClient, Transaction as PrismaTransaction } from "@pr
 import type { Transaction, TransactionType } from "@/shared/models/transaction";
 import type { TransactionFilters } from "@/types/transaction-filters";
 import type { DisplayTransactionType } from "@/server/contexts/public-finance/domain/models/display-transaction";
-import { PL_CATEGORIES } from "@/shared/accounting/account-category";
+import { PL_CATEGORIES, BS_CATEGORIES } from "@/shared/accounting/account-category";
 import type {
   ITransactionRepository,
   PaginatedResult,
@@ -225,6 +225,11 @@ export class PrismaTransactionRepository
     >();
 
     for (const item of accountData) {
+      // BS科目（仮払金・立替金など）は収入・支出ノードとして表示しない。
+      // 未払費用などBS科目の特別表示は別途 adjustWithBalance で行う。
+      if (item.account in BS_CATEGORIES) {
+        continue;
+      }
       const mapping = PL_CATEGORIES[item.account] || {
         category: item.account,
       };
@@ -256,6 +261,11 @@ export class PrismaTransactionRepository
     >();
 
     for (const item of accountData) {
+      // BS科目（仮払金・立替金など）は収入・支出ノードとして表示しない。
+      // 未払費用などBS科目の特別表示は別途 adjustWithBalance で行う。
+      if (item.account in BS_CATEGORIES) {
+        continue;
+      }
       const mapping = PL_CATEGORIES[item.account] || {
         category: item.account,
       };

--- a/webapp/src/server/contexts/public-finance/infrastructure/repositories/prisma-transaction.repository.ts
+++ b/webapp/src/server/contexts/public-finance/infrastructure/repositories/prisma-transaction.repository.ts
@@ -227,12 +227,15 @@ export class PrismaTransactionRepository
     for (const item of accountData) {
       // BS科目（仮払金・立替金など）は収入・支出ノードとして表示しない。
       // 未払費用などBS科目の特別表示は別途 adjustWithBalance で行う。
-      if (item.account in BS_CATEGORIES) {
+      if (Object.hasOwn(BS_CATEGORIES, item.account)) {
         continue;
       }
-      const mapping = PL_CATEGORIES[item.account] || {
-        category: item.account,
-      };
+      const mapping: { category: string; subcategory?: string } = Object.hasOwn(
+        PL_CATEGORIES,
+        item.account,
+      )
+        ? PL_CATEGORIES[item.account]
+        : { category: item.account };
       const key = mapping.subcategory
         ? `${mapping.category}|${mapping.subcategory}`
         : mapping.category;
@@ -263,12 +266,15 @@ export class PrismaTransactionRepository
     for (const item of accountData) {
       // BS科目（仮払金・立替金など）は収入・支出ノードとして表示しない。
       // 未払費用などBS科目の特別表示は別途 adjustWithBalance で行う。
-      if (item.account in BS_CATEGORIES) {
+      if (Object.hasOwn(BS_CATEGORIES, item.account)) {
         continue;
       }
-      const mapping = PL_CATEGORIES[item.account] || {
-        category: item.account,
-      };
+      const mapping: { category: string; subcategory?: string } = Object.hasOwn(
+        PL_CATEGORIES,
+        item.account,
+      )
+        ? PL_CATEGORIES[item.account]
+        : { category: item.account };
       // friendlyカテゴリーの場合は、subcategoryをtagに置き換える
       const subcategory = item.tag || undefined;
       const key = subcategory ? `${mapping.category}|${subcategory}` : mapping.category;


### PR DESCRIPTION
## 目的（Why）

公開ページの閲覧者（市民）が、政治資金の収支を正しく理解できるようにするため。

現状、収入・支出のみを表すべきサンキー図の右側（支出側）に、本来 BS 科目である **「仮払金」** が表示されてしまっている。仮払金は資産科目であり、収支のフローとして出てくるのは不自然なため、これを除外する。

## 原因

1. **分類（admin / インポート時）** — [mf-record-converter.ts](admin/src/server/contexts/data-import/infrastructure/mf/mf-record-converter.ts) の `determineTransactionType` が「借方=BS科目／貸方=PL費用科目」の仕訳を、BS科目の種類を問わず一律 `expense` と判定する（直近の「非現金BS科目を収支認識する」機能で追加）。借方が仮払金でも該当する。
2. **集計（webapp / 表示時）** — `getCategoryAggregationForSankey` は expense を `debitAccount` でグループ化し、`PL_CATEGORIES[account] || { category: account }` のフォールバックにより、PL科目に無い「仮払金」がそのまま支出カテゴリ名（ノード）に昇格していた。

なお、未払費用の特別表示は `adjustWithBalance`（流動負債残高）経由の別経路で、`liability` 型の科目のみを対象とするため、資産である仮払金は元々含まれていない。

## 変更内容

webapp 側の集計（表示）で BS 科目を収入・支出ノードから除外する。

- `aggregateByCategory` / `aggregateByCategoryWithTag` で、勘定科目が `BS_CATEGORIES` に含まれる場合はノード化をスキップ
- 表示専用の修正のため、**既存データにそのまま効き、再インポートは不要**
- 未払費用の特別ノードは別経路のため**維持**される
- 分類側（仮払金を収支として認識するデータ）はそのまま温存

## 検証

- `pnpm type-check` ✅
- `pnpm lint` ✅（警告は既存の別ファイル）
- `pnpm test` ✅ 115 passed
- `pnpm knip` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 一部の会計カテゴリが収入・支出の集計に重複して反映される問題を修正しました。
  * 貸借対照表に属する勘定が、該当しない集計結果に含まれないようになりました。
  * データ取り込み時のカテゴリ/勘定科目判定の基準を調整し、集計結果の整合性を改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->