### PR TITLE
fix: 貸借対照表の値を支援技術に公開する

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,6 +221,9 @@ importers:
       jest:
         specifier: ^30.2.0
         version: 30.3.0(@types/node@25.5.0)
+      node-html-parser:
+        specifier: 9.0.0
+        version: 9.0.0
       postcss:
         specifier: ^8.5.6
         version: 8.5.8
@@ -2440,6 +2443,10 @@ packages:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
 
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
@@ -3129,6 +3136,9 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  node-html-parser@9.0.0:
+    resolution: {integrity: sha512-MhdaHPyxnyYu/sf0TpiRvDnTrkum0UKHC7FdbDGIUQNlx3I7xzwXoyV0eMUMv/XU+lkJT1glOUzpDPq7b2p1Ew==}
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -5931,6 +5941,8 @@ snapshots:
 
   entities@4.5.0: {}
 
+  entities@8.0.0: {}
+
   environment@1.1.0: {}
 
   error-ex@1.3.4:
@@ -6790,6 +6802,11 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
+
+  node-html-parser@9.0.0:
+    dependencies:
+      css-select: 5.2.2
+      entities: 8.0.0
 
   node-int64@0.4.0: {}
 

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -22,6 +22,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "jest": "^30.2.0",
+    "node-html-parser": "9.0.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.18",
     "ts-jest": "^29.4.6",

--- a/webapp/src/client/components/top-page/features/charts/BalanceSheetChart.tsx
+++ b/webapp/src/client/components/top-page/features/charts/BalanceSheetChart.tsx
@@ -170,17 +170,19 @@ export default function BalanceSheetChart({ data }: BalanceSheetChartProps) {
 
   return (
     <div className="flex justify-center mt-10">
-      <div
-        className="w-full max-w-[500px] flex gap-[1px] h-[380px]"
-        role="img"
-        aria-label="貸借対照表チャート"
-      >
+      <figure className="w-full max-w-[500px] flex gap-[1px] h-[380px]">
+        <figcaption className="sr-only">貸借対照表</figcaption>
+
         {/* 左側（資産） */}
-        <div className="flex-1 flex flex-col">{leftItems.map((item) => renderItem(item))}</div>
+        <section className="flex-1 flex flex-col" aria-label="資産">
+          {leftItems.map((item) => renderItem(item))}
+        </section>
 
         {/* 右側（負債・資本） */}
-        <div className="flex-1 flex flex-col">{rightItems.map((item) => renderItem(item))}</div>
-      </div>
+        <section className="flex-1 flex flex-col" aria-label="負債・純資産">
+          {rightItems.map((item) => renderItem(item))}
+        </section>
+      </figure>
     </div>
   );
 }

--- a/webapp/tests/client/components/top-page/features/charts/BalanceSheetChart.test.tsx
+++ b/webapp/tests/client/components/top-page/features/charts/BalanceSheetChart.test.tsx
@@ -1,3 +1,4 @@
+import { parse, type HTMLElement } from "node-html-parser";
 import { renderToStaticMarkup } from "react-dom/server";
 import BalanceSheetChart from "@/client/components/top-page/features/charts/BalanceSheetChart";
 
@@ -18,31 +19,54 @@ describe("BalanceSheetChart", () => {
       }}
     />,
   );
+  const document = parse(markup);
+
+  const getRequiredElement = (selector: string) => {
+    const element = document.querySelector(selector);
+
+    expect(element).not.toBeNull();
+
+    return element as HTMLElement;
+  };
+
+  const expectAccountAndAmount = (
+    section: HTMLElement,
+    accountName: string,
+    amount: string,
+  ) => {
+    const item = section.children.find((child) =>
+      child.textContent.replace(/\s+/g, "").includes(accountName),
+    );
+
+    expect(item).toBeDefined();
+    expect(item?.textContent.replace(/\s+/g, "")).toContain(`${accountName}${amount}`);
+  };
 
   it("貸借対照表の値を画像ロールで隠さず、意味のある図と区分として公開する", () => {
-    expect(markup).not.toContain('role="img"');
-    expect(markup).toContain("<figure");
-    expect(markup).toContain('<figcaption class="sr-only">貸借対照表</figcaption>');
-    expect(markup).toMatch(/<section[^>]*aria-label="資産"/);
-    expect(markup).toMatch(/<section[^>]*aria-label="負債・純資産"/);
+    expect(document.querySelector('[role="img"]')).toBeNull();
+
+    const figure = getRequiredElement("figure");
+    const figcaption = figure.querySelector("figcaption");
+
+    expect(figcaption).not.toBeNull();
+    expect(figcaption?.parentNode).toBe(figure);
+    expect(figure.firstElementChild).toBe(figcaption);
+    expect(figcaption?.textContent).toBe("貸借対照表");
+    expect(figcaption?.classList.contains("sr-only")).toBe(true);
+    expect(figure.querySelector('section[aria-label="資産"]')).not.toBeNull();
+    expect(figure.querySelector('section[aria-label="負債・純資産"]')).not.toBeNull();
   });
 
-  it("勘定名と金額を支援技術から参照できるテキストとして保持する", () => {
-    const textContent = markup.replace(/<[^>]+>/g, "");
+  it("各区分内で勘定名と対応する金額を支援技術から参照できる", () => {
+    const assets = getRequiredElement('section[aria-label="資産"]');
+    const liabilitiesAndNetAssets = getRequiredElement(
+      'section[aria-label="負債・純資産"]',
+    );
 
-    for (const expectedText of [
-      "流動資産",
-      "1億2345万円",
-      "固定資産",
-      "5万円",
-      "流動負債",
-      "250万円",
-      "固定負債",
-      "1万円",
-      "純資産",
-      "1億2099万円",
-    ]) {
-      expect(textContent).toContain(expectedText);
-    }
+    expectAccountAndAmount(assets, "流動資産", "1億2345万円");
+    expectAccountAndAmount(assets, "固定資産", "5万円");
+    expectAccountAndAmount(liabilitiesAndNetAssets, "流動負債", "250万円");
+    expectAccountAndAmount(liabilitiesAndNetAssets, "固定負債", "1万円");
+    expectAccountAndAmount(liabilitiesAndNetAssets, "純資産", "1億2099万円");
   });
 });

--- a/webapp/tests/client/components/top-page/features/charts/BalanceSheetChart.test.tsx
+++ b/webapp/tests/client/components/top-page/features/charts/BalanceSheetChart.test.tsx
@@ -1,0 +1,48 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import BalanceSheetChart from "@/client/components/top-page/features/charts/BalanceSheetChart";
+
+describe("BalanceSheetChart", () => {
+  const markup = renderToStaticMarkup(
+    <BalanceSheetChart
+      data={{
+        left: {
+          currentAssets: 123_450_000,
+          fixedAssets: 50_000,
+          debtExcess: 0,
+        },
+        right: {
+          currentLiabilities: 2_500_000,
+          fixedLiabilities: 10_000,
+          netAssets: 120_990_000,
+        },
+      }}
+    />,
+  );
+
+  it("貸借対照表の値を画像ロールで隠さず、意味のある図と区分として公開する", () => {
+    expect(markup).not.toContain('role="img"');
+    expect(markup).toContain("<figure");
+    expect(markup).toContain('<figcaption class="sr-only">貸借対照表</figcaption>');
+    expect(markup).toMatch(/<section[^>]*aria-label="資産"/);
+    expect(markup).toMatch(/<section[^>]*aria-label="負債・純資産"/);
+  });
+
+  it("勘定名と金額を支援技術から参照できるテキストとして保持する", () => {
+    const textContent = markup.replace(/<[^>]+>/g, "");
+
+    for (const expectedText of [
+      "流動資産",
+      "1億2345万円",
+      "固定資産",
+      "5万円",
+      "流動負債",
+      "250万円",
+      "固定負債",
+      "1万円",
+      "純資産",
+      "1億2099万円",
+    ]) {
+      expect(textContent).toContain(expectedText);
+    }
+  });
+});


### PR DESCRIPTION
## 目的

スクリーンリーダー利用者が、貸借対照表に表示される各勘定名と金額を取得できるようにするための変更です。

## 背景

`BalanceSheetChart` は、すべての勘定名・金額を含むコンテナ全体を `role=img` としていました。ARIA の画像ロールは内容を一つの原子的な画像として公開するため、子要素のテキストが支援技術から参照できず、利用者には「貸借対照表チャート」という名前しか伝わりませんでした。

## 変更内容

- 原子的な `role=img` をネイティブの `figure` / `figcaption` に変更
- 左右の内容を「資産」「負債・純資産」という名前付き `section` に整理
- 勘定名と金額が描画結果に残り、画像ロールで隠されないことを回帰テストで固定

見た目の変更はありません。

## 検証

- `pnpm --filter webapp test` — 16 suites / 135 tests passed
- `pnpm --filter admin test` — 67 passed, 1 existing skip / 823 tests passed
- admin / webapp の TypeScript 型検査 — passed
- admin / webapp の Biome lint — passed（変更外の既存 warning 5件）
- `knip` — passed（既存の configuration hint 1件）
- admin / webapp の dependency-cruiser — passed
- `pnpm --filter webapp build` — コンパイルと TypeScript は成功。静的生成時に、この作業環境に `DATABASE_URL` がないため `/sitemap.xml` の Prisma 呼び出しで停止

## アクセシビリティ確認範囲

ソース構造、静的描画結果、ARIA/HTML意味論を確認しています。WCAG/JIS適合を主張するものではありません。日本語環境の NVDA / VoiceOver で、figure、2つの区分、各勘定名・金額の読み上げ順と冗長性を人手確認する余地があります。

## 関連

- #1142 で残課題とされていた図表アクセシビリティのうち、貸借対照表に対象を限定した後続PRです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **アクセシビリティ**
  * 貸借対照表チャートにスクリーンリーダー向けの説明と適切なARIAラベルを追加しました。
  * 資産・負債の区分や勘定名、金額を、支援技術で認識しやすい形式で提供します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->