### PR TITLE
fix: proxy matcher の拡張子除外による認証バイパスを修正

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -109,10 +109,19 @@ module.exports = {
     },
     {
       name: "no-shared-to-contexts",
-      comment: "sharedコンテキストから他のコンテキストへの依存は禁止",
+      comment:
+        "sharedコンテキストから他のコンテキストへの依存は禁止。" +
+        "ただし認証ガード（auth の requireAuth）のみ暫定的に許可している。" +
+        "shared/presentation/actions の 6 件は本来 shared に置くべきものではなく" +
+        "（他コンテキストから呼ばれておらず、admin 画面専用の入口である）、" +
+        "適切なコンテキストへ移設した時点でこの例外は削除すること。" +
+        "それまでは shared → auth の循環依存が残っている状態。",
       severity: "error",
       from: { path: "contexts/shared" },
-      to: { path: "contexts/(data-import|report|auth)" },
+      to: {
+        path: "contexts/(data-import|report|auth)",
+        pathNot: "contexts/auth/presentation/loaders/require-auth",
+      },
     },
 
     // ===========================================

--- a/admin/src/app/api/balance-snapshots/route.ts
+++ b/admin/src/app/api/balance-snapshots/route.ts
@@ -1,8 +1,12 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { loadBalanceSnapshotsData } from "@/server/contexts/shared/presentation/loaders/load-balance-snapshots-data";
+import { requireAuthResponse } from "@/server/contexts/auth/presentation/loaders/require-auth-response";
 
 export async function GET(request: NextRequest) {
+  const unauthorized = await requireAuthResponse();
+  if (unauthorized) return unauthorized;
+
   try {
     const { searchParams } = new URL(request.url);
     const orgId = searchParams.get("orgId");

--- a/admin/src/app/api/export-report/route.ts
+++ b/admin/src/app/api/export-report/route.ts
@@ -7,8 +7,12 @@ import { XmlExportUsecase } from "@/server/contexts/report/application/usecases/
 import { DonationAssembler } from "@/server/contexts/report/application/services/donation-assembler";
 import { ExpenseAssembler } from "@/server/contexts/report/application/services/expense-assembler";
 import { IncomeAssembler } from "@/server/contexts/report/application/services/income-assembler";
+import { requireAuthResponse } from "@/server/contexts/auth/presentation/loaders/require-auth-response";
 
 export async function GET(request: Request) {
+  const unauthorized = await requireAuthResponse();
+  if (unauthorized) return unauthorized;
+
   const url = new URL(request.url);
   const politicalOrganizationId = url.searchParams.get("politicalOrganizationId");
   const financialYearRaw = url.searchParams.get("financialYear");

--- a/admin/src/app/api/transactions/route.ts
+++ b/admin/src/app/api/transactions/route.ts
@@ -3,8 +3,12 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaTransactionRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-transaction.repository";
 import { GetTransactionsUsecase } from "@/server/contexts/data-import/application/usecases/get-transactions-usecase";
+import { requireAuthResponse } from "@/server/contexts/auth/presentation/loaders/require-auth-response";
 
 export async function GET(request: NextRequest) {
+  const unauthorized = await requireAuthResponse();
+  if (unauthorized) return unauthorized;
+
   try {
     const { searchParams } = new URL(request.url);
 

--- a/admin/src/app/api/transactions/search-by-nos/route.ts
+++ b/admin/src/app/api/transactions/search-by-nos/route.ts
@@ -1,8 +1,12 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { loadTransactionsByNos } from "@/server/contexts/data-import/presentation/loaders/load-transactions-by-nos";
+import { requireAuthResponse } from "@/server/contexts/auth/presentation/loaders/require-auth-response";
 
 export async function GET(request: NextRequest) {
+  const unauthorized = await requireAuthResponse();
+  if (unauthorized) return unauthorized;
+
   const { searchParams } = new URL(request.url);
   const orgId = searchParams.get("orgId");
   const nos = searchParams.get("nos");

--- a/admin/src/proxy.ts
+++ b/admin/src/proxy.ts
@@ -149,6 +149,10 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
   return response;
 }
 
+// 除外は静的アセットのプレフィックスのみに限定する。
+// パス中の拡張子一致で除外すると `/political-organizations/1.png` のような
+// 動的ルートが認証ゲートを素通りし、そこにバンドルされたサーバーアクションを
+// 未認証で実行できてしまう。
 export const config = {
-  matcher: ["/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)"],
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
 };

--- a/admin/src/server/contexts/auth/domain/errors/auth-error.ts
+++ b/admin/src/server/contexts/auth/domain/errors/auth-error.ts
@@ -4,6 +4,7 @@ import "server-only";
  * 認証エラーコードの型定義（網羅性チェック用）
  */
 export type AuthErrorCode =
+  | "UNAUTHORIZED"
   | "AUTH_FAILED"
   | "SESSION_EXPIRED"
   | "INVALID_TOKEN"
@@ -33,6 +34,7 @@ export class AuthError extends Error {
  * ユーザー向けメッセージ変換マップ（Presentation 層で使用）
  */
 export const AUTH_ERROR_MESSAGES: Record<AuthErrorCode, string> = {
+  UNAUTHORIZED: "認証が必要です。ログインしてください",
   AUTH_FAILED: "メールアドレスまたはパスワードが正しくありません",
   SESSION_EXPIRED: "セッションの有効期限が切れました。再度ログインしてください",
   INVALID_TOKEN: "認証情報が無効です。再度ログインしてください",

--- a/admin/src/server/contexts/auth/presentation/actions/invite-user.ts
+++ b/admin/src/server/contexts/auth/presentation/actions/invite-user.ts
@@ -9,11 +9,14 @@ import {
 import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaUserRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-user.repository";
 import { AuthError, AUTH_ERROR_MESSAGES } from "@/server/contexts/auth/domain/errors/auth-error";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
 
 /**
  * ユーザー招待アクション
  */
 export async function inviteUser(email: string): Promise<{ ok: boolean; error?: string }> {
+  await requireAuth();
+
   const authProvider = new SupabaseAuthProvider();
   const userRepository = new PrismaUserRepository(prisma);
   const adminAuthProvider = new SupabaseAdminAuthProvider();

--- a/admin/src/server/contexts/auth/presentation/actions/update-user-role.ts
+++ b/admin/src/server/contexts/auth/presentation/actions/update-user-role.ts
@@ -8,6 +8,7 @@ import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaUserRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-user.repository";
 import { AuthError, AUTH_ERROR_MESSAGES } from "@/server/contexts/auth/domain/errors/auth-error";
 import type { User } from "@/server/contexts/shared/domain/repositories/user-repository.interface";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
 
 /**
  * ユーザーロール更新アクション
@@ -16,6 +17,8 @@ export async function updateUserRole(
   userId: string,
   role: UserRole,
 ): Promise<{ ok: true; user: User } | { ok: false; error: string }> {
+  await requireAuth();
+
   const authProvider = new SupabaseAuthProvider();
   const userRepository = new PrismaUserRepository(prisma);
   const usecase = new UpdateUserRoleUsecase(authProvider, userRepository);

--- a/admin/src/server/contexts/auth/presentation/loaders/require-auth-response.ts
+++ b/admin/src/server/contexts/auth/presentation/loaders/require-auth-response.ts
@@ -1,0 +1,23 @@
+import "server-only";
+
+import { NextResponse } from "next/server";
+import { getCurrentUser } from "@/server/contexts/auth/presentation/loaders/load-current-user";
+
+/**
+ * Route Handler 用の認証ガード。
+ *
+ * 未認証の場合は 401 の NextResponse を返すので、呼び出し側は
+ * 返り値が非 null ならそのまま return すること。認証済みの場合は null を返す。
+ *
+ * proxy (middleware) の matcher はルーティング層のゲートに過ぎないため、
+ * Route Handler 側でも明示的に認証を確認する。
+ */
+export async function requireAuthResponse(): Promise<NextResponse | null> {
+  const user = await getCurrentUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "認証が必要です" }, { status: 401 });
+  }
+
+  return null;
+}

--- a/admin/src/server/contexts/auth/presentation/loaders/require-auth.ts
+++ b/admin/src/server/contexts/auth/presentation/loaders/require-auth.ts
@@ -1,0 +1,22 @@
+import "server-only";
+
+import { getCurrentUser } from "@/server/contexts/auth/presentation/loaders/load-current-user";
+import { AuthError } from "@/server/contexts/auth/domain/errors/auth-error";
+import type { AuthUser } from "@/server/contexts/auth/domain/models/auth-user";
+
+/**
+ * 認証済みユーザーを取得する。未認証の場合は例外を投げる。
+ *
+ * proxy (middleware) による認証はルーティング層のゲートに過ぎず、
+ * サーバーアクションや Route Handler はレイアウトのレンダリング前に実行されるため、
+ * 副作用を伴う処理・データを返す処理では必ずこのガードを通すこと。
+ */
+export async function requireAuth(): Promise<AuthUser> {
+  const user = await getCurrentUser();
+
+  if (!user) {
+    throw new AuthError("UNAUTHORIZED", "認証が必要です");
+  }
+
+  return user;
+}

--- a/admin/src/server/contexts/data-import/presentation/actions/bulk-delete-transactions.ts
+++ b/admin/src/server/contexts/data-import/presentation/actions/bulk-delete-transactions.ts
@@ -4,12 +4,15 @@ import "server-only";
 import { updateTag } from "next/cache";
 import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { WebappCacheInvalidator } from "@/server/contexts/shared/infrastructure/services/webapp-cache-invalidator";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
 
 export async function bulkDeleteTransactionsAction(ids: string[]): Promise<{
   success: boolean;
   deletedCount?: number;
   error?: string;
 }> {
+  await requireAuth();
+
   try {
     const deletedCount = await prisma.transaction.deleteMany({
       where: {

--- a/admin/src/server/contexts/data-import/presentation/actions/delete-all-transactions.ts
+++ b/admin/src/server/contexts/data-import/presentation/actions/delete-all-transactions.ts
@@ -5,12 +5,15 @@ import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaTransactionRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-transaction.repository";
 import { DeleteAllTransactionsUsecase } from "@/server/contexts/data-import/application/usecases/delete-all-transactions-usecase";
 import { WebappCacheInvalidator } from "@/server/contexts/shared/infrastructure/services/webapp-cache-invalidator";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
 
 export async function deleteAllTransactionsAction(organizationId?: string): Promise<{
   success: boolean;
   deletedCount?: number;
   error?: string;
 }> {
+  await requireAuth();
+
   try {
     const repository = new PrismaTransactionRepository(prisma);
     const usecase = new DeleteAllTransactionsUsecase(repository);

--- a/admin/src/server/contexts/data-import/presentation/actions/delete-transaction.ts
+++ b/admin/src/server/contexts/data-import/presentation/actions/delete-transaction.ts
@@ -4,11 +4,14 @@ import { updateTag } from "next/cache";
 import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaTransactionRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-transaction.repository";
 import { WebappCacheInvalidator } from "@/server/contexts/shared/infrastructure/services/webapp-cache-invalidator";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
 
 export async function deleteTransactionAction(id: string): Promise<{
   success: boolean;
   error?: string;
 }> {
+  await requireAuth();
+
   try {
     const repository = new PrismaTransactionRepository(prisma);
     await repository.delete(id);

--- a/admin/src/server/contexts/data-import/presentation/actions/preview-csv.ts
+++ b/admin/src/server/contexts/data-import/presentation/actions/preview-csv.ts
@@ -5,6 +5,7 @@ import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaTransactionRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-transaction.repository";
 import { PreviewMfCsvUsecase } from "@/server/contexts/data-import/application/usecases/preview-mf-csv-usecase";
 import type { PreviewMfCsvResult } from "@/server/contexts/data-import/application/usecases/preview-mf-csv-usecase";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
 const transactionRepository = new PrismaTransactionRepository(prisma);
 const previewUsecase = new PreviewMfCsvUsecase(transactionRepository);
 
@@ -15,6 +16,8 @@ export interface PreviewCsvRequest {
 
 export async function previewCsv(data: PreviewCsvRequest): Promise<PreviewMfCsvResult> {
   "use server";
+  await requireAuth();
+
   try {
     const { file, politicalOrganizationId } = data;
 

--- a/admin/src/server/contexts/data-import/presentation/actions/upload-csv.ts
+++ b/admin/src/server/contexts/data-import/presentation/actions/upload-csv.ts
@@ -6,6 +6,7 @@ import { PrismaTransactionRepository } from "@/server/contexts/shared/infrastruc
 import { WebappCacheInvalidator } from "@/server/contexts/shared/infrastructure/services/webapp-cache-invalidator";
 import { SavePreviewTransactionsUsecase } from "@/server/contexts/data-import/application/usecases/save-preview-transactions-usecase";
 import type { PreviewTransaction } from "@/server/contexts/data-import/domain/models/preview-transaction";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
 
 const transactionRepository = new PrismaTransactionRepository(prisma);
 const cacheInvalidator = new WebappCacheInvalidator();
@@ -27,6 +28,8 @@ export interface UploadCsvResponse {
 
 export async function uploadCsv(data: UploadCsvRequest): Promise<UploadCsvResponse> {
   "use server";
+  await requireAuth();
+
   try {
     const { validTransactions, politicalOrganizationId } = data;
 

--- a/admin/src/server/contexts/report/presentation/actions/bulk-assign-counterpart.ts
+++ b/admin/src/server/contexts/report/presentation/actions/bulk-assign-counterpart.ts
@@ -6,6 +6,7 @@ import { BulkAssignCounterpartUsecase } from "@/server/contexts/report/applicati
 import { PrismaReportTransactionRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-report-transaction.repository";
 import { PrismaCounterpartRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-counterpart.repository";
 import { PrismaTransactionCounterpartRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-transaction-counterpart.repository";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
 
 interface BulkAssignCounterpartActionResult {
   success: boolean;
@@ -18,6 +19,8 @@ export async function bulkAssignCounterpartAction(
   transactionIds: string[],
   counterpartId: string,
 ): Promise<BulkAssignCounterpartActionResult> {
+  await requireAuth();
+
   try {
     const transactionRepository = new PrismaReportTransactionRepository(prisma);
     const counterpartRepository = new PrismaCounterpartRepository(prisma);

--- a/admin/src/server/contexts/report/presentation/actions/bulk-assign-donor.ts
+++ b/admin/src/server/contexts/report/presentation/actions/bulk-assign-donor.ts
@@ -6,6 +6,7 @@ import { PrismaDonorRepository } from "@/server/contexts/report/infrastructure/r
 import { PrismaTransactionDonorRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-transaction-donor.repository";
 import { PrismaTransactionWithDonorRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-transaction-with-donor.repository";
 import { BulkAssignDonorUsecase } from "@/server/contexts/report/application/usecases/assign-donor-usecase";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
 
 interface BulkAssignDonorActionResult {
   success: boolean;
@@ -17,6 +18,8 @@ export async function bulkAssignDonorAction(
   transactionIds: string[],
   donorId: string,
 ): Promise<BulkAssignDonorActionResult> {
+  await requireAuth();
+
   try {
     const transactionRepository = new PrismaTransactionWithDonorRepository(prisma);
     const donorRepository = new PrismaDonorRepository(prisma);

--- a/admin/src/server/contexts/report/presentation/actions/bulk-unassign-counterpart.ts
+++ b/admin/src/server/contexts/report/presentation/actions/bulk-unassign-counterpart.ts
@@ -8,10 +8,13 @@ import {
   type BulkUnassignCounterpartInput,
   type BulkUnassignCounterpartResult,
 } from "@/server/contexts/report/application/usecases/bulk-unassign-counterpart-usecase";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
 
 export async function bulkUnassignCounterpartAction(
   input: BulkUnassignCounterpartInput,
 ): Promise<BulkUnassignCounterpartResult> {
+  await requireAuth();
+
   const repository = new PrismaTransactionCounterpartRepository(prisma);
   const usecase = new BulkUnassignCounterpartUsecase(repository);
   const result = await usecase.execute(input);

--- a/admin/src/server/contexts/report/presentation/actions/create-counterpart.ts
+++ b/admin/src/server/contexts/report/presentation/actions/create-counterpart.ts
@@ -5,6 +5,7 @@ import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaCounterpartRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-counterpart.repository";
 import { CreateCounterpartUsecase } from "@/server/contexts/report/application/usecases/manage-counterpart-usecase";
 import type { CreateCounterpartInput } from "@/server/contexts/report/domain/models/counterpart";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
 
 interface CreateCounterpartActionResult {
   success: boolean;
@@ -15,6 +16,8 @@ interface CreateCounterpartActionResult {
 export async function createCounterpartAction(
   input: CreateCounterpartInput,
 ): Promise<CreateCounterpartActionResult> {
+  await requireAuth();
+
   try {
     const repository = new PrismaCounterpartRepository(prisma);
     const usecase = new CreateCounterpartUsecase(repository);

--- a/admin/src/server/contexts/report/presentation/actions/create-donor.ts
+++ b/admin/src/server/contexts/report/presentation/actions/create-donor.ts
@@ -5,6 +5,7 @@ import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaDonorRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-donor.repository";
 import { CreateDonorUsecase } from "@/server/contexts/report/application/usecases/manage-donor-usecase";
 import type { CreateDonorInput } from "@/server/contexts/report/domain/models/donor";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
 
 interface CreateDonorActionResult {
   success: boolean;
@@ -13,6 +14,8 @@ interface CreateDonorActionResult {
 }
 
 export async function createDonorAction(input: CreateDonorInput): Promise<CreateDonorActionResult> {
+  await requireAuth();
+
   try {
     const repository = new PrismaDonorRepository(prisma);
     const usecase = new CreateDonorUsecase(repository);

--- a/admin/src/server/contexts/report/presentation/actions/delete-counterpart.ts
+++ b/admin/src/server/contexts/report/presentation/actions/delete-counterpart.ts
@@ -6,6 +6,7 @@ import { revalidatePath } from "next/cache";
 import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaCounterpartRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-counterpart.repository";
 import { DeleteCounterpartUsecase } from "@/server/contexts/report/application/usecases/manage-counterpart-usecase";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
 
 interface DeleteCounterpartActionResult {
   success: boolean;
@@ -13,6 +14,8 @@ interface DeleteCounterpartActionResult {
 }
 
 export async function deleteCounterpartAction(id: string): Promise<DeleteCounterpartActionResult> {
+  await requireAuth();
+
   try {
     const repository = new PrismaCounterpartRepository(prisma);
     const usecase = new DeleteCounterpartUsecase(repository);

--- a/admin/src/server/contexts/report/presentation/actions/delete-donor.ts
+++ b/admin/src/server/contexts/report/presentation/actions/delete-donor.ts
@@ -6,6 +6,7 @@ import { revalidatePath } from "next/cache";
 import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaDonorRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-donor.repository";
 import { DeleteDonorUsecase } from "@/server/contexts/report/application/usecases/manage-donor-usecase";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
 
 interface DeleteDonorActionResult {
   success: boolean;
@@ -13,6 +14,8 @@ interface DeleteDonorActionResult {
 }
 
 export async function deleteDonorAction(id: string): Promise<DeleteDonorActionResult> {
+  await requireAuth();
+
   try {
     const repository = new PrismaDonorRepository(prisma);
     const usecase = new DeleteDonorUsecase(repository, false);

--- a/admin/src/server/contexts/report/presentation/actions/import-donor-csv.ts
+++ b/admin/src/server/contexts/report/presentation/actions/import-donor-csv.ts
@@ -16,6 +16,7 @@ import {
   NoValidRowsError,
 } from "@/server/contexts/report/domain/errors/donor-csv-error";
 import { ImportDonorCsvUsecase } from "@/server/contexts/report/application/usecases/import-donor-csv-usecase";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
 
 export interface ImportDonorCsvRequest {
   csvContent: string;
@@ -27,6 +28,8 @@ export type ImportDonorCsvResult =
   | { ok: false; error: string };
 
 export async function importDonorCsv(data: ImportDonorCsvRequest): Promise<ImportDonorCsvResult> {
+  await requireAuth();
+
   try {
     const { csvContent, politicalOrganizationId } = data;
 

--- a/admin/src/server/contexts/report/presentation/actions/preview-donor-csv.ts
+++ b/admin/src/server/contexts/report/presentation/actions/preview-donor-csv.ts
@@ -13,6 +13,7 @@ import {
 } from "@/server/contexts/report/domain/errors/donor-csv-error";
 import { PreviewDonorCsvUsecase } from "@/server/contexts/report/application/usecases/preview-donor-csv-usecase";
 import type { PreviewDonorCsvResult } from "@/server/contexts/report/presentation/types/preview-donor-csv-types";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
 
 export interface PreviewDonorCsvRequest {
   file: File;
@@ -22,6 +23,8 @@ export interface PreviewDonorCsvRequest {
 export async function previewDonorCsv(
   data: PreviewDonorCsvRequest,
 ): Promise<PreviewDonorCsvResult> {
+  await requireAuth();
+
   try {
     const { file, politicalOrganizationId } = data;
 

--- a/admin/src/server/contexts/report/presentation/actions/save-organization-profile.ts
+++ b/admin/src/server/contexts/report/presentation/actions/save-organization-profile.ts
@@ -5,6 +5,7 @@ import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaOrganizationReportProfileRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-organization-report-profile.repository";
 import { SaveOrganizationProfileUsecase } from "@/server/contexts/report/application/usecases/save-organization-profile-usecase";
 import type { OrganizationReportProfileDetails } from "@/server/contexts/report/domain/models/organization-report-profile";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
 
 interface SaveOrganizationProfileData {
   id?: string;
@@ -18,6 +19,8 @@ interface SaveOrganizationProfileData {
 }
 
 export async function saveOrganizationProfile(data: SaveOrganizationProfileData) {
+  await requireAuth();
+
   try {
     const repository = new PrismaOrganizationReportProfileRepository(prisma);
     const usecase = new SaveOrganizationProfileUsecase(repository);

--- a/admin/src/server/contexts/report/presentation/actions/search-counterpart-address.ts
+++ b/admin/src/server/contexts/report/presentation/actions/search-counterpart-address.ts
@@ -3,11 +3,14 @@
 import { SearchCounterpartAddressUsecase } from "@/server/contexts/report/application/usecases/search-counterpart-address-usecase";
 import { VercelAIGateway } from "@/server/contexts/report/infrastructure/llm/vercel-ai-gateway";
 import type { AddressSearchResult } from "@/server/contexts/report/presentation/types/address-search";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
 
 export async function searchCounterpartAddressAction(
   companyName: string,
   hint?: string,
 ): Promise<AddressSearchResult> {
+  await requireAuth();
+
   try {
     const gateway = new VercelAIGateway();
     const usecase = new SearchCounterpartAddressUsecase(gateway);

--- a/admin/src/server/contexts/report/presentation/actions/suggest-counterpart.ts
+++ b/admin/src/server/contexts/report/presentation/actions/suggest-counterpart.ts
@@ -7,12 +7,15 @@ import {
 } from "@/server/contexts/report/application/usecases/suggest-counterpart-usecase";
 import { PrismaReportTransactionRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-report-transaction.repository";
 import { PrismaCounterpartRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-counterpart.repository";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
 
 export async function suggestCounterpartAction(
   transactionId: string,
   politicalOrganizationId: string,
   limit?: number,
 ): Promise<SuggestCounterpartResult> {
+  await requireAuth();
+
   try {
     const transactionRepository = new PrismaReportTransactionRepository(prisma);
     const counterpartRepository = new PrismaCounterpartRepository(prisma);

--- a/admin/src/server/contexts/report/presentation/actions/update-counterpart.ts
+++ b/admin/src/server/contexts/report/presentation/actions/update-counterpart.ts
@@ -5,6 +5,7 @@ import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaCounterpartRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-counterpart.repository";
 import { UpdateCounterpartUsecase } from "@/server/contexts/report/application/usecases/manage-counterpart-usecase";
 import type { UpdateCounterpartInput } from "@/server/contexts/report/domain/models/counterpart";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
 
 interface UpdateCounterpartActionResult {
   success: boolean;
@@ -15,6 +16,8 @@ export async function updateCounterpartAction(
   id: string,
   input: UpdateCounterpartInput,
 ): Promise<UpdateCounterpartActionResult> {
+  await requireAuth();
+
   try {
     const repository = new PrismaCounterpartRepository(prisma);
     const usecase = new UpdateCounterpartUsecase(repository);

--- a/admin/src/server/contexts/report/presentation/actions/update-donor.ts
+++ b/admin/src/server/contexts/report/presentation/actions/update-donor.ts
@@ -5,6 +5,7 @@ import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaDonorRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-donor.repository";
 import { UpdateDonorUsecase } from "@/server/contexts/report/application/usecases/manage-donor-usecase";
 import type { UpdateDonorInput } from "@/server/contexts/report/domain/models/donor";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
 
 interface UpdateDonorActionResult {
   success: boolean;
@@ -15,6 +16,8 @@ export async function updateDonorAction(
   id: string,
   input: UpdateDonorInput,
 ): Promise<UpdateDonorActionResult> {
+  await requireAuth();
+
   try {
     const repository = new PrismaDonorRepository(prisma);
     const usecase = new UpdateDonorUsecase(repository);

--- a/admin/src/server/contexts/report/presentation/actions/update-grant-expenditure-flag.ts
+++ b/admin/src/server/contexts/report/presentation/actions/update-grant-expenditure-flag.ts
@@ -6,6 +6,7 @@ import { revalidatePath } from "next/cache";
 import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { UpdateGrantExpenditureFlagUsecase } from "@/server/contexts/report/application/usecases/update-grant-expenditure-flag-usecase";
 import { PrismaReportTransactionRepository } from "@/server/contexts/report/infrastructure/repositories/prisma-report-transaction.repository";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
 
 interface UpdateGrantExpenditureFlagActionResult {
   success: boolean;
@@ -16,6 +17,8 @@ export async function updateGrantExpenditureFlagAction(
   transactionId: string,
   isGrantExpenditure: boolean,
 ): Promise<UpdateGrantExpenditureFlagActionResult> {
+  await requireAuth();
+
   try {
     const transactionRepository = new PrismaReportTransactionRepository(prisma);
     const usecase = new UpdateGrantExpenditureFlagUsecase(transactionRepository);

--- a/admin/src/server/contexts/shared/presentation/actions/clear-webapp-cache.ts
+++ b/admin/src/server/contexts/shared/presentation/actions/clear-webapp-cache.ts
@@ -2,6 +2,7 @@
 
 import { WebappCacheInvalidator } from "@/server/contexts/shared/infrastructure/services/webapp-cache-invalidator";
 import { ClearWebappCacheUsecase } from "@/server/contexts/shared/application/usecases/clear-webapp-cache-usecase";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
 
 interface ClearWebappCacheResponse {
   success: boolean;
@@ -12,5 +13,7 @@ const cacheInvalidator = new WebappCacheInvalidator();
 const clearWebappCacheUsecase = new ClearWebappCacheUsecase(cacheInvalidator);
 
 export async function clearWebappCacheAction(): Promise<ClearWebappCacheResponse> {
+  await requireAuth();
+
   return await clearWebappCacheUsecase.execute();
 }

--- a/admin/src/server/contexts/shared/presentation/actions/create-balance-snapshot.ts
+++ b/admin/src/server/contexts/shared/presentation/actions/create-balance-snapshot.ts
@@ -3,6 +3,7 @@
 import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaBalanceSnapshotRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-balance-snapshot.repository";
 import { CreateBalanceSnapshotUsecase } from "@/server/contexts/shared/application/usecases/create-balance-snapshot-usecase";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
 
 interface CreateBalanceSnapshotData {
   politicalOrganizationId: string;
@@ -11,6 +12,8 @@ interface CreateBalanceSnapshotData {
 }
 
 export async function createBalanceSnapshot(data: CreateBalanceSnapshotData) {
+  await requireAuth();
+
   try {
     const { politicalOrganizationId, snapshotDate, balance } = data;
 

--- a/admin/src/server/contexts/shared/presentation/actions/create-political-organization.ts
+++ b/admin/src/server/contexts/shared/presentation/actions/create-political-organization.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaPoliticalOrganizationRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-political-organization.repository";
 import { CreatePoliticalOrganizationUsecase } from "@/server/contexts/shared/application/usecases/create-political-organization-usecase";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
 
 const repository = new PrismaPoliticalOrganizationRepository(prisma);
 const usecase = new CreatePoliticalOrganizationUsecase(repository);
@@ -16,6 +17,8 @@ export interface CreatePoliticalOrganizationData {
 }
 
 export async function createPoliticalOrganization(data: CreatePoliticalOrganizationData) {
+  await requireAuth();
+
   try {
     const { displayName, orgName, slug, description } = data;
 

--- a/admin/src/server/contexts/shared/presentation/actions/delete-balance-snapshot.ts
+++ b/admin/src/server/contexts/shared/presentation/actions/delete-balance-snapshot.ts
@@ -4,8 +4,11 @@ import { revalidatePath } from "next/cache";
 import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaBalanceSnapshotRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-balance-snapshot.repository";
 import { DeleteBalanceSnapshotUsecase } from "@/server/contexts/shared/application/usecases/delete-balance-snapshot-usecase";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
 
 export async function deleteBalanceSnapshot(id: string) {
+  await requireAuth();
+
   try {
     if (!id.trim()) {
       throw new Error("残高スナップショットIDは必須です");

--- a/admin/src/server/contexts/shared/presentation/actions/delete-political-organization.ts
+++ b/admin/src/server/contexts/shared/presentation/actions/delete-political-organization.ts
@@ -5,6 +5,7 @@ import { revalidatePath } from "next/cache";
 import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { DeletePoliticalOrganizationUsecase } from "@/server/contexts/shared/application/usecases/delete-political-organization-usecase";
 import { PrismaPoliticalOrganizationRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-political-organization.repository";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
 
 interface DeletePoliticalOrganizationResult {
   success: boolean;
@@ -14,6 +15,8 @@ interface DeletePoliticalOrganizationResult {
 export async function deletePoliticalOrganization(
   orgId: bigint,
 ): Promise<DeletePoliticalOrganizationResult> {
+  await requireAuth();
+
   const repository = new PrismaPoliticalOrganizationRepository(prisma);
   const usecase = new DeletePoliticalOrganizationUsecase(repository);
 

--- a/admin/src/server/contexts/shared/presentation/actions/update-political-organization.ts
+++ b/admin/src/server/contexts/shared/presentation/actions/update-political-organization.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { prisma } from "@/server/contexts/shared/infrastructure/prisma";
 import { PrismaPoliticalOrganizationRepository } from "@/server/contexts/shared/infrastructure/repositories/prisma-political-organization.repository";
 import { UpdatePoliticalOrganizationUsecase } from "@/server/contexts/shared/application/usecases/update-political-organization-usecase";
+import { requireAuth } from "@/server/contexts/auth/presentation/loaders/require-auth";
 
 export interface UpdatePoliticalOrganizationData {
   displayName: string;
@@ -16,6 +17,8 @@ export async function updatePoliticalOrganization(
   id: string,
   data: UpdatePoliticalOrganizationData,
 ) {
+  await requireAuth();
+
   try {
     const organizationId = parseInt(id, 10);
 

--- a/admin/tests/server/proxy-matcher.test.ts
+++ b/admin/tests/server/proxy-matcher.test.ts
@@ -1,0 +1,63 @@
+import { config } from "@/proxy";
+
+/** Next.js が matcher 文字列を正規表現へ変換するのと同じ形でアンカーする。 */
+const toRegExp = (matcher: string) => new RegExp(`^${matcher}$`);
+
+/**
+ * proxy (middleware) の matcher は admin アプリ唯一の認証ゲート。
+ *
+ * 過去に否定先読み `.*\.(?:svg|png|...)$` がパス名全体へ適用されており、
+ * `/political-organizations/1.png` のような動的ルートが matcher から外れて
+ * 未認証のままサーバーアクションを実行できる状態だった（CLAUDE-SECURITY-RESULTS.md F1）。
+ * 拡張子ベースの除外を復活させるとこのテストが落ちる。
+ */
+describe("proxy matcher", () => {
+  const matchers = config.matcher.map(toRegExp);
+  const runsProxy = (pathname: string) => matchers.some((re) => re.test(pathname));
+
+  describe("認証ゲートを通す（proxy が実行される）", () => {
+    const guardedPaths = [
+      "/",
+      "/political-organizations",
+      "/political-organizations/1",
+      "/counterparts/5",
+      "/export-report/1/2026",
+      "/upload-csv",
+      "/users",
+    ];
+
+    it.each(guardedPaths)("%s", (pathname) => {
+      expect(runsProxy(pathname)).toBe(true);
+    });
+  });
+
+  describe("拡張子を付けた動的ルートも認証ゲートを通す（F1 リグレッション）", () => {
+    const bypassAttempts = [
+      "/political-organizations/1.png",
+      "/political-organizations/1.jpg",
+      "/political-organizations/1.jpeg",
+      "/political-organizations/1.svg",
+      "/political-organizations/1.gif",
+      "/political-organizations/1.webp",
+      "/counterparts/5.png",
+      "/export-report/1/2026.png",
+      "/users.svg",
+    ];
+
+    it.each(bypassAttempts)("%s", (pathname) => {
+      expect(runsProxy(pathname)).toBe(true);
+    });
+  });
+
+  describe("静的アセットのプレフィックスのみ除外される", () => {
+    const excludedPaths = [
+      "/_next/static/chunks/main.js",
+      "/_next/image",
+      "/favicon.ico",
+    ];
+
+    it.each(excludedPaths)("%s", (pathname) => {
+      expect(runsProxy(pathname)).toBe(false);
+    });
+  });
+});

--- a/webapp/src/proxy.ts
+++ b/webapp/src/proxy.ts
@@ -62,6 +62,9 @@ export async function proxy(request: NextRequest) {
   return NextResponse.next();
 }
 
+// 除外は静的アセットのプレフィックスのみに限定する。
+// パス中の拡張子一致で除外すると `/o/<slug>/2026.png` のような動的ルートが
+// Basic 認証・メンテナンスモードを素通りしてしまう。
 export const config = {
-  matcher: ["/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)"],
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
 };

--- a/webapp/tests/server/proxy-matcher.test.ts
+++ b/webapp/tests/server/proxy-matcher.test.ts
@@ -1,0 +1,49 @@
+import { config } from "@/proxy";
+
+/** Next.js が matcher 文字列を正規表現へ変換するのと同じ形でアンカーする。 */
+const toRegExp = (matcher: string) => new RegExp(`^${matcher}$`);
+
+/**
+ * proxy (middleware) の matcher は Basic 認証とメンテナンスモードのゲート。
+ *
+ * 過去に否定先読み `.*\.(?:svg|png|...)$` がパス名全体へ適用されており、
+ * `/o/<slug>/2026.png` のような動的ルートが Basic 認証・メンテナンスモードを
+ * 素通りできる状態だった（CLAUDE-SECURITY-RESULTS.md F3）。
+ * 拡張子ベースの除外を復活させるとこのテストが落ちる。
+ */
+describe("proxy matcher", () => {
+  const matchers = config.matcher.map(toRegExp);
+  const runsProxy = (pathname: string) => matchers.some((re) => re.test(pathname));
+
+  describe("ゲートを通す（proxy が実行される）", () => {
+    const guardedPaths = ["/", "/o/team-mirai", "/o/team-mirai/2026"];
+
+    it.each(guardedPaths)("%s", (pathname) => {
+      expect(runsProxy(pathname)).toBe(true);
+    });
+  });
+
+  describe("拡張子を付けた動的ルートもゲートを通す（F3 リグレッション）", () => {
+    const bypassAttempts = [
+      "/o/team-mirai/2026.png",
+      "/o/team-mirai/2026.jpg",
+      "/o/team-mirai/2026.jpeg",
+      "/o/team-mirai/2026.svg",
+      "/o/team-mirai/2026.gif",
+      "/o/team-mirai/2026.webp",
+      "/o/team-mirai.png",
+    ];
+
+    it.each(bypassAttempts)("%s", (pathname) => {
+      expect(runsProxy(pathname)).toBe(true);
+    });
+  });
+
+  describe("静的アセットのプレフィックスのみ除外される", () => {
+    const excludedPaths = ["/_next/static/chunks/main.js", "/_next/image", "/favicon.ico"];
+
+    it.each(excludedPaths)("%s", (pathname) => {
+      expect(runsProxy(pathname)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## 目的（Why）

admin の管理者が、**未認証の第三者にデータを書き換えられる状態を解消するため**。

proxy (middleware) の matcher が唯一の認証ゲートになっていますが、そこに穴があり、未認証のリクエストが管理画面のサーバーアクションに到達できる状態でした。webapp 側では同じ原因で Basic 認証とメンテナンスモードがバイパスされていました。

内部セキュリティスキャンの指摘（F1: HIGH / F3: MEDIUM）への対応です。

## 原因

matcher の否定先読み `.*\.(?:svg|png|jpg|jpeg|gif|webp)$` が `/_next` 配下だけでなく **パス名全体** に適用されていました。そのため動的セグメントを持つルートに画像拡張子を付けたパスが matcher から外れ、proxy が一度も実行されません。

Next.js はルートツリーのレンダリング **前** に `handleAction` を実行するため、`(auth)/layout.tsx` の `getCurrentUser()` チェックはこの経路で呼ばれたサーバーアクションを保護しません。結果として、セッションなしで政治団体レコードの更新などの書き込み操作が可能でした（公開 webapp の URL を決める `slug` を含む）。

## 変更内容

### 1. matcher の修正（根本原因）

除外を静的アセットのプレフィックスのみに限定しました。

```diff
- matcher: ["/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)"]
+ matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"]
```

`admin/src/proxy.ts` と `webapp/src/proxy.ts` の両方に適用。

### 2. 多層防御

調査したところ、**サーバーアクションと API ルートは自前の認証チェックを一切持っておらず**、proxy が唯一のゲートになっていました。matcher の修正だけに依存しない構成にするため、明示的なチェックを追加しています。

- `requireAuth()` / `requireAuthResponse()` ヘルパーを新設
- サーバーアクション **28 件** に `requireAuth()` を追加（`update-user-role`・`invite-user` も特権操作として対象）
- データを返す Route Handler **3 件** に 401 を返すガードを追加
  - `api/auth/callback` はログインフローのため意図的に対象外
- `AuthErrorCode` に `UNAUTHORIZED` を追加

### 3. リグレッションテスト

`admin/tests/server/proxy-matcher.test.ts` / `webapp/tests/server/proxy-matcher.test.ts` を追加。matcher を Next.js と同じ形で正規表現に変換し、拡張子付きの動的ルートが確実にゲートを通ることを検証します。

**旧 matcher に戻すと 9 件のケースが実際に失敗することを確認済み**（空振りテストでないことを検証しています）。

## 動作確認

| | テスト | typecheck | lint | knip |
|---|---|---|---|---|
| admin | 823 passed (+19) | ✅ | ✅ | ✅ |
| webapp | 133 passed (+13) | ✅ | ✅ | ✅ |

残存する lint warning は、いずれも本 PR で触れていないファイルの既存のものです。

## レビュー時の注意点

- **webapp の `public/` 配下が proxy 経由になります。** 中身は SVG アイコンと OG 画像のみで、Basic 認証は staging でしか有効になりません（本番は `BASIC_AUTH_SECRET` 未設定）。ただし staging で OG 画像をクローラに取得させたい場合は 401 になる点をご確認ください。
- 未対応: F3 の指摘にある `[year]` セグメントの厳密な数値検証（`parseInt("2026.png")` が `2026` を返す件）。バイパス経路自体は塞がったため緊急性は下がっていますが、別途対応が必要です。
- 実行を伴う検証（ビルド・PoC）は行っていません。matcher の挙動は Next.js 同梱の `path-to-regexp` との突き合わせで確認しています。


### depcruise の暫定例外について（要確認）

`shared` のサーバーアクションに `requireAuth()` を追加した結果、`shared → auth` の依存が発生し `no-shared-to-contexts` に抵触しました。`auth → shared` は既に 24 箇所あるため、これは**実際の循環依存**です。

根本原因は、`shared/presentation/actions` の以下 6 件が本来 `shared` に置くべきものではない点にあります。いずれも他コンテキストからは呼ばれておらず、admin 画面専用の入口です（`shared` の定義は「コンテキスト横断で共有される部品」）。

- `update-political-organization.ts` / `delete-political-organization.ts` / `create-political-organization.ts`
- `create-balance-snapshot.ts` / `delete-balance-snapshot.ts`
- `clear-webapp-cache.ts`

つまり「認証を足したら循環した」というより、**元々置き場所が不適切だったのが認証追加で可視化された**状態です。

ただし認証バイパス（HIGH）の修正をコンテキスト再編と同一 PR で行うとレビュー範囲が広がるため、**`requireAuth` のみを許可する暫定例外**を入れています。例外はごく狭く、他の `shared → auth` import は引き続きエラーになることを確認済みです。

適切なコンテキストへの移設は別 PR で対応し、その時点でこの例外を削除します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **セキュリティ**
  * 管理画面の残高、取引、レポート、CSV、ユーザー・団体情報などの操作に認証を必須化しました。
  * 未認証の場合は処理を中断し、認証要求を返します。

* **改善**
  * 拡張子付きの動的ページも認証対象になり、保護範囲を強化しました。
  * 静的アセットは引き続き適切に除外されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
