### PR TITLE
fix: 取引一覧のソート状態を支援技術へ公開する

### DIFF
--- a/webapp/e2e/tests/transactions.spec.ts
+++ b/webapp/e2e/tests/transactions.spec.ts
@@ -34,4 +34,55 @@ test.describe("取引一覧ページ", () => {
 			`以下のエラーが発生しました:\n${errors.join("\n")}`,
 		).toHaveLength(0);
 	});
+
+	test("デスクトップの列見出しが現在のソート状態を公開すること", async ({ page }) => {
+		await page.goto("/o/sample-party/2026/transactions");
+
+		const table = page.getByRole("table", { name: "政治資金取引一覧表" });
+		const dateSortButton = table.getByRole("button", { name: "日付順でソート" });
+		const amountSortButton = table.getByRole("button", { name: "金額順でソート" });
+		const dateHeader = dateSortButton.locator("xpath=ancestor::th");
+		const amountHeader = amountSortButton.locator("xpath=ancestor::th");
+
+		await expect(table.locator("th[aria-sort]")).toHaveCount(1);
+		await expect(dateHeader).toHaveAttribute("aria-sort", "descending");
+		expect(await amountHeader.getAttribute("aria-sort")).toBeNull();
+		expect(await dateSortButton.getAttribute("aria-describedby")).toBeNull();
+		expect(await amountSortButton.getAttribute("aria-describedby")).toBeNull();
+		await expect(dateSortButton.locator("img")).toHaveAttribute("alt", "");
+		await expect(amountSortButton.locator("img")).toHaveAttribute("alt", "");
+
+		await dateSortButton.click();
+		await expect(page).toHaveURL(/sort=date.*order=asc/);
+		await expect(dateHeader).toHaveAttribute("aria-sort", "ascending");
+
+		await amountSortButton.click();
+		await expect(page).toHaveURL(/sort=amount.*order=desc/);
+		await expect(table.locator("th[aria-sort]")).toHaveCount(1);
+		expect(await dateHeader.getAttribute("aria-sort")).toBeNull();
+		await expect(amountHeader).toHaveAttribute("aria-sort", "descending");
+
+		await amountSortButton.click();
+		await expect(page).toHaveURL(/sort=amount.*order=asc/);
+		await expect(amountHeader).toHaveAttribute("aria-sort", "ascending");
+	});
+
+	test("モバイルの並び順ボタンが選択状態を公開すること", async ({ page }) => {
+		await page.setViewportSize({ width: 390, height: 844 });
+		await page.goto("/o/sample-party/2026/transactions");
+
+		const sortGroup = page.getByRole("group", { name: "並び順" });
+		const newestButton = sortGroup.getByRole("button", { name: "新しい順" });
+		const oldestButton = sortGroup.getByRole("button", { name: "古い順" });
+
+		await expect(sortGroup.locator('button[aria-pressed="true"]')).toHaveCount(1);
+		await expect(newestButton).toHaveAttribute("aria-pressed", "true");
+		await expect(oldestButton).toHaveAttribute("aria-pressed", "false");
+
+		await oldestButton.click();
+		await expect(page).toHaveURL(/sort=date.*order=asc/);
+		await expect(sortGroup.locator('button[aria-pressed="true"]')).toHaveCount(1);
+		await expect(newestButton).toHaveAttribute("aria-pressed", "false");
+		await expect(oldestButton).toHaveAttribute("aria-pressed", "true");
+	});
 });

--- a/webapp/src/client/components/top-page/features/transactions-table/InteractiveTransactionTable.tsx
+++ b/webapp/src/client/components/top-page/features/transactions-table/InteractiveTransactionTable.tsx
@@ -61,16 +61,13 @@ export default function InteractiveTransactionTable({
 
   const handleSort = (field: "date" | "amount") => {
     const params = new URLSearchParams(searchParams.toString());
-    const currentSort = params.get("sort");
-    const currentOrder = params.get("order");
+    const currentSort = params.get("sort") ?? "date";
+    const currentOrder = params.get("order") ?? "desc";
 
     // Toggle order if sorting the same field, otherwise default to desc
-    if (currentSort === field) {
-      params.set("order", currentOrder === "desc" ? "asc" : "desc");
-    } else {
-      params.set("sort", field);
-      params.set("order", "desc");
-    }
+    const nextOrder = currentSort === field && currentOrder === "desc" ? "asc" : "desc";
+    params.set("sort", field);
+    params.set("order", nextOrder);
 
     // Reset to page 1 when sorting changes
     params.set("page", "1");

--- a/webapp/src/client/components/top-page/features/transactions-table/TransactionTableHeader.tsx
+++ b/webapp/src/client/components/top-page/features/transactions-table/TransactionTableHeader.tsx
@@ -20,29 +20,39 @@ export default function TransactionTableHeader({
   selectedCategories,
 }: TransactionTableHeaderProps) {
   const [isFilterOpen, setIsFilterOpen] = useState(false);
+  const activeSort = currentSort ?? "date";
+  const activeOrder = currentOrder ?? "desc";
+  const dateSortDirection =
+    activeSort === "date" ? (activeOrder === "asc" ? "ascending" : "descending") : undefined;
+  const amountSortDirection =
+    activeSort === "amount" ? (activeOrder === "asc" ? "ascending" : "descending") : undefined;
+
   return (
     <thead className="hidden md:table-header-group bg-white">
       <tr className="h-12 border-b border-[#D5DBE1]">
         {/* 日付 - 140px width to match row */}
-        <th className="text-left px-4 h-12 font-normal w-[140px]" scope="col">
+        <th
+          className="text-left px-4 h-12 font-normal w-[140px]"
+          scope="col"
+          aria-sort={allowControl ? dateSortDirection : undefined}
+        >
           {allowControl && onSort ? (
             <button
               type="button"
               onClick={() => onSort("date")}
               className="flex items-center gap-1 h-5 hover:opacity-70 transition-opacity cursor-pointer"
               aria-label="日付順でソート"
-              aria-describedby="sort-date-description"
             >
               <span className="text-gray-800 text-sm font-bold leading-[1.5]">日付</span>
               <div className="w-5 h-5 flex items-center justify-center">
                 <Image
                   src="/icons/icon-chevron-down.svg"
-                  alt="Sort by date"
+                  alt=""
                   width={20}
                   height={20}
                   className={`w-5 h-5 transition-transform ${
-                    currentSort === "date" ? (currentOrder === "asc" ? "rotate-180" : "") : ""
-                  } ${currentSort === "date" ? "opacity-100" : "opacity-50"}`}
+                    activeSort === "date" ? (activeOrder === "asc" ? "rotate-180" : "") : ""
+                  } ${activeSort === "date" ? "opacity-100" : "opacity-50"}`}
                 />
               </div>
             </button>
@@ -99,25 +109,28 @@ export default function TransactionTableHeader({
         </th>
 
         {/* 金額 - 180px width to match row (combined plus/minus + amount) */}
-        <th className="text-right pr-6 h-12 font-normal w-[180px]" scope="col">
+        <th
+          className="text-right pr-6 h-12 font-normal w-[180px]"
+          scope="col"
+          aria-sort={allowControl ? amountSortDirection : undefined}
+        >
           {allowControl && onSort ? (
             <button
               type="button"
               onClick={() => onSort("amount")}
               className="flex items-center gap-1 h-5 hover:opacity-70 transition-opacity ml-auto cursor-pointer"
               aria-label="金額順でソート"
-              aria-describedby="sort-amount-description"
             >
               <span className="text-gray-800 text-sm font-bold leading-[1.5]">金額</span>
               <div className="w-5 h-5 flex items-center justify-center">
                 <Image
                   src="/icons/icon-chevron-down.svg"
-                  alt="Sort by amount"
+                  alt=""
                   width={20}
                   height={20}
                   className={`w-5 h-5 transition-transform ${
-                    currentSort === "amount" ? (currentOrder === "asc" ? "rotate-180" : "") : ""
-                  } ${currentSort === "amount" ? "opacity-100" : "opacity-50"}`}
+                    activeSort === "amount" ? (activeOrder === "asc" ? "rotate-180" : "") : ""
+                  } ${activeSort === "amount" ? "opacity-100" : "opacity-50"}`}
                 />
               </div>
             </button>

--- a/webapp/src/client/components/top-page/features/transactions-table/TransactionTableMobileHeader.tsx
+++ b/webapp/src/client/components/top-page/features/transactions-table/TransactionTableMobileHeader.tsx
@@ -37,7 +37,8 @@ export default function TransactionTableMobileHeader({
   return (
     <div className="w-full bg-white relative border-b-0">
       {/* Tab Items */}
-      <div className="flex gap-6 overflow-x-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
+      <fieldset className="flex min-w-0 gap-6 overflow-x-auto border-0 p-0 m-0 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
+        <legend className="sr-only">並び順</legend>
         {TAB_ITEMS.map((tab) => {
           const isActive = currentSort === tab.id;
 
@@ -47,6 +48,7 @@ export default function TransactionTableMobileHeader({
               type="button"
               onClick={() => handleClick(tab.id)}
               className="flex flex-col items-center justify-center relative whitespace-nowrap py-2 px-0 cursor-pointer touch-manipulation"
+              aria-pressed={isActive}
             >
               {/* Tab Label */}
               <span
@@ -64,7 +66,7 @@ export default function TransactionTableMobileHeader({
             </button>
           );
         })}
-      </div>
+      </fieldset>
 
       {/* Bottom border line */}
       <div className="w-full h-[1px] bg-[#E5E7EB]" />


### PR DESCRIPTION
## 概要

取引一覧の並び順を、視覚的な矢印・色・下線だけでなく支援技術からも確認できるようにします。前回の #1223（貸借対照表）とは別領域の、独立したアクセシビリティ改善です。

## 問題

- デスクトップのソートボタンが、存在しない `aria-describedby` のIDを参照していました。
- 現在のソート列と昇順・降順が、矢印の向きと不透明度だけで表現されていました。
- モバイルの並び順は、選択中の項目が文字色と下線だけで表現されていました。
- 初期表示は日付降順ですが、初回の日付ボタン押下でも同じ降順を再設定していました。

## 変更内容

- 現在ソート中の列見出し1件だけに `aria-sort="ascending|descending"` を設定
- 解決先のない `aria-describedby` を削除
- ソート矢印を `alt=""` の装飾画像として扱う
- モバイルの並び順を `fieldset` / `legend` でグループ化し、各ボタンへ `aria-pressed` を設定
- 初期 `date-desc` とクリック時のトグル処理を同じ状態モデルへ統一
- デスクトップ・モバイル双方の状態遷移をPlaywright E2Eへ追加

## 検証

- `corepack pnpm --filter webapp test` — 133 tests passed
- `corepack pnpm --filter admin test` — 823 passed / 1 skipped
- `corepack pnpm --filter webapp type-check` — passed
- `corepack pnpm --filter admin type-check` — passed
- `corepack pnpm --filter webapp lint` — passed（既存警告1件）
- `corepack pnpm --filter admin lint` — passed（既存警告4件）
- `corepack pnpm exec knip` — passed（既存configuration hint 1件）
- dependency-cruiser（admin / webapp）— passed
- `corepack pnpm --filter admin build` — passed
- Playwright test discovery — 3 tests recognized

ローカルのwebapp buildはコンパイルと型検査まで成功し、`DATABASE_URL` がないため `/sitemap.xml` の静的生成で停止しました。Dockerエンジンが未起動だったため追加E2Eの実走はPR CIで確認します。

## アクセシビリティ上の境界

これは対象コンポーネントの `SCREEN-ARIA` 補助チェックに基づく修正であり、WCAG/JIS全体への適合を主張するものではありません。NVDA / VoiceOverによる日本語読み上げは人手確認が必要です。

## 既存PRとの関係

- #1142 の変更ファイル（Selector、Header、CashFlow等）とは重複しません。
- #1223 の貸借対照表修正とは変更ファイル・利用者操作とも重複しません。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 取引一覧の並び替えで、指定がない場合の日付・降順を既定値として適用。
  * デスクトップ・モバイルで、現在の並び替え項目と選択状態を明確に表示。
  * スクリーンリーダー向けのARIA属性を改善し、並び替え操作のアクセシビリティを向上。
* **テスト**
  * デスクトップ・モバイルの並び替え、選択状態、ARIA属性、URL遷移に関するテストを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->