### PR TITLE
fix: 金額を一つの読み上げ単位として公開する

### DIFF
--- a/webapp/jest.config.js
+++ b/webapp/jest.config.js
@@ -2,12 +2,13 @@ module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
   roots: ["<rootDir>/tests"],
-  testMatch: ["**/*.test.ts"],
+  testMatch: ["**/*.test.ts", "**/*.test.tsx"],
   moduleFileExtensions: ["ts", "tsx", "js", "jsx"],
   transform: {
-    "^.+\\.ts$": "ts-jest",
+    "^.+\\.tsx?$": "ts-jest",
   },
   moduleNameMapper: {
+    "^client-only$": "<rootDir>/tests/__mocks__/server-only.js",
     "^server-only$": "<rootDir>/tests/__mocks__/server-only.js",
     "^@/shared/(.*)$": "<rootDir>/../shared/$1",
     "^@/(.*)$": "<rootDir>/src/$1",

--- a/webapp/src/client/components/top-page/features/financial-summary/AccessibleFormattedAmount.tsx
+++ b/webapp/src/client/components/top-page/features/financial-summary/AccessibleFormattedAmount.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from "react";
+import type { FormattedAmount } from "@/client/lib/financial-calculator";
+
+interface AccessibleFormattedAmountProps {
+  amount: FormattedAmount;
+  children: ReactNode;
+  visualClassName?: string;
+}
+
+function getAccessibleAmountText(amount: FormattedAmount): string {
+  return `${amount.main}${amount.secondary}${amount.tertiary}${amount.unit}`;
+}
+
+export default function AccessibleFormattedAmount({
+  amount,
+  children,
+  visualClassName,
+}: AccessibleFormattedAmountProps) {
+  return (
+    <>
+      <span className="sr-only">{getAccessibleAmountText(amount)}</span>
+      <span aria-hidden="true" className={visualClassName}>
+        {children}
+      </span>
+    </>
+  );
+}

--- a/webapp/src/client/components/top-page/features/financial-summary/BalanceDetailCard.tsx
+++ b/webapp/src/client/components/top-page/features/financial-summary/BalanceDetailCard.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from "react";
+import AccessibleFormattedAmount from "@/client/components/top-page/features/financial-summary/AccessibleFormattedAmount";
 import type { FormattedAmount } from "@/client/lib/financial-calculator";
 
 interface BalanceDetailCardProps {
@@ -24,22 +25,22 @@ function formatAmountDisplay(amount: FormattedAmount, isLarge: boolean = false):
 
   if (amount.tertiary) {
     return (
-      <span className="flex items-baseline gap-1">
+      <AccessibleFormattedAmount amount={amount} visualClassName="flex items-baseline gap-1">
         <span className={mainClass}>{amount.main}</span>
         <span className={unitClass}>{amount.secondary}</span>
         <span className={mainClass}>{amount.tertiary}</span>
         <span className={unitClass}>{amount.unit}</span>
-      </span>
+      </AccessibleFormattedAmount>
     );
   }
   return (
-    <span className="flex items-baseline gap-1">
+    <AccessibleFormattedAmount amount={amount} visualClassName="flex items-baseline gap-1">
       <span className={mainClass}>{amount.main}</span>
       <span className={unitClass}>
         {amount.secondary}
         {amount.unit}
       </span>
-    </span>
+    </AccessibleFormattedAmount>
   );
 }
 

--- a/webapp/src/client/components/top-page/features/financial-summary/FinancialSummaryCard.tsx
+++ b/webapp/src/client/components/top-page/features/financial-summary/FinancialSummaryCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 import "client-only";
 import BaseCard from "@/client/components/ui/BaseCard";
+import AccessibleFormattedAmount from "@/client/components/top-page/features/financial-summary/AccessibleFormattedAmount";
 import type { FormattedAmount } from "@/client/lib/financial-calculator";
 
 interface FinancialSummaryCardProps {
@@ -24,7 +25,10 @@ export default function FinancialSummaryCard({
         <div className={`font-bold text-sm sm:text-base`} style={{ color: titleColor }}>
           {title}
         </div>
-        <div className="flex items-baseline gap-1 translate-y-0.5">
+        <AccessibleFormattedAmount
+          amount={amount}
+          visualClassName="flex items-baseline gap-1 translate-y-0.5"
+        >
           <span
             className="font-bold text-[28px] sm:text-[36px] leading-5"
             style={{ color: amountColor }}
@@ -50,7 +54,7 @@ export default function FinancialSummaryCard({
           >
             {amount.unit}
           </span>
-        </div>
+        </AccessibleFormattedAmount>
       </div>
     </BaseCard>
   );

--- a/webapp/tests/client/components/top-page/features/financial-summary/AccessibleFormattedAmount.test.tsx
+++ b/webapp/tests/client/components/top-page/features/financial-summary/AccessibleFormattedAmount.test.tsx
@@ -1,0 +1,67 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import AccessibleFormattedAmount from "@/client/components/top-page/features/financial-summary/AccessibleFormattedAmount";
+import FinancialSummaryCard from "@/client/components/top-page/features/financial-summary/FinancialSummaryCard";
+import type { FormattedAmount } from "@/client/lib/financial-calculator";
+
+describe("AccessibleFormattedAmount", () => {
+  const testCases: Array<{
+    description: string;
+    amount: FormattedAmount;
+    accessibleText: string;
+  }> = [
+    {
+      description: "億と万円を含む金額",
+      amount: { main: "5", secondary: "億", tertiary: "3210", unit: "万円" },
+      accessibleText: "5億3210万円",
+    },
+    {
+      description: "億円ちょうどの金額",
+      amount: { main: "1", secondary: "億", tertiary: "", unit: "円" },
+      accessibleText: "1億円",
+    },
+    {
+      description: "万円単位の金額",
+      amount: { main: "970", secondary: "", tertiary: "", unit: "万円" },
+      accessibleText: "970万円",
+    },
+    {
+      description: "負の金額",
+      amount: { main: "-1", secondary: "億", tertiary: "5000", unit: "万円" },
+      accessibleText: "-1億5000万円",
+    },
+  ];
+
+  it.each(testCases)(
+    "$descriptionを単一の読み上げ用文字列として描画する",
+    ({ amount, accessibleText }) => {
+      const markup = renderToStaticMarkup(
+        <AccessibleFormattedAmount amount={amount} visualClassName="visual-amount">
+          <span>{amount.main}</span>
+          <span>{amount.secondary}</span>
+          <span>{amount.tertiary}</span>
+          <span>{amount.unit}</span>
+        </AccessibleFormattedAmount>,
+      );
+
+      expect(markup).toContain(`<span class="sr-only">${accessibleText}</span>`);
+      expect(markup).toContain('<span aria-hidden="true" class="visual-amount">');
+      expect(markup.match(/aria-hidden=/g)).toHaveLength(1);
+    },
+  );
+
+  it("サマリーカードで可視表示を隠し、連結した金額だけを読み上げ対象にする", () => {
+    const amount = { main: "5", secondary: "億", tertiary: "3210", unit: "万円" };
+    const markup = renderToStaticMarkup(
+      <FinancialSummaryCard
+        title="収入総額"
+        amount={amount}
+        titleColor="#000000"
+        amountColor="#000000"
+      />,
+    );
+
+    expect(markup).toContain('<span class="sr-only">5億3210万円</span>');
+    expect(markup).toContain('<span aria-hidden="true" class="flex items-baseline');
+    expect(markup.match(/aria-hidden=/g)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## 概要

金額を視覚上の桁・単位ごとに分けて表示している箇所で、Windows ナレーター等が `5` / `億` / `3210` / `万円` を別々の読み上げ対象として扱う問題を修正します。

## 変更内容

- 連結済みの金額（例: `5億3210万円`）を `sr-only` で読み上げ側へ公開
- 既存の可視表示を `aria-hidden=true` にして重複・分割読み上げを防止
- 上部サマリーカードと残高詳細カードへ共通コンポーネントを適用
- 金額パターンと実際のサマリーカード組み込みを回帰テストで固定

既存の文字サイズ・色・間隔・レスポンシブ用クラスは変更していません。

## 検証

- `corepack pnpm --dir webapp exec jest --runInBand`: 14 suites / 120 tests passed
- `corepack pnpm --dir webapp type-check`: passed
- 変更ファイルの `biome check`: passed
- コードレビュー: P0-P2 findings なし

`next build` はコンパイルと TypeScript 検査まで成功しましたが、ローカルに `DATABASE_URL` / `DIRECT_URL` がないため、既存の `/sitemap.xml` prerender で停止しました。今回の差分に sitemap・server・Prisma の変更はありません。

## 確認してほしい点

実機の Windows ナレーターによる最終的な発音・移動単位は未確認です。Preview 環境で、金額全体が一つの読み上げ単位になることをご確認いただけると助かります。

なお、`BalanceSheetChart` は `role=img` の説明設計が別途必要なため、このPRの対象外としています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **アクセシビリティ**
  - 金額表示をスクリーンリーダー向けに最適化し、「5億3210万円」などの金額を自然な文章として読み上げられるようにしました。
  - 視覚的な表示と読み上げ用テキストを分離し、重複して読み上げられる問題を防止しました。

- **テスト**
  - 金額の読み上げ内容や、視覚表示が適切に読み上げ対象外となることを確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->