### PR TITLE
chore(ci): CIの依存関係をロックファイルで固定

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
             ${{ runner.os }}-prisma-
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run lint for admin
         run: pnpm --filter admin run lint
@@ -120,7 +120,7 @@ jobs:
             ${{ runner.os }}-nextjs-webapp-
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Run lint for webapp
         run: pnpm --filter webapp run lint
@@ -154,7 +154,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Check unused code
         run: pnpm knip
@@ -237,7 +237,7 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Install Playwright browsers
         run: pnpm --filter admin exec playwright install chromium --with-deps


### PR DESCRIPTION
## 概要

GitHub Actions の依存関係インストールで、`pnpm-lock.yaml` を厳密に使用するように変更しました。

## 変更内容

- CI の全ジョブで `pnpm install --frozen-lockfile` を使用
- `package.json` と `pnpm-lock.yaml` の不整合を CI で検出可能に変更
- CI 実行中にロックファイルが意図せず更新されることを防止