### PR TITLE
Improve error handling in WebappCacheInvalidator

### DIFF
--- a/admin/src/server/contexts/shared/infrastructure/services/webapp-cache-invalidator.ts
+++ b/admin/src/server/contexts/shared/infrastructure/services/webapp-cache-invalidator.ts
@@ -11,29 +11,42 @@ export class WebappCacheInvalidator implements ICacheInvalidator {
 
   async invalidateWebappCache(): Promise<void> {
     if (!this.refreshToken) {
-      return;
+      throw new Error(
+        "DATA_REFRESH_TOKEN が設定されていないため、ウェブアプリのキャッシュをクリアできません",
+      );
     }
 
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 5000); // 5秒タイムアウト
 
+    let response: Response;
     try {
-      const response = await fetch(`${this.webappUrl}/api/refresh`, {
+      response = await fetch(`${this.webappUrl}/api/refresh`, {
         method: "POST",
         headers: {
           "x-refresh-token": this.refreshToken,
         },
         signal: controller.signal,
       });
-
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
     } catch (error) {
-      console.warn("Failed to refresh webapp cache:", error);
-      // キャッシュ更新の失敗は usecase を失敗させない
+      if (error instanceof Error && error.name === "AbortError") {
+        throw new Error(`ウェブアプリ (${this.webappUrl}) への接続がタイムアウトしました（5秒）`);
+      }
+      throw new Error(
+        `ウェブアプリ (${this.webappUrl}) への接続に失敗しました: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
     } finally {
       clearTimeout(timeoutId);
+    }
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      const detail = body ? ` ${body}` : "";
+      throw new Error(
+        `ウェブアプリのキャッシュクリアに失敗しました (HTTP ${response.status}).${detail}`,
+      );
     }
   }
 }

--- a/admin/tests/server/contexts/shared/infrastructure/services/webapp-cache-invalidator.test.ts
+++ b/admin/tests/server/contexts/shared/infrastructure/services/webapp-cache-invalidator.test.ts
@@ -1,0 +1,80 @@
+import { WebappCacheInvalidator } from "@/server/contexts/shared/infrastructure/services/webapp-cache-invalidator";
+
+describe("WebappCacheInvalidator", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it("refreshToken が未設定の場合、エラーを投げる", async () => {
+    const invalidator = new WebappCacheInvalidator("http://webapp.test", undefined);
+    const fetchSpy = jest.fn();
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    await expect(invalidator.invalidateWebappCache()).rejects.toThrow(
+      /DATA_REFRESH_TOKEN/,
+    );
+    // トークンが無ければ fetch も呼ばれない
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("正常なレスポンスの場合、正常に完了する", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+    }) as unknown as typeof fetch;
+
+    const invalidator = new WebappCacheInvalidator("http://webapp.test", "token");
+
+    await expect(invalidator.invalidateWebappCache()).resolves.toBeUndefined();
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://webapp.test/api/refresh",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "x-refresh-token": "token" },
+      }),
+    );
+  });
+
+  it("レスポンスが ok でない場合、ステータスとボディを含むエラーを投げる", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: jest.fn().mockResolvedValue("Unauthorized"),
+    }) as unknown as typeof fetch;
+
+    const invalidator = new WebappCacheInvalidator("http://webapp.test", "token");
+
+    await expect(invalidator.invalidateWebappCache()).rejects.toThrow(
+      /HTTP 401.*Unauthorized/,
+    );
+  });
+
+  it("ネットワークエラーの場合、接続失敗のエラーを投げる", async () => {
+    global.fetch = jest
+      .fn()
+      .mockRejectedValue(new Error("ECONNREFUSED")) as unknown as typeof fetch;
+
+    const invalidator = new WebappCacheInvalidator("http://webapp.test", "token");
+
+    await expect(invalidator.invalidateWebappCache()).rejects.toThrow(
+      /接続に失敗しました.*ECONNREFUSED/,
+    );
+  });
+
+  it("タイムアウト（AbortError）の場合、タイムアウトのエラーを投げる", async () => {
+    const abortError = new Error("aborted");
+    abortError.name = "AbortError";
+    global.fetch = jest
+      .fn()
+      .mockRejectedValue(abortError) as unknown as typeof fetch;
+
+    const invalidator = new WebappCacheInvalidator("http://webapp.test", "token");
+
+    await expect(invalidator.invalidateWebappCache()).rejects.toThrow(
+      /タイムアウト/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Enhanced error handling in `WebappCacheInvalidator` to provide better diagnostics when cache invalidation fails. Previously, errors were silently logged and ignored. Now, errors are properly thrown with detailed context, and comprehensive test coverage has been added.

## Key Changes

- **Error handling improvements**:
  - Changed missing `refreshToken` from silent return to throwing an error with clear message
  - Added specific error handling for network timeouts (AbortError) with user-friendly message
  - Added specific error handling for connection failures with original error details
  - Added HTTP error handling that includes response status and body content
  
- **Test coverage**:
  - Added comprehensive test suite covering all error scenarios:
    - Missing refresh token
    - Successful cache invalidation
    - HTTP error responses
    - Network connection failures
    - Request timeouts

## Implementation Details

- Errors now include the webapp URL and specific failure reason for better debugging
- HTTP error responses now include the response body (when available) to help diagnose API issues
- Network errors preserve the original error message for context
- Timeout errors are clearly distinguished from other connection failures
- All error messages are in Japanese to match the application's localization

https://claude.ai/code/session_01BFm7JtpCPQa5ChyfiFuMap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * Webアプリのキャッシュ更新に失敗した際、エラーを適切に通知するよう改善しました。
  * 更新トークン未設定、HTTPエラー、ネットワークエラー、タイムアウト時に、原因が分かるメッセージを表示します。

* **テスト**
  * 正常終了および各種エラーケースの動作確認を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->