### PR TITLE
release: develop の内容を main へ反映

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -35,7 +35,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "iconv-lite": "^0.7.2",
-    "lucide-react": "^0.562.0",
+    "lucide-react": "^0.577.0",
     "next": "16.1.1",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/docs/20260823_1813_Gitブランチ運用のmain単一化移行手順.md
+++ b/docs/20260823_1813_Gitブランチ運用のmain単一化移行手順.md
@@ -1,0 +1,187 @@
+# Git ブランチ運用の main 単一化 移行手順
+
+## 目的
+
+開発者が「develop と main の2本のブランチを同期させ続ける手間」から解放されるため。
+
+現状は develop（ステージング）と main（プロダクション）の2本立てで、本番反映のたびに develop → main の PR を作成・マージする必要がある。実際 `origin/develop..origin/main` には develop 側へ取り込まれていないコミットが7件あり（`SECURITY.md` 追加など main 直接コミット由来のものを含む）、両ブランチの乖離が発生している。
+
+これを main 単一ブランチに統合し、次の運用に変更する。
+
+| 環境 | デプロイ契機 |
+|------|-------------|
+| ステージング | main への push で自動デプロイ（従来どおり） |
+| プロダクション | 手動でボタンを押してデプロイ |
+
+## 現状の構成
+
+### リポジトリ
+
+- リポジトリ: `team-mirai/marumie`
+- デフォルトブランチ: `develop`（`origin/HEAD -> origin/develop`）
+- 対象アプリ: `webapp`（公開用フロントエンド）、`admin`（管理画面）の2つ。それぞれ Vercel プロジェクトが存在する想定
+
+### ブランチの乖離状況
+
+```
+origin/main..origin/develop : 15 コミット（develop にあって main にない）
+origin/develop..origin/main :  7 コミット（main にあって develop にない）
+```
+
+両方向に差分があるため、移行前に必ず双方向の同期が必要。
+
+### ブランチ名を参照している箇所
+
+| ファイル | 該当箇所 | 内容 |
+|----------|---------|------|
+| `.coderabbit.yml` | L86 | `reviews.auto_review.base_branches` に `develop` |
+| `README.md` | L5 | codecov バッジの URL に `branch/develop` |
+| `.claude/commands/pr.md` | L26, L27, L38, L48 | PR 作成手順の develop 前提の記述 |
+| `.claude/commands/e2e.md` | L18 | 差分取得の基準ブランチが `develop` |
+
+`.github/workflows/ci.yml` は `on: pull_request` のみでブランチ名の指定がないため**変更不要**。`.github/workflows/dependabot-auto-merge.yml` も `workflow_run` 起動でブランチ名を持たないため**変更不要**。`renovate.json` も `baseBranches` 未指定（デフォルトブランチに追随）のため**変更不要**。
+
+### Vercel 側の現状（要確認）
+
+`webapp/vercel.json` / `admin/vercel.json` にはビルドコマンドのみ記載されており、ブランチとデプロイ環境の紐付けは Vercel ダッシュボード側の設定で管理されている。
+
+コード内で `VERCEL_ENV` を参照している箇所が1つある。
+
+- `webapp/src/server/contexts/public-finance/presentation/loaders/constants.ts`
+  - `process.env.VERCEL_ENV === "production" ? 3600 : 10`（キャッシュ revalidate 秒数）
+
+**この定数の挙動は移行方式によって変わるため、後述の「注意点」を必ず確認すること。**
+
+## 移行手順
+
+### フェーズ1: 事前準備（コード変更なし）
+
+1. **チームへの周知**
+   - 移行日時と、移行後は develop を使わないことをアナウンスする
+   - 移行作業中は develop / main への push を止めてもらう
+
+2. **オープンな PR の棚卸し**
+   - base が `develop` になっている PR を一覧化する（`gh pr list --base develop`）
+   - 移行後、これらの PR の base を `main` に変更する必要がある（GitHub のデフォルトブランチ変更時に自動追随しないため）
+
+3. **Vercel の現行設定をスクリーンショット等で記録**
+   - webapp / admin それぞれの Production Branch 設定
+   - 各環境（Production / Preview）の環境変数一覧
+   - ロールバック時に元へ戻せるようにしておく
+
+### フェーズ2: ブランチの同期
+
+4. **main → develop の取り込み**
+   - main にしかないコミット7件を develop へマージする PR を作成しマージする
+   - すでに `merge/main-to-develop` というブランチが存在するため、これが使えるか確認する
+
+5. **develop → main の取り込み**
+   - develop の内容を main へマージする PR を作成しマージする（従来の本番リリースと同じ操作）
+   - これにより develop と main の内容が完全に一致する
+
+6. **一致の確認**
+   - `git rev-list --count origin/main..origin/develop` と `git rev-list --count origin/develop..origin/main` が両方 0 になることを確認する
+
+### フェーズ3: Vercel の設定変更
+
+7. **ステージング環境の向き先変更**
+   - ステージング用の Vercel プロジェクト（または環境）の対象ブランチを `develop` から `main` へ変更する
+   - webapp / admin の両方について実施する
+
+8. **プロダクション環境の自動デプロイ停止**
+   - プロダクション用 Vercel プロジェクトで、main への push による自動デプロイを無効化する
+   - Vercel の設定方法は複数あるため、いずれかを選択する:
+     - **Ignored Build Step** に `exit 0`（＝常にビルドをスキップ）を設定し、手動 Redeploy のみ受け付ける
+     - **Git Integration の Production Deployment を無効化**（Settings → Git → Production Deployments を off）
+   - webapp / admin の両方について実施する
+
+9. **手動デプロイ手順の確認**
+   - プロダクションへの手動デプロイ操作を実際に1回試し、想定どおり動くことを確認する
+   - Vercel ダッシュボードの Deployments 一覧から、対象コミットの「Promote to Production」または「Redeploy」を使う運用になる
+
+### フェーズ4: GitHub の設定変更
+
+10. **デフォルトブランチの変更**
+    - Settings → General → Default branch を `develop` から `main` へ変更する
+    - これにより `gh pr create` が自動的に main を base にするようになる（`pr.md` は `--base` を付けない方針のため）
+
+11. **ブランチ保護ルールの移行**
+    - develop に設定されている保護ルール（Require status checks など）を main に対して設定する
+    - CI のステータスチェック必須設定を main へ移す
+    - develop の保護ルールを削除する
+
+12. **フェーズ1で洗い出した PR の base 付け替え**
+    - `gh pr edit <番号> --base main` で順次変更する
+
+13. **develop ブランチの削除**
+    - リモートの develop を削除する（`git push origin --delete develop`）
+    - 削除前に、main に develop の内容がすべて含まれていることを再確認する
+    - 各開発者にローカルの develop 削除と `git fetch --prune` を依頼する
+
+### フェーズ5: リポジトリ内の記述変更
+
+14. **`.coderabbit.yml`**
+    - `reviews.auto_review.base_branches` の `develop` を `main` に変更する
+
+15. **`README.md`**
+    - codecov バッジ URL の `branch/develop` を `branch/main` に変更する
+
+16. **`.claude/commands/pr.md`**
+    - L26, L27: ブランチ決定手順の「developやmain」「developから新しいブランチを作成」を main 基準に書き換える
+    - L38: コンフリクト確認の `origin/develop` を `origin/main` に変更する
+    - L48: 「developやmainへの直接pushは禁止」を「mainへの直接pushは禁止」に変更する
+
+17. **`.claude/commands/e2e.md`**
+    - L18: 差分取得の基準を `develop...HEAD` から `main...HEAD` に変更する
+
+18. **codecov 側の設定確認**
+    - codecov のデフォルトブランチ設定が develop になっている場合、main へ変更する（バッジ URL 変更だけでは不十分な場合がある）
+
+### フェーズ6: 動作確認
+
+19. **ステージングの自動デプロイ確認**
+    - main へ何らかの変更をマージし、ステージングに自動反映されることを確認する
+
+20. **プロダクションの手動デプロイ確認**
+    - main への push でプロダクションが**自動デプロイされないこと**を確認する
+    - 手動デプロイ操作でプロダクションへ反映されることを確認する
+
+21. **CI とレビュー自動化の確認**
+    - main を base とした PR で CI が起動することを確認する
+    - CodeRabbit の自動レビューが起動することを確認する
+
+## 注意点
+
+### VERCEL_ENV とキャッシュ設定の関係
+
+`webapp/src/server/contexts/public-finance/presentation/loaders/constants.ts` は `VERCEL_ENV === "production"` のときだけ revalidate を 3600 秒にし、それ以外は 10 秒にしている。
+
+Vercel の `VERCEL_ENV` は「どのブランチか」ではなく「Production デプロイか Preview デプロイか」で決まる。したがって:
+
+- ステージングを **Preview デプロイ**として運用する場合 → `VERCEL_ENV` は `preview` となり、revalidate は 10 秒のまま（現状の develop 運用と同じ挙動）
+- ステージングを **別 Vercel プロジェクトの Production** として運用する場合 → `VERCEL_ENV` は `production` となり、revalidate が 3600 秒になる
+
+現状のステージングがどちらの方式かによって、移行後の挙動が変わりうる。フェーズ3の設定変更時に現行方式を確認し、挙動が変わる場合はこの定数の判定条件を見直すこと。
+
+### DB マイグレーションの実行タイミング
+
+`webapp/vercel.json` の `buildCommand` は `pnpm run build:vercel` で、これは `db:setup`（`prisma migrate deploy`）を含む。つまり **webapp のビルドが走るたびにマイグレーションが実行される**。
+
+プロダクションを手動デプロイに変えると、「main にマージ済みだがプロダクション未デプロイ」という状態が常態化する。このとき:
+
+- ステージングのビルドではステージング DB にマイグレーションが適用される
+- プロダクション DB には手動デプロイするまでマイグレーションが適用されない
+
+つまり main のコードとプロダクション DB のスキーマがずれる期間が生まれる。破壊的なマイグレーション（カラム削除・リネームなど）を含む変更では、この期間を意識した運用が必要になる。
+
+### main へのマージ = ステージング反映という意味変化
+
+これまで develop へのマージは「ステージングで検証する」意味だったが、移行後は main へのマージが同じ役割を担う。main は「常にリリース可能な状態」ではなく「ステージングで検証中の状態」になる点をチームで合意しておく必要がある。
+
+プロダクションへ何をデプロイしたかは Vercel のデプロイ履歴でのみ追跡できるようになるため、リリースタグを打つなどの運用を別途検討する余地がある。
+
+### 作業の順序
+
+フェーズ2（ブランチ同期）を完了せずにフェーズ4（develop 削除）へ進むと、main にしかないコミットや develop にしかないコミットが失われる。フェーズは順番どおりに実施すること。
+
+また、フェーズ3（Vercel のプロダクション自動デプロイ停止）をフェーズ2（develop → main マージ）より先に行うと、意図しないタイミングでプロダクションへデプロイされる事故を防げる。順序を入れ替えたい場合はこの点を考慮する。

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "dotenv": "^17.0.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.3.11",
+    "@biomejs/biome": "2.5.7",
     "concurrently": "^9.2.1",
     "dependency-cruiser": "^17.3.6",
     "dotenv-cli": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "license": "AGPL-3.0",
   "private": true,
-  "packageManager": "pnpm@10.30.3",
+  "packageManager": "pnpm@10.34.5",
   "workspaces": [
     "packages/*",
     "admin",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ importers:
         version: 9.2.1
       dependency-cruiser:
         specifier: ^17.3.6
-        version: 17.3.9
+        version: 17.4.3
       dotenv-cli:
         specifier: ^11.0.0
         version: 11.0.0
@@ -1850,6 +1850,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -2354,8 +2355,8 @@ packages:
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
-  dependency-cruiser@17.3.9:
-    resolution: {integrity: sha512-LwaotlB9bZ8zhdFGGYf/g2oYkYj7YNxlqx1btL/XIYGob/aKRArsSwkLKo+ZrHiegsEArQVg4ZQ3NhAh8uk+hg==}
+  dependency-cruiser@17.4.3:
+    resolution: {integrity: sha512-L4GLuAvmXevWnPCIaFfOz6eD92c+yY+pDgVqgufrLDnW3xYA799CSZQlly2r2N13nhAlnZY6VzY7Rx5pHNvk2w==}
     engines: {node: ^20.12||^22||>=24}
     hasBin: true
 
@@ -2428,12 +2429,12 @@ packages:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
     engines: {node: '>=14'}
 
-  enhanced-resolve@5.20.0:
-    resolution: {integrity: sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==}
+  enhanced-resolve@5.22.1:
+    resolution: {integrity: sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww==}
     engines: {node: '>=10.13.0'}
 
-  enhanced-resolve@5.20.1:
-    resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
+  enhanced-resolve@5.24.5:
+    resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
     engines: {node: '>=10.13.0'}
 
   entities@4.5.0:
@@ -2446,6 +2447,10 @@ packages:
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.27.4:
     resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
@@ -2608,8 +2613,8 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   html-escaper@2.0.2:
@@ -2672,8 +2677,8 @@ packages:
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
-  is-core-module@2.16.1:
-    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
     engines: {node: '>= 0.4'}
 
   is-extglob@2.1.1:
@@ -3228,12 +3233,20 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
   pirates@4.0.7:
@@ -3393,8 +3406,8 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
-  resolve@1.22.11:
-    resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
     engines: {node: '>= 0.4'}
     hasBin: true
 
@@ -3430,6 +3443,16 @@ packages:
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.8.1:
+    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -3595,8 +3618,8 @@ packages:
   tailwindcss@4.2.2:
     resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
 
-  tapable@2.3.0:
-    resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
   tar@7.5.11:
@@ -5233,7 +5256,7 @@ snapshots:
   '@tailwindcss/node@4.2.2':
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      enhanced-resolve: 5.20.1
+      enhanced-resolve: 5.24.5
       jiti: 2.6.1
       lightningcss: 1.32.0
       magic-string: 0.30.21
@@ -5517,7 +5540,7 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   apexcharts@5.10.4: {}
 
@@ -5838,7 +5861,7 @@ snapshots:
 
   defu@6.1.4: {}
 
-  dependency-cruiser@17.3.9:
+  dependency-cruiser@17.4.3:
     dependencies:
       acorn: 8.16.0
       acorn-jsx: 5.3.2(acorn@8.16.0)
@@ -5846,16 +5869,16 @@ snapshots:
       acorn-loose: 8.5.2
       acorn-walk: 8.3.5
       commander: 14.0.3
-      enhanced-resolve: 5.20.0
+      enhanced-resolve: 5.22.1
       ignore: 7.0.5
       interpret: 3.1.1
       is-installed-globally: 1.0.0
       json5: 2.2.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       prompts: 2.4.2
       rechoir: 0.8.0
       safe-regex: 2.1.1
-      semver: 7.7.4
+      semver: 7.8.1
       tsconfig-paths-webpack-plugin: 4.2.0
       watskeburt: 5.0.3
 
@@ -5919,15 +5942,15 @@ snapshots:
 
   empathic@2.0.0: {}
 
-  enhanced-resolve@5.20.0:
+  enhanced-resolve@5.22.1:
     dependencies:
       graceful-fs: 4.2.11
-      tapable: 2.3.0
+      tapable: 2.3.3
 
-  enhanced-resolve@5.20.1:
+  enhanced-resolve@5.24.5:
     dependencies:
       graceful-fs: 4.2.11
-      tapable: 2.3.0
+      tapable: 2.3.3
 
   entities@4.5.0: {}
 
@@ -5936,6 +5959,8 @@ snapshots:
   error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
+
+  es-errors@1.3.0: {}
 
   esbuild@0.27.4:
     optionalDependencies:
@@ -6128,7 +6153,7 @@ snapshots:
 
   has-flag@4.0.0: {}
 
-  hasown@2.0.2:
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -6182,9 +6207,9 @@ snapshots:
 
   is-arrayish@0.2.1: {}
 
-  is-core-module@2.16.1:
+  is-core-module@2.16.2:
     dependencies:
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   is-extglob@2.1.1: {}
 
@@ -6221,7 +6246,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.7.4
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
@@ -6371,7 +6396,7 @@ snapshots:
       jest-regex-util: 30.0.1
       jest-util: 30.3.0
       jest-worker: 30.3.0
-      picomatch: 4.0.3
+      picomatch: 4.0.5
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.3
@@ -6395,7 +6420,7 @@ snapshots:
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
       graceful-fs: 4.2.11
-      picomatch: 4.0.3
+      picomatch: 4.0.5
       pretty-format: 30.3.0
       slash: 3.0.0
       stack-utils: 2.0.6
@@ -6505,7 +6530,7 @@ snapshots:
       jest-message-util: 30.3.0
       jest-util: 30.3.0
       pretty-format: 30.3.0
-      semver: 7.7.4
+      semver: 7.8.5
       synckit: 0.11.12
     transitivePeerDependencies:
       - supports-color
@@ -6517,7 +6542,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
-      picomatch: 4.0.3
+      picomatch: 4.0.5
 
   jest-validate@30.3.0:
     dependencies:
@@ -6708,7 +6733,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.5
 
   make-error@1.3.6: {}
 
@@ -6723,7 +6748,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   mimic-fn@2.1.0: {}
 
@@ -6894,9 +6919,13 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
+  picomatch@2.3.2: {}
 
   picomatch@4.0.3: {}
+
+  picomatch@4.0.4: {}
+
+  picomatch@4.0.5: {}
 
   pirates@4.0.7: {}
 
@@ -7026,7 +7055,7 @@ snapshots:
 
   rechoir@0.8.0:
     dependencies:
-      resolve: 1.22.11
+      resolve: 1.22.12
 
   regexp-tree@0.1.27: {}
 
@@ -7040,9 +7069,10 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
-  resolve@1.22.11:
+  resolve@1.22.12:
     dependencies:
-      is-core-module: 2.16.1
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
@@ -7075,11 +7105,15 @@ snapshots:
 
   semver@7.7.4: {}
 
+  semver@7.8.1: {}
+
+  semver@7.8.5: {}
+
   sharp@0.34.5:
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
-      semver: 7.7.4
+      semver: 7.8.5
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5
@@ -7239,7 +7273,7 @@ snapshots:
 
   tailwindcss@4.2.2: {}
 
-  tapable@2.3.0: {}
+  tapable@2.3.3: {}
 
   tar@7.5.11:
     dependencies:
@@ -7290,8 +7324,8 @@ snapshots:
   tsconfig-paths-webpack-plugin@4.2.0:
     dependencies:
       chalk: 4.1.2
-      enhanced-resolve: 5.20.0
-      tapable: 2.3.0
+      enhanced-resolve: 5.22.1
+      tapable: 2.3.3
       tsconfig-paths: 4.2.0
 
   tsconfig-paths@4.2.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,7 +156,7 @@ importers:
         version: 30.3.0(@types/node@25.5.0)
       postcss:
         specifier: ^8.5.6
-        version: 8.5.8
+        version: 8.5.10
       tailwindcss:
         specifier: ^4.1.18
         version: 4.2.2
@@ -223,7 +223,7 @@ importers:
         version: 30.3.0(@types/node@25.5.0)
       postcss:
         specifier: ^8.5.6
-        version: 8.5.8
+        version: 8.5.10
       tailwindcss:
         specifier: ^4.1.18
         version: 4.2.2
@@ -1850,6 +1850,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -3081,8 +3082,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3264,8 +3265,8 @@ packages:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   pretty-format@30.3.0:
@@ -5296,7 +5297,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
-      postcss: 8.5.8
+      postcss: 8.5.10
       tailwindcss: 4.2.2
 
   '@tanstack/react-table@8.21.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
@@ -5739,7 +5740,7 @@ snapshots:
       dom-serializer: 2.0.0
       domhandler: 5.0.3
       htmlparser2: 8.0.2
-      postcss: 8.5.8
+      postcss: 8.5.10
       postcss-media-query-parser: 0.2.3
 
   cross-spawn@7.0.6:
@@ -6747,7 +6748,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.16: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -6922,13 +6923,13 @@ snapshots:
 
   postcss@8.4.31:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postcss@8.5.8:
+  postcss@8.5.10:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,8 +109,8 @@ importers:
         specifier: ^0.7.2
         version: 0.7.2
       lucide-react:
-        specifier: ^0.562.0
-        version: 0.562.0(react@19.2.3)
+        specifier: ^0.577.0
+        version: 0.577.0(react@19.2.3)
       next:
         specifier: 16.1.1
         version: 16.1.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1850,6 +1850,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -3023,8 +3024,8 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  lucide-react@0.562.0:
-    resolution: {integrity: sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==}
+  lucide-react@0.577.0:
+    resolution: {integrity: sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -6698,7 +6699,7 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lucide-react@0.562.0(react@19.2.3):
+  lucide-react@0.577.0(react@19.2.3):
     dependencies:
       react: 19.2.3
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,6 +221,9 @@ importers:
       jest:
         specifier: ^30.2.0
         version: 30.3.0(@types/node@25.5.0)
+      node-html-parser:
+        specifier: 9.0.0
+        version: 9.0.0
       postcss:
         specifier: ^8.5.6
         version: 8.5.8
@@ -2440,6 +2443,10 @@ packages:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
 
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
@@ -3129,6 +3136,9 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  node-html-parser@9.0.0:
+    resolution: {integrity: sha512-MhdaHPyxnyYu/sf0TpiRvDnTrkum0UKHC7FdbDGIUQNlx3I7xzwXoyV0eMUMv/XU+lkJT1glOUzpDPq7b2p1Ew==}
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -5931,6 +5941,8 @@ snapshots:
 
   entities@4.5.0: {}
 
+  entities@8.0.0: {}
+
   environment@1.1.0: {}
 
   error-ex@1.3.4:
@@ -6790,6 +6802,11 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
+
+  node-html-parser@9.0.0:
+    dependencies:
+      css-select: 5.2.2
+      entities: 8.0.0
 
   node-int64@0.4.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         version: 17.3.1
     devDependencies:
       '@biomejs/biome':
-        specifier: 2.3.11
-        version: 2.3.11
+        specifier: 2.5.7
+        version: 2.5.7
       concurrently:
         specifier: ^9.2.1
         version: 9.2.1
@@ -427,59 +427,59 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@biomejs/biome@2.3.11':
-    resolution: {integrity: sha512-/zt+6qazBWguPG6+eWmiELqO+9jRsMZ/DBU3lfuU2ngtIQYzymocHhKiZRyrbra4aCOoyTg/BmY+6WH5mv9xmQ==}
+  '@biomejs/biome@2.5.7':
+    resolution: {integrity: sha512-zr8K/DcY5tYsQOQwqMJ0AWElo6QgmgNI7idXgXLhevVszlt8RGVpesEJPqx3ThazLaOwjJ5Y8fz3BtH5fGZNsw==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.3.11':
-    resolution: {integrity: sha512-/uXXkBcPKVQY7rc9Ys2CrlirBJYbpESEDme7RKiBD6MmqR2w3j0+ZZXRIL2xiaNPsIMMNhP1YnA+jRRxoOAFrA==}
+  '@biomejs/cli-darwin-arm64@2.5.7':
+    resolution: {integrity: sha512-vxo/Ls3/PYdQWyLhYYcgMOCzQypAjcY+iihS8M0wW03l16TCLW4zqZzGo75gm1VdCMj38hTVZ31KBWrZ4G9dJw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.3.11':
-    resolution: {integrity: sha512-fh7nnvbweDPm2xEmFjfmq7zSUiox88plgdHF9OIW4i99WnXrAC3o2P3ag9judoUMv8FCSUnlwJCM1B64nO5Fbg==}
+  '@biomejs/cli-darwin-x64@2.5.7':
+    resolution: {integrity: sha512-Cd3Ga61amT/Yl/0x8elP5hhGYaFy4bw6WuysTgf7oo8TA5tJ5A1k+DkVoJ2BHbTVil51gTX9VPzArnrlLJ3Kyg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.3.11':
-    resolution: {integrity: sha512-XPSQ+XIPZMLaZ6zveQdwNjbX+QdROEd1zPgMwD47zvHV+tCGB88VH+aynyGxAHdzL+Tm/+DtKST5SECs4iwCLg==}
+  '@biomejs/cli-linux-arm64-musl@2.5.7':
+    resolution: {integrity: sha512-xPI5yB6XlpDbNkS+bm1t42olw5c4l3UrlOmLg7KtLJvjvkNF/1V4tnUgfkylGIeb3u/T+BzMGYqgQhzjAoJzuQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.3.11':
-    resolution: {integrity: sha512-l4xkGa9E7Uc0/05qU2lMYfN1H+fzzkHgaJoy98wO+b/7Gl78srbCRRgwYSW+BTLixTBrM6Ede5NSBwt7rd/i6g==}
+  '@biomejs/cli-linux-arm64@2.5.7':
+    resolution: {integrity: sha512-rR2QE0yF2GYSuYuKIa7pKvODGJqnOH+2eDREAM8wV+mWKSkMQKdAp4zXEZfTaxY8PMoNONnpgSWcBCyLDPDOKg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.3.11':
-    resolution: {integrity: sha512-vU7a8wLs5C9yJ4CB8a44r12aXYb8yYgBn+WeyzbMjaCMklzCv1oXr8x+VEyWodgJt9bDmhiaW/I0RHbn7rsNmw==}
+  '@biomejs/cli-linux-x64-musl@2.5.7':
+    resolution: {integrity: sha512-rE5VZi+qtmPgQH+l7jVxYoZ18b/TiHEhulhMpjmCZH1PltSbjRcxNWywC3HZ9tYottG7ORkeTtoscBilKSBm0g==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.3.11':
-    resolution: {integrity: sha512-/1s9V/H3cSe0r0Mv/Z8JryF5x9ywRxywomqZVLHAoa/uN0eY7F8gEngWKNS5vbbN/BsfpCG5yeBT5ENh50Frxg==}
+  '@biomejs/cli-linux-x64@2.5.7':
+    resolution: {integrity: sha512-FQgqJhscrqJUFptGaRSUJWlXAExwWcDwLuK49dvKfkQ1bB5SEEyFssnsxQY83Xm6jR0EbbX3+8+D5bfvYqUG2Q==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.3.11':
-    resolution: {integrity: sha512-PZQ6ElCOnkYapSsysiTy0+fYX+agXPlWugh6+eQ6uPKI3vKAqNp6TnMhoM3oY2NltSB89hz59o8xIfOdyhi9Iw==}
+  '@biomejs/cli-win32-arm64@2.5.7':
+    resolution: {integrity: sha512-Oq4x0CCwP4jirrcTywXs5kOGZ4v5vuEP+gWrbtjApOA2CL9F3F9GlIdQIci8AKSCa/zURanMRpX/4wQ7Am6hHg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.3.11':
-    resolution: {integrity: sha512-43VrG813EW+b5+YbDbz31uUsheX+qFKCpXeY9kfdAx+ww3naKxeVkTD9zLIWxUPfJquANMHrmW3wbe/037G0Qg==}
+  '@biomejs/cli-win32-x64@2.5.7':
+    resolution: {integrity: sha512-V+0wu/nrj2S+MhP4EQ0uHNolP0IALEsz45pg0WoKkHfDeh0+ItHwP/p7bX5RPoMOl9NkpHYWdYPhIcy2mACHvQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -1850,6 +1850,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -4047,39 +4048,39 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@biomejs/biome@2.3.11':
+  '@biomejs/biome@2.5.7':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.3.11
-      '@biomejs/cli-darwin-x64': 2.3.11
-      '@biomejs/cli-linux-arm64': 2.3.11
-      '@biomejs/cli-linux-arm64-musl': 2.3.11
-      '@biomejs/cli-linux-x64': 2.3.11
-      '@biomejs/cli-linux-x64-musl': 2.3.11
-      '@biomejs/cli-win32-arm64': 2.3.11
-      '@biomejs/cli-win32-x64': 2.3.11
+      '@biomejs/cli-darwin-arm64': 2.5.7
+      '@biomejs/cli-darwin-x64': 2.5.7
+      '@biomejs/cli-linux-arm64': 2.5.7
+      '@biomejs/cli-linux-arm64-musl': 2.5.7
+      '@biomejs/cli-linux-x64': 2.5.7
+      '@biomejs/cli-linux-x64-musl': 2.5.7
+      '@biomejs/cli-win32-arm64': 2.5.7
+      '@biomejs/cli-win32-x64': 2.5.7
 
-  '@biomejs/cli-darwin-arm64@2.3.11':
+  '@biomejs/cli-darwin-arm64@2.5.7':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.3.11':
+  '@biomejs/cli-darwin-x64@2.5.7':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.3.11':
+  '@biomejs/cli-linux-arm64-musl@2.5.7':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.3.11':
+  '@biomejs/cli-linux-arm64@2.5.7':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.3.11':
+  '@biomejs/cli-linux-x64-musl@2.5.7':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.3.11':
+  '@biomejs/cli-linux-x64@2.5.7':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.3.11':
+  '@biomejs/cli-win32-arm64@2.5.7':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.3.11':
+  '@biomejs/cli-win32-x64@2.5.7':
     optional: true
 
   '@emnapi/core@1.9.1':

--- a/webapp/e2e/tests/transactions.spec.ts
+++ b/webapp/e2e/tests/transactions.spec.ts
@@ -34,4 +34,55 @@ test.describe("取引一覧ページ", () => {
 			`以下のエラーが発生しました:\n${errors.join("\n")}`,
 		).toHaveLength(0);
 	});
+
+	test("デスクトップの列見出しが現在のソート状態を公開すること", async ({ page }) => {
+		await page.goto("/o/sample-party/2026/transactions");
+
+		const table = page.getByRole("table", { name: "政治資金取引一覧表" });
+		const dateSortButton = table.getByRole("button", { name: "日付順でソート" });
+		const amountSortButton = table.getByRole("button", { name: "金額順でソート" });
+		const dateHeader = dateSortButton.locator("xpath=ancestor::th");
+		const amountHeader = amountSortButton.locator("xpath=ancestor::th");
+
+		await expect(table.locator("th[aria-sort]")).toHaveCount(1);
+		await expect(dateHeader).toHaveAttribute("aria-sort", "descending");
+		expect(await amountHeader.getAttribute("aria-sort")).toBeNull();
+		expect(await dateSortButton.getAttribute("aria-describedby")).toBeNull();
+		expect(await amountSortButton.getAttribute("aria-describedby")).toBeNull();
+		await expect(dateSortButton.locator("img")).toHaveAttribute("alt", "");
+		await expect(amountSortButton.locator("img")).toHaveAttribute("alt", "");
+
+		await dateSortButton.click();
+		await expect(page).toHaveURL(/sort=date.*order=asc/);
+		await expect(dateHeader).toHaveAttribute("aria-sort", "ascending");
+
+		await amountSortButton.click();
+		await expect(page).toHaveURL(/sort=amount.*order=desc/);
+		await expect(table.locator("th[aria-sort]")).toHaveCount(1);
+		expect(await dateHeader.getAttribute("aria-sort")).toBeNull();
+		await expect(amountHeader).toHaveAttribute("aria-sort", "descending");
+
+		await amountSortButton.click();
+		await expect(page).toHaveURL(/sort=amount.*order=asc/);
+		await expect(amountHeader).toHaveAttribute("aria-sort", "ascending");
+	});
+
+	test("モバイルの並び順ボタンが選択状態を公開すること", async ({ page }) => {
+		await page.setViewportSize({ width: 390, height: 844 });
+		await page.goto("/o/sample-party/2026/transactions");
+
+		const sortGroup = page.getByRole("group", { name: "並び順" });
+		const newestButton = sortGroup.getByRole("button", { name: "新しい順" });
+		const oldestButton = sortGroup.getByRole("button", { name: "古い順" });
+
+		await expect(sortGroup.locator('button[aria-pressed="true"]')).toHaveCount(1);
+		await expect(newestButton).toHaveAttribute("aria-pressed", "true");
+		await expect(oldestButton).toHaveAttribute("aria-pressed", "false");
+
+		await oldestButton.click();
+		await expect(page).toHaveURL(/sort=date.*order=asc/);
+		await expect(sortGroup.locator('button[aria-pressed="true"]')).toHaveCount(1);
+		await expect(newestButton).toHaveAttribute("aria-pressed", "false");
+		await expect(oldestButton).toHaveAttribute("aria-pressed", "true");
+	});
 });

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -22,6 +22,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "jest": "^30.2.0",
+    "node-html-parser": "9.0.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.18",
     "ts-jest": "^29.4.6",

--- a/webapp/src/client/components/top-page/features/charts/BalanceSheetChart.tsx
+++ b/webapp/src/client/components/top-page/features/charts/BalanceSheetChart.tsx
@@ -170,17 +170,19 @@ export default function BalanceSheetChart({ data }: BalanceSheetChartProps) {
 
   return (
     <div className="flex justify-center mt-10">
-      <div
-        className="w-full max-w-[500px] flex gap-[1px] h-[380px]"
-        role="img"
-        aria-label="貸借対照表チャート"
-      >
+      <figure className="w-full max-w-[500px] flex gap-[1px] h-[380px]">
+        <figcaption className="sr-only">貸借対照表</figcaption>
+
         {/* 左側（資産） */}
-        <div className="flex-1 flex flex-col">{leftItems.map((item) => renderItem(item))}</div>
+        <section className="flex-1 flex flex-col" aria-label="資産">
+          {leftItems.map((item) => renderItem(item))}
+        </section>
 
         {/* 右側（負債・資本） */}
-        <div className="flex-1 flex flex-col">{rightItems.map((item) => renderItem(item))}</div>
-      </div>
+        <section className="flex-1 flex flex-col" aria-label="負債・純資産">
+          {rightItems.map((item) => renderItem(item))}
+        </section>
+      </figure>
     </div>
   );
 }

--- a/webapp/src/client/components/top-page/features/transactions-table/InteractiveTransactionTable.tsx
+++ b/webapp/src/client/components/top-page/features/transactions-table/InteractiveTransactionTable.tsx
@@ -61,16 +61,13 @@ export default function InteractiveTransactionTable({
 
   const handleSort = (field: "date" | "amount") => {
     const params = new URLSearchParams(searchParams.toString());
-    const currentSort = params.get("sort");
-    const currentOrder = params.get("order");
+    const currentSort = params.get("sort") ?? "date";
+    const currentOrder = params.get("order") ?? "desc";
 
     // Toggle order if sorting the same field, otherwise default to desc
-    if (currentSort === field) {
-      params.set("order", currentOrder === "desc" ? "asc" : "desc");
-    } else {
-      params.set("sort", field);
-      params.set("order", "desc");
-    }
+    const nextOrder = currentSort === field && currentOrder === "desc" ? "asc" : "desc";
+    params.set("sort", field);
+    params.set("order", nextOrder);
 
     // Reset to page 1 when sorting changes
     params.set("page", "1");

--- a/webapp/src/client/components/top-page/features/transactions-table/TransactionTableHeader.tsx
+++ b/webapp/src/client/components/top-page/features/transactions-table/TransactionTableHeader.tsx
@@ -20,29 +20,39 @@ export default function TransactionTableHeader({
   selectedCategories,
 }: TransactionTableHeaderProps) {
   const [isFilterOpen, setIsFilterOpen] = useState(false);
+  const activeSort = currentSort ?? "date";
+  const activeOrder = currentOrder ?? "desc";
+  const dateSortDirection =
+    activeSort === "date" ? (activeOrder === "asc" ? "ascending" : "descending") : undefined;
+  const amountSortDirection =
+    activeSort === "amount" ? (activeOrder === "asc" ? "ascending" : "descending") : undefined;
+
   return (
     <thead className="hidden md:table-header-group bg-white">
       <tr className="h-12 border-b border-[#D5DBE1]">
         {/* 日付 - 140px width to match row */}
-        <th className="text-left px-4 h-12 font-normal w-[140px]" scope="col">
+        <th
+          className="text-left px-4 h-12 font-normal w-[140px]"
+          scope="col"
+          aria-sort={allowControl ? dateSortDirection : undefined}
+        >
           {allowControl && onSort ? (
             <button
               type="button"
               onClick={() => onSort("date")}
               className="flex items-center gap-1 h-5 hover:opacity-70 transition-opacity cursor-pointer"
               aria-label="日付順でソート"
-              aria-describedby="sort-date-description"
             >
               <span className="text-gray-800 text-sm font-bold leading-[1.5]">日付</span>
               <div className="w-5 h-5 flex items-center justify-center">
                 <Image
                   src="/icons/icon-chevron-down.svg"
-                  alt="Sort by date"
+                  alt=""
                   width={20}
                   height={20}
                   className={`w-5 h-5 transition-transform ${
-                    currentSort === "date" ? (currentOrder === "asc" ? "rotate-180" : "") : ""
-                  } ${currentSort === "date" ? "opacity-100" : "opacity-50"}`}
+                    activeSort === "date" ? (activeOrder === "asc" ? "rotate-180" : "") : ""
+                  } ${activeSort === "date" ? "opacity-100" : "opacity-50"}`}
                 />
               </div>
             </button>
@@ -99,25 +109,28 @@ export default function TransactionTableHeader({
         </th>
 
         {/* 金額 - 180px width to match row (combined plus/minus + amount) */}
-        <th className="text-right pr-6 h-12 font-normal w-[180px]" scope="col">
+        <th
+          className="text-right pr-6 h-12 font-normal w-[180px]"
+          scope="col"
+          aria-sort={allowControl ? amountSortDirection : undefined}
+        >
           {allowControl && onSort ? (
             <button
               type="button"
               onClick={() => onSort("amount")}
               className="flex items-center gap-1 h-5 hover:opacity-70 transition-opacity ml-auto cursor-pointer"
               aria-label="金額順でソート"
-              aria-describedby="sort-amount-description"
             >
               <span className="text-gray-800 text-sm font-bold leading-[1.5]">金額</span>
               <div className="w-5 h-5 flex items-center justify-center">
                 <Image
                   src="/icons/icon-chevron-down.svg"
-                  alt="Sort by amount"
+                  alt=""
                   width={20}
                   height={20}
                   className={`w-5 h-5 transition-transform ${
-                    currentSort === "amount" ? (currentOrder === "asc" ? "rotate-180" : "") : ""
-                  } ${currentSort === "amount" ? "opacity-100" : "opacity-50"}`}
+                    activeSort === "amount" ? (activeOrder === "asc" ? "rotate-180" : "") : ""
+                  } ${activeSort === "amount" ? "opacity-100" : "opacity-50"}`}
                 />
               </div>
             </button>

--- a/webapp/src/client/components/top-page/features/transactions-table/TransactionTableMobileHeader.tsx
+++ b/webapp/src/client/components/top-page/features/transactions-table/TransactionTableMobileHeader.tsx
@@ -37,7 +37,8 @@ export default function TransactionTableMobileHeader({
   return (
     <div className="w-full bg-white relative border-b-0">
       {/* Tab Items */}
-      <div className="flex gap-6 overflow-x-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
+      <fieldset className="flex min-w-0 gap-6 overflow-x-auto border-0 p-0 m-0 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
+        <legend className="sr-only">並び順</legend>
         {TAB_ITEMS.map((tab) => {
           const isActive = currentSort === tab.id;
 
@@ -47,6 +48,7 @@ export default function TransactionTableMobileHeader({
               type="button"
               onClick={() => handleClick(tab.id)}
               className="flex flex-col items-center justify-center relative whitespace-nowrap py-2 px-0 cursor-pointer touch-manipulation"
+              aria-pressed={isActive}
             >
               {/* Tab Label */}
               <span
@@ -64,7 +66,7 @@ export default function TransactionTableMobileHeader({
             </button>
           );
         })}
-      </div>
+      </fieldset>
 
       {/* Bottom border line */}
       <div className="w-full h-[1px] bg-[#E5E7EB]" />

--- a/webapp/tests/client/components/top-page/features/charts/BalanceSheetChart.test.tsx
+++ b/webapp/tests/client/components/top-page/features/charts/BalanceSheetChart.test.tsx
@@ -1,3 +1,4 @@
+import { parse, type HTMLElement } from "node-html-parser";
 import { renderToStaticMarkup } from "react-dom/server";
 import BalanceSheetChart from "@/client/components/top-page/features/charts/BalanceSheetChart";
 
@@ -18,31 +19,54 @@ describe("BalanceSheetChart", () => {
       }}
     />,
   );
+  const document = parse(markup);
+
+  const getRequiredElement = (selector: string) => {
+    const element = document.querySelector(selector);
+
+    expect(element).not.toBeNull();
+
+    return element as HTMLElement;
+  };
+
+  const expectAccountAndAmount = (
+    section: HTMLElement,
+    accountName: string,
+    amount: string,
+  ) => {
+    const item = section.children.find((child) =>
+      child.textContent.replace(/\s+/g, "").includes(accountName),
+    );
+
+    expect(item).toBeDefined();
+    expect(item?.textContent.replace(/\s+/g, "")).toContain(`${accountName}${amount}`);
+  };
 
   it("貸借対照表の値を画像ロールで隠さず、意味のある図と区分として公開する", () => {
-    expect(markup).not.toContain('role="img"');
-    expect(markup).toContain("<figure");
-    expect(markup).toContain('<figcaption class="sr-only">貸借対照表</figcaption>');
-    expect(markup).toMatch(/<section[^>]*aria-label="資産"/);
-    expect(markup).toMatch(/<section[^>]*aria-label="負債・純資産"/);
+    expect(document.querySelector('[role="img"]')).toBeNull();
+
+    const figure = getRequiredElement("figure");
+    const figcaption = figure.querySelector("figcaption");
+
+    expect(figcaption).not.toBeNull();
+    expect(figcaption?.parentNode).toBe(figure);
+    expect(figure.firstElementChild).toBe(figcaption);
+    expect(figcaption?.textContent).toBe("貸借対照表");
+    expect(figcaption?.classList.contains("sr-only")).toBe(true);
+    expect(figure.querySelector('section[aria-label="資産"]')).not.toBeNull();
+    expect(figure.querySelector('section[aria-label="負債・純資産"]')).not.toBeNull();
   });
 
-  it("勘定名と金額を支援技術から参照できるテキストとして保持する", () => {
-    const textContent = markup.replace(/<[^>]+>/g, "");
+  it("各区分内で勘定名と対応する金額を支援技術から参照できる", () => {
+    const assets = getRequiredElement('section[aria-label="資産"]');
+    const liabilitiesAndNetAssets = getRequiredElement(
+      'section[aria-label="負債・純資産"]',
+    );
 
-    for (const expectedText of [
-      "流動資産",
-      "1億2345万円",
-      "固定資産",
-      "5万円",
-      "流動負債",
-      "250万円",
-      "固定負債",
-      "1万円",
-      "純資産",
-      "1億2099万円",
-    ]) {
-      expect(textContent).toContain(expectedText);
-    }
+    expectAccountAndAmount(assets, "流動資産", "1億2345万円");
+    expectAccountAndAmount(assets, "固定資産", "5万円");
+    expectAccountAndAmount(liabilitiesAndNetAssets, "流動負債", "250万円");
+    expectAccountAndAmount(liabilitiesAndNetAssets, "固定負債", "1万円");
+    expectAccountAndAmount(liabilitiesAndNetAssets, "純資産", "1億2099万円");
   });
 });

--- a/webapp/tests/client/components/top-page/features/charts/BalanceSheetChart.test.tsx
+++ b/webapp/tests/client/components/top-page/features/charts/BalanceSheetChart.test.tsx
@@ -1,0 +1,48 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import BalanceSheetChart from "@/client/components/top-page/features/charts/BalanceSheetChart";
+
+describe("BalanceSheetChart", () => {
+  const markup = renderToStaticMarkup(
+    <BalanceSheetChart
+      data={{
+        left: {
+          currentAssets: 123_450_000,
+          fixedAssets: 50_000,
+          debtExcess: 0,
+        },
+        right: {
+          currentLiabilities: 2_500_000,
+          fixedLiabilities: 10_000,
+          netAssets: 120_990_000,
+        },
+      }}
+    />,
+  );
+
+  it("貸借対照表の値を画像ロールで隠さず、意味のある図と区分として公開する", () => {
+    expect(markup).not.toContain('role="img"');
+    expect(markup).toContain("<figure");
+    expect(markup).toContain('<figcaption class="sr-only">貸借対照表</figcaption>');
+    expect(markup).toMatch(/<section[^>]*aria-label="資産"/);
+    expect(markup).toMatch(/<section[^>]*aria-label="負債・純資産"/);
+  });
+
+  it("勘定名と金額を支援技術から参照できるテキストとして保持する", () => {
+    const textContent = markup.replace(/<[^>]+>/g, "");
+
+    for (const expectedText of [
+      "流動資産",
+      "1億2345万円",
+      "固定資産",
+      "5万円",
+      "流動負債",
+      "250万円",
+      "固定負債",
+      "1万円",
+      "純資産",
+      "1億2099万円",
+    ]) {
+      expect(textContent).toContain(expectedText);
+    }
+  });
+});


### PR DESCRIPTION
## 目的

Git ブランチ運用を main 単一化へ移行する前提として、main と develop の内容を一致させるため。

移行手順（`docs/20260823_1813_Gitブランチ運用のmain単一化移行手順.md`）のフェーズ2にあたる作業。

## 事前調査の結果

コミット数のうえでは `origin/develop..origin/main` に7件の差分があるが、**main 独自の実質的な変更は存在しない**ことを確認済み。

- 6件は `Merge pull request #xxxx from team-mirai/develop` というリリースマージコミット自体で、内容の変更を持たない
- 残る1件 `bb5c984b`（`SECURITY.md` の追加）は、同一内容のファイルが develop 側にも別経路で存在する（`diff` で完全一致を確認済み）

ファイル単位で照合しても main のみに存在するファイルはなく、**develop は main の内容を完全に包含している**。よって本 PR のマージのみで両ブランチの内容は一致し、`main → develop` の逆方向マージは不要。

## 含まれる変更

依存関係の更新とアクセシビリティ修正が中心で、相反する機能変更は含まれない。

**依存関係の更新**
- `postcss` v8.5.10（セキュリティ修正）
- `@biomejs/biome` v2.5.7
- `dependency-cruiser` v17.4.3
- `lucide-react` ^0.577.0
- `pnpm` v10.34.5

**アクセシビリティ修正**
- 貸借対照表の値を支援技術に公開する（#1223）
- 取引一覧のソート状態を支援技術へ公開する（#1224）
- 貸借対照表の DOM 構造検証テストの強化

**ドキュメント**
- Git ブランチ運用の main 単一化移行手順（#1232, #1233）

## 注意

このマージは**本番環境へのデプロイを伴う**。マージのタイミングに留意すること。

なお訂正 PR #1233 を develop へマージすると、その内容も本 PR に自動的に反映される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)