### PR TITLE
docs: ブランチ同期は develop → main の一方向で足りる旨に訂正

### DIFF
--- a/docs/20260823_1813_Gitブランチ運用のmain単一化移行手順.md
+++ b/docs/20260823_1813_Gitブランチ運用のmain単一化移行手順.md
@@ -4,7 +4,7 @@
 
 開発者が「develop と main の2本のブランチを同期させ続ける手間」から解放されるため。
 
-現状は develop（ステージング）と main（プロダクション）の2本立てで、本番反映のたびに develop → main の PR を作成・マージする必要がある。実際 `origin/develop..origin/main` には develop 側へ取り込まれていないコミットが7件あり（`SECURITY.md` 追加など main 直接コミット由来のものを含む）、両ブランチの乖離が発生している。
+現状は develop（ステージング）と main（プロダクション）の2本立てで、本番反映のたびに develop → main の PR を作成・マージする必要がある。
 
 これを main 単一ブランチに統合し、次の運用に変更する。
 
@@ -23,12 +23,21 @@
 
 ### ブランチの乖離状況
 
+コミット数のうえでは両方向に差分がある。
+
 ```
 origin/main..origin/develop : 15 コミット（develop にあって main にない）
 origin/develop..origin/main :  7 コミット（main にあって develop にない）
 ```
 
-両方向に差分があるため、移行前に必ず双方向の同期が必要。
+ただし後者7件の中身を確認したところ、**main 独自の実質的な変更は存在しない**。
+
+- 6件は `Merge pull request #xxxx from team-mirai/develop` というリリースマージコミット自体であり、内容の変更を持たない
+- 残る1件 `bb5c984b`（`SECURITY.md` の追加）は、同一内容のファイルが develop 側にも別経路で存在する（`diff` で完全一致を確認済み）
+
+ファイル単位で照合しても main のみに存在するファイルはなく、develop は main の内容を完全に包含している。
+
+したがって**同期は develop → main の一方向マージのみでよい**。
 
 ### ブランチ名を参照している箇所
 
@@ -71,82 +80,82 @@ origin/develop..origin/main :  7 コミット（main にあって develop にな
 
 ### フェーズ2: ブランチの同期
 
-4. **main → develop の取り込み**
-   - main にしかないコミット7件を develop へマージする PR を作成しマージする
-   - すでに `merge/main-to-develop` というブランチが存在するため、これが使えるか確認する
+前述のとおり develop は main の内容をすべて含むため、一方向のマージのみで足りる。
 
-5. **develop → main の取り込み**
+4. **develop → main の取り込み**
    - develop の内容を main へマージする PR を作成しマージする（従来の本番リリースと同じ操作）
-   - これにより develop と main の内容が完全に一致する
+   - これにより main の内容が develop と一致する
+   - この操作は本番デプロイを伴うため、マージのタイミングに注意する
 
-6. **一致の確認**
-   - `git rev-list --count origin/main..origin/develop` と `git rev-list --count origin/develop..origin/main` が両方 0 になることを確認する
+5. **一致の確認**
+   - `git diff origin/main origin/develop` に差分が出ないことを確認する
+   - マージコミット分だけ `git rev-list --count origin/develop..origin/main` は 0 にならないが、内容が一致していれば問題ない
 
 ### フェーズ3: Vercel の設定変更
 
-7. **ステージング環境の向き先変更**
+6. **ステージング環境の向き先変更**
    - ステージング用の Vercel プロジェクト（または環境）の対象ブランチを `develop` から `main` へ変更する
    - webapp / admin の両方について実施する
 
-8. **プロダクション環境の自動デプロイ停止**
+7. **プロダクション環境の自動デプロイ停止**
    - プロダクション用 Vercel プロジェクトで、main への push による自動デプロイを無効化する
    - Vercel の設定方法は複数あるため、いずれかを選択する:
      - **Ignored Build Step** に `exit 0`（＝常にビルドをスキップ）を設定し、手動 Redeploy のみ受け付ける
      - **Git Integration の Production Deployment を無効化**（Settings → Git → Production Deployments を off）
    - webapp / admin の両方について実施する
 
-9. **手動デプロイ手順の確認**
+8. **手動デプロイ手順の確認**
    - プロダクションへの手動デプロイ操作を実際に1回試し、想定どおり動くことを確認する
    - Vercel ダッシュボードの Deployments 一覧から、対象コミットの「Promote to Production」または「Redeploy」を使う運用になる
 
 ### フェーズ4: GitHub の設定変更
 
-10. **デフォルトブランチの変更**
+9. **デフォルトブランチの変更**
     - Settings → General → Default branch を `develop` から `main` へ変更する
     - これにより `gh pr create` が自動的に main を base にするようになる（`pr.md` は `--base` を付けない方針のため）
 
-11. **ブランチ保護ルールの移行**
+10. **ブランチ保護ルールの移行**
     - develop に設定されている保護ルール（Require status checks など）を main に対して設定する
     - CI のステータスチェック必須設定を main へ移す
     - develop の保護ルールを削除する
 
-12. **フェーズ1で洗い出した PR の base 付け替え**
+11. **フェーズ1で洗い出した PR の base 付け替え**
     - `gh pr edit <番号> --base main` で順次変更する
 
-13. **develop ブランチの削除**
+12. **develop ブランチの削除**
     - リモートの develop を削除する（`git push origin --delete develop`）
     - 削除前に、main に develop の内容がすべて含まれていることを再確認する
     - 各開発者にローカルの develop 削除と `git fetch --prune` を依頼する
 
 ### フェーズ5: リポジトリ内の記述変更
 
-14. **`.coderabbit.yml`**
+13. **`.coderabbit.yml`**
     - `reviews.auto_review.base_branches` の `develop` を `main` に変更する
 
-15. **`README.md`**
+14. **`README.md`**
     - codecov バッジ URL の `branch/develop` を `branch/main` に変更する
 
-16. **`.claude/commands/pr.md`**
+15. **`.claude/commands/pr.md`**
     - L26, L27: ブランチ決定手順の「developやmain」「developから新しいブランチを作成」を main 基準に書き換える
     - L38: コンフリクト確認の `origin/develop` を `origin/main` に変更する
     - L48: 「developやmainへの直接pushは禁止」を「mainへの直接pushは禁止」に変更する
 
-17. **`.claude/commands/e2e.md`**
+16. **`.claude/commands/e2e.md`**
     - L18: 差分取得の基準を `develop...HEAD` から `main...HEAD` に変更する
 
-18. **codecov 側の設定確認**
+17. **codecov 側の設定確認**
     - codecov のデフォルトブランチ設定が develop になっている場合、main へ変更する（バッジ URL 変更だけでは不十分な場合がある）
 
 ### フェーズ6: 動作確認
 
-19. **ステージングの自動デプロイ確認**
+18. **ステージングの自動デプロイ確認**
     - main へ何らかの変更をマージし、ステージングに自動反映されることを確認する
 
-20. **プロダクションの手動デプロイ確認**
+19. **プロダクションの手動デプロイ確認**
     - main への push でプロダクションが**自動デプロイされないこと**を確認する
     - 手動デプロイ操作でプロダクションへ反映されることを確認する
 
-21. **CI とレビュー自動化の確認**
+20. **CI とレビュー自動化の確認**
     - main を base とした PR で CI が起動することを確認する
     - CodeRabbit の自動レビューが起動することを確認する
 
@@ -182,6 +191,6 @@ Vercel の `VERCEL_ENV` は「どのブランチか」ではなく「Production 
 
 ### 作業の順序
 
-フェーズ2（ブランチ同期）を完了せずにフェーズ4（develop 削除）へ進むと、main にしかないコミットや develop にしかないコミットが失われる。フェーズは順番どおりに実施すること。
+フェーズ2（ブランチ同期）を完了せずにフェーズ4（develop 削除）へ進むと、develop にしかないコミットが失われる。フェーズは順番どおりに実施すること。
 
 また、フェーズ3（Vercel のプロダクション自動デプロイ停止）をフェーズ2（develop → main マージ）より先に行うと、意図しないタイミングでプロダクションへデプロイされる事故を防げる。順序を入れ替えたい場合はこの点を考慮する。


### PR DESCRIPTION
## 目的

移行作業者が、不要な `main → develop` の同期作業を行わずに済むため。

先行 PR #1232 で追加した移行手順ドキュメントに誤りがあったため訂正する。

## 何が誤っていたか

「`origin/develop..origin/main` に7コミットあるので、両方向の同期が必要」と記載していたが、これはコミット数のみを見た誤りだった。中身を確認したところ **main 独自の実質的な変更は存在しない**。

- 6件は `Merge pull request #xxxx from team-mirai/develop` というリリースマージコミット自体であり、内容の変更を持たない
- 残る1件 `bb5c984b`（`SECURITY.md` の追加）は、同一内容のファイルが develop 側にも別経路で存在する（`diff` で完全一致を確認済み）

ファイル単位で照合しても main のみに存在するファイルはなく、develop は main の内容を完全に包含している。

## 変更内容

ドキュメント1件の修正のみで、コードの変更はない。

- 「乖離状況」セクションに上記の調査結果を追記
- フェーズ2から「main → develop の取り込み」ステップを削除し、`develop → main` の一方向マージのみに変更
- 一致の確認方法を `git diff origin/main origin/develop` に変更（マージコミット分があるためコミット数は 0 にならない）
- 「注意点 > 作業の順序」の記述を実態に合わせる
- 以降のステップ番号を繰り上げ（全21ステップ → 20ステップ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * Gitブランチ運用の移行手順を更新しました。
  * `develop` から `main` への一方向マージで同期できる運用を明記しました。
  * 不要になった同期作業を削除し、内容差分を中心とした確認手順に変更しました。
  * 作業順序に関する注意事項を明確化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->