### PR TITLE
docs: Gitブランチ運用のmain単一化移行手順を追加

### DIFF
--- a/docs/20260823_1813_Gitブランチ運用のmain単一化移行手順.md
+++ b/docs/20260823_1813_Gitブランチ運用のmain単一化移行手順.md
@@ -1,0 +1,187 @@
+# Git ブランチ運用の main 単一化 移行手順
+
+## 目的
+
+開発者が「develop と main の2本のブランチを同期させ続ける手間」から解放されるため。
+
+現状は develop（ステージング）と main（プロダクション）の2本立てで、本番反映のたびに develop → main の PR を作成・マージする必要がある。実際 `origin/develop..origin/main` には develop 側へ取り込まれていないコミットが7件あり（`SECURITY.md` 追加など main 直接コミット由来のものを含む）、両ブランチの乖離が発生している。
+
+これを main 単一ブランチに統合し、次の運用に変更する。
+
+| 環境 | デプロイ契機 |
+|------|-------------|
+| ステージング | main への push で自動デプロイ（従来どおり） |
+| プロダクション | 手動でボタンを押してデプロイ |
+
+## 現状の構成
+
+### リポジトリ
+
+- リポジトリ: `team-mirai/marumie`
+- デフォルトブランチ: `develop`（`origin/HEAD -> origin/develop`）
+- 対象アプリ: `webapp`（公開用フロントエンド）、`admin`（管理画面）の2つ。それぞれ Vercel プロジェクトが存在する想定
+
+### ブランチの乖離状況
+
+```
+origin/main..origin/develop : 15 コミット（develop にあって main にない）
+origin/develop..origin/main :  7 コミット（main にあって develop にない）
+```
+
+両方向に差分があるため、移行前に必ず双方向の同期が必要。
+
+### ブランチ名を参照している箇所
+
+| ファイル | 該当箇所 | 内容 |
+|----------|---------|------|
+| `.coderabbit.yml` | L86 | `reviews.auto_review.base_branches` に `develop` |
+| `README.md` | L5 | codecov バッジの URL に `branch/develop` |
+| `.claude/commands/pr.md` | L26, L27, L38, L48 | PR 作成手順の develop 前提の記述 |
+| `.claude/commands/e2e.md` | L18 | 差分取得の基準ブランチが `develop` |
+
+`.github/workflows/ci.yml` は `on: pull_request` のみでブランチ名の指定がないため**変更不要**。`.github/workflows/dependabot-auto-merge.yml` も `workflow_run` 起動でブランチ名を持たないため**変更不要**。`renovate.json` も `baseBranches` 未指定（デフォルトブランチに追随）のため**変更不要**。
+
+### Vercel 側の現状（要確認）
+
+`webapp/vercel.json` / `admin/vercel.json` にはビルドコマンドのみ記載されており、ブランチとデプロイ環境の紐付けは Vercel ダッシュボード側の設定で管理されている。
+
+コード内で `VERCEL_ENV` を参照している箇所が1つある。
+
+- `webapp/src/server/contexts/public-finance/presentation/loaders/constants.ts`
+  - `process.env.VERCEL_ENV === "production" ? 3600 : 10`（キャッシュ revalidate 秒数）
+
+**この定数の挙動は移行方式によって変わるため、後述の「注意点」を必ず確認すること。**
+
+## 移行手順
+
+### フェーズ1: 事前準備（コード変更なし）
+
+1. **チームへの周知**
+   - 移行日時と、移行後は develop を使わないことをアナウンスする
+   - 移行作業中は develop / main への push を止めてもらう
+
+2. **オープンな PR の棚卸し**
+   - base が `develop` になっている PR を一覧化する（`gh pr list --base develop`）
+   - 移行後、これらの PR の base を `main` に変更する必要がある（GitHub のデフォルトブランチ変更時に自動追随しないため）
+
+3. **Vercel の現行設定をスクリーンショット等で記録**
+   - webapp / admin それぞれの Production Branch 設定
+   - 各環境（Production / Preview）の環境変数一覧
+   - ロールバック時に元へ戻せるようにしておく
+
+### フェーズ2: ブランチの同期
+
+4. **main → develop の取り込み**
+   - main にしかないコミット7件を develop へマージする PR を作成しマージする
+   - すでに `merge/main-to-develop` というブランチが存在するため、これが使えるか確認する
+
+5. **develop → main の取り込み**
+   - develop の内容を main へマージする PR を作成しマージする（従来の本番リリースと同じ操作）
+   - これにより develop と main の内容が完全に一致する
+
+6. **一致の確認**
+   - `git rev-list --count origin/main..origin/develop` と `git rev-list --count origin/develop..origin/main` が両方 0 になることを確認する
+
+### フェーズ3: Vercel の設定変更
+
+7. **ステージング環境の向き先変更**
+   - ステージング用の Vercel プロジェクト（または環境）の対象ブランチを `develop` から `main` へ変更する
+   - webapp / admin の両方について実施する
+
+8. **プロダクション環境の自動デプロイ停止**
+   - プロダクション用 Vercel プロジェクトで、main への push による自動デプロイを無効化する
+   - Vercel の設定方法は複数あるため、いずれかを選択する:
+     - **Ignored Build Step** に `exit 0`（＝常にビルドをスキップ）を設定し、手動 Redeploy のみ受け付ける
+     - **Git Integration の Production Deployment を無効化**（Settings → Git → Production Deployments を off）
+   - webapp / admin の両方について実施する
+
+9. **手動デプロイ手順の確認**
+   - プロダクションへの手動デプロイ操作を実際に1回試し、想定どおり動くことを確認する
+   - Vercel ダッシュボードの Deployments 一覧から、対象コミットの「Promote to Production」または「Redeploy」を使う運用になる
+
+### フェーズ4: GitHub の設定変更
+
+10. **デフォルトブランチの変更**
+    - Settings → General → Default branch を `develop` から `main` へ変更する
+    - これにより `gh pr create` が自動的に main を base にするようになる（`pr.md` は `--base` を付けない方針のため）
+
+11. **ブランチ保護ルールの移行**
+    - develop に設定されている保護ルール（Require status checks など）を main に対して設定する
+    - CI のステータスチェック必須設定を main へ移す
+    - develop の保護ルールを削除する
+
+12. **フェーズ1で洗い出した PR の base 付け替え**
+    - `gh pr edit <番号> --base main` で順次変更する
+
+13. **develop ブランチの削除**
+    - リモートの develop を削除する（`git push origin --delete develop`）
+    - 削除前に、main に develop の内容がすべて含まれていることを再確認する
+    - 各開発者にローカルの develop 削除と `git fetch --prune` を依頼する
+
+### フェーズ5: リポジトリ内の記述変更
+
+14. **`.coderabbit.yml`**
+    - `reviews.auto_review.base_branches` の `develop` を `main` に変更する
+
+15. **`README.md`**
+    - codecov バッジ URL の `branch/develop` を `branch/main` に変更する
+
+16. **`.claude/commands/pr.md`**
+    - L26, L27: ブランチ決定手順の「developやmain」「developから新しいブランチを作成」を main 基準に書き換える
+    - L38: コンフリクト確認の `origin/develop` を `origin/main` に変更する
+    - L48: 「developやmainへの直接pushは禁止」を「mainへの直接pushは禁止」に変更する
+
+17. **`.claude/commands/e2e.md`**
+    - L18: 差分取得の基準を `develop...HEAD` から `main...HEAD` に変更する
+
+18. **codecov 側の設定確認**
+    - codecov のデフォルトブランチ設定が develop になっている場合、main へ変更する（バッジ URL 変更だけでは不十分な場合がある）
+
+### フェーズ6: 動作確認
+
+19. **ステージングの自動デプロイ確認**
+    - main へ何らかの変更をマージし、ステージングに自動反映されることを確認する
+
+20. **プロダクションの手動デプロイ確認**
+    - main への push でプロダクションが**自動デプロイされないこと**を確認する
+    - 手動デプロイ操作でプロダクションへ反映されることを確認する
+
+21. **CI とレビュー自動化の確認**
+    - main を base とした PR で CI が起動することを確認する
+    - CodeRabbit の自動レビューが起動することを確認する
+
+## 注意点
+
+### VERCEL_ENV とキャッシュ設定の関係
+
+`webapp/src/server/contexts/public-finance/presentation/loaders/constants.ts` は `VERCEL_ENV === "production"` のときだけ revalidate を 3600 秒にし、それ以外は 10 秒にしている。
+
+Vercel の `VERCEL_ENV` は「どのブランチか」ではなく「Production デプロイか Preview デプロイか」で決まる。したがって:
+
+- ステージングを **Preview デプロイ**として運用する場合 → `VERCEL_ENV` は `preview` となり、revalidate は 10 秒のまま（現状の develop 運用と同じ挙動）
+- ステージングを **別 Vercel プロジェクトの Production** として運用する場合 → `VERCEL_ENV` は `production` となり、revalidate が 3600 秒になる
+
+現状のステージングがどちらの方式かによって、移行後の挙動が変わりうる。フェーズ3の設定変更時に現行方式を確認し、挙動が変わる場合はこの定数の判定条件を見直すこと。
+
+### DB マイグレーションの実行タイミング
+
+`webapp/vercel.json` の `buildCommand` は `pnpm run build:vercel` で、これは `db:setup`（`prisma migrate deploy`）を含む。つまり **webapp のビルドが走るたびにマイグレーションが実行される**。
+
+プロダクションを手動デプロイに変えると、「main にマージ済みだがプロダクション未デプロイ」という状態が常態化する。このとき:
+
+- ステージングのビルドではステージング DB にマイグレーションが適用される
+- プロダクション DB には手動デプロイするまでマイグレーションが適用されない
+
+つまり main のコードとプロダクション DB のスキーマがずれる期間が生まれる。破壊的なマイグレーション（カラム削除・リネームなど）を含む変更では、この期間を意識した運用が必要になる。
+
+### main へのマージ = ステージング反映という意味変化
+
+これまで develop へのマージは「ステージングで検証する」意味だったが、移行後は main へのマージが同じ役割を担う。main は「常にリリース可能な状態」ではなく「ステージングで検証中の状態」になる点をチームで合意しておく必要がある。
+
+プロダクションへ何をデプロイしたかは Vercel のデプロイ履歴でのみ追跡できるようになるため、リリースタグを打つなどの運用を別途検討する余地がある。
+
+### 作業の順序
+
+フェーズ2（ブランチ同期）を完了せずにフェーズ4（develop 削除）へ進むと、main にしかないコミットや develop にしかないコミットが失われる。フェーズは順番どおりに実施すること。
+
+また、フェーズ3（Vercel のプロダクション自動デプロイ停止）をフェーズ2（develop → main マージ）より先に行うと、意図しないタイミングでプロダクションへデプロイされる事故を防げる。順序を入れ替えたい場合はこの点を考慮する。


### PR DESCRIPTION
## 目的

開発者が「develop と main の2本のブランチを同期させ続ける手間」から解放されるため。

現状は develop（ステージング）と main（プロダクション）の2本立てで、本番反映のたびに develop → main の PR を作成・マージする必要がある。実際に両ブランチは双方向に乖離しており、`origin/develop..origin/main` には develop へ取り込まれていないコミットが7件ある（`SECURITY.md` 追加など main 直接コミット由来のものを含む）。

これを main 単一ブランチへ統合するための移行手順を設計ドキュメントとしてまとめた。

| 環境 | 移行後のデプロイ契機 |
|------|-------------------|
| ステージング | main への push で自動デプロイ（従来どおり） |
| プロダクション | 手動でボタンを押してデプロイ |

## 変更内容

設計ドキュメント1件の追加のみで、コードの変更はない。

- `docs/20260823_1813_Gitブランチ運用のmain単一化移行手順.md`

移行手順を6フェーズ21ステップに分解している（事前準備 → ブランチ同期 → Vercel設定変更 → GitHub設定変更 → リポジトリ内記述変更 → 動作確認）。

## 調査でわかったこと

**ブランチ名を参照しているのは4ファイルのみ**

- `.coderabbit.yml` (L86) — `base_branches`
- `README.md` (L5) — codecov バッジ URL
- `.claude/commands/pr.md` (L26, L27, L38, L48)
- `.claude/commands/e2e.md` (L18)

一方 `ci.yml` / `dependabot-auto-merge.yml` / `renovate.json` は変更不要（前者2つはブランチ名を持たないトリガー、renovate は `baseBranches` 未指定でデフォルトブランチに追随するため）。

## レビューで特に見てほしい点

ドキュメント内「注意点」に記載した以下2点について、認識が合っているか確認いただきたい。

**1. `VERCEL_ENV` とキャッシュ設定の関係**

`webapp/src/server/contexts/public-finance/presentation/loaders/constants.ts` が `VERCEL_ENV === "production"` で revalidate を 3600秒/10秒 に切り替えている。`VERCEL_ENV` はブランチではなく Production/Preview デプロイの別で決まるため、現状のステージングがどちらの方式で動いているかによって移行後の挙動が変わりうる。

**2. マイグレーションとプロダクションデプロイのズレ**

`webapp/vercel.json` の `build:vercel` が `prisma migrate deploy` を含むため、ビルドのたびにマイグレーションが走る。プロダクションを手動デプロイにすると「main にマージ済みだが本番未デプロイ」＝ コードと本番DBスキーマがずれる期間が常態化する。

なお Vercel のプロダクション自動デプロイ停止方法は「Ignored Build Step に `exit 0`」と「Git Integration の Production Deployments 無効化」の2案を併記している。実際の設定画面を見て選定いただきたい。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **ドキュメント**
  - main単一ブランチ運用へ移行するための手順を追加しました。
  - developとmainの同期、ステージング・本番デプロイ設定の変更、GitHub設定更新、動作確認までの流れを整理しました。
  - キャッシュ設定、データベースマイグレーション、移行後の運用上の注意点を記載しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->