### PR TITLE
docs: main単一化の移行手順をGitHub Actions方式で書き直す

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -33,14 +33,22 @@ jobs:
 
       # webapp のビルドに prisma migrate deploy が含まれるため、
       # 先に webapp をデプロイして本番DBのスキーマを更新する
+      # --build-env MANUAL_DEPLOY=1 が ignoreCommand の条件を満たし、
+      # Git 連携によるビルドはスキップしたまま CLI からのデプロイのみ通す
       - name: Deploy webapp
-        run: vercel deploy --prod --yes --cwd webapp --token "$VERCEL_TOKEN"
+        run: |
+          vercel deploy --prod --yes --cwd webapp \
+            --build-env MANUAL_DEPLOY=1 \
+            --token "$VERCEL_TOKEN"
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_WEBAPP }}
 
       - name: Deploy admin
-        run: vercel deploy --prod --yes --cwd admin --token "$VERCEL_TOKEN"
+        run: |
+          vercel deploy --prod --yes --cwd admin \
+            --build-env MANUAL_DEPLOY=1 \
+            --token "$VERCEL_TOKEN"
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_ADMIN }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,37 @@
+name: Deploy Production
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      # webapp のビルドに prisma migrate deploy が含まれるため、
+      # 先に webapp をデプロイして本番DBのスキーマを更新する
+      - name: Deploy webapp
+        run: vercel deploy --prod --yes --cwd webapp --token "$VERCEL_TOKEN"
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_WEBAPP }}
+
+      - name: Deploy admin
+        run: vercel deploy --prod --yes --cwd admin --token "$VERCEL_TOKEN"
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_ADMIN }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -16,6 +16,15 @@ jobs:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
 
     steps:
+      # workflow_dispatch は任意の ref を選択できるため、
+      # 検証済みの main 以外からの本番デプロイを拒否する
+      - name: Verify ref is main
+        run: |
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "本番デプロイは main からのみ実行できます (指定: $GITHUB_REF)"
+            exit 1
+          fi
+
       - name: Checkout code
         uses: actions/checkout@v6
 

--- a/admin/vercel.json
+++ b/admin/vercel.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "installCommand": "npm i -g pnpm@10.30.3 && cd .. && pnpm install --frozen-lockfile",
-  "ignoreCommand": "[ \"$VERCEL_ENV\" = \"production\" ] && exit 0 || exit 1"
+  "ignoreCommand": "[ \"$VERCEL_ENV\" = \"production\" ] && [ \"$MANUAL_DEPLOY\" != \"1\" ] && exit 0 || exit 1"
 }

--- a/admin/vercel.json
+++ b/admin/vercel.json
@@ -1,3 +1,5 @@
 {
-  "installCommand": "npm i -g pnpm@10.30.3 && cd .. && pnpm install --frozen-lockfile"
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "npm i -g pnpm@10.30.3 && cd .. && pnpm install --frozen-lockfile",
+  "ignoreCommand": "[ \"$VERCEL_ENV\" = \"production\" ] && exit 0 || exit 1"
 }

--- a/docs/20260823_1813_Gitブランチ運用のmain単一化移行手順.md
+++ b/docs/20260823_1813_Gitブランチ運用のmain単一化移行手順.md
@@ -44,9 +44,17 @@ Supabase は単一プロジェクトだが、`DATABASE_URL` / `DIRECT_URL` は `
 build:vercel = db:setup && build
 ```
 
-つまり **webapp のビルド＝マイグレーション適用＝コード公開が不可分**であり、ビルドが走った環境の `DATABASE_URL` が指すデータベースへマイグレーションが適用される。
+つまり webapp のビルドが走ると、その環境の `DATABASE_URL` が指すデータベースへマイグレーションが適用される。マイグレーションとコード公開は同一のビルドで実行されるため、通常は両者が揃って反映される。
 
-この性質は移行後も維持する。本番デプロイを実行した時点で本番DBへのマイグレーションとコード公開が同時に起きるため、「コードは古いままスキーマだけ進む」状態は発生しない。
+ただし `db:setup && build` は逐次実行であり、原子的ではない。`db:setup` の成功後に `build` が失敗した場合、**マイグレーションだけが適用され、コードは前回のまま**という状態が生じる。この場合、旧コードが新しいスキーマを参照することになる。
+
+このため破壊的なスキーマ変更（カラムの削除・リネーム・型変更・NOT NULL 制約の追加など）を行う際は、expand/contract 方式を用いて旧コードとの互換性を保つこと。
+
+- expand: 新しいカラムを追加する（旧コードは無視できる）
+- 移行: 新旧両方のカラムを扱うコードをデプロイする
+- contract: 旧カラムを削除する（新コードは参照していない）
+
+これを別々のリリースに分けることで、ビルド失敗時にも旧コードが動作し続ける。
 
 ### ブランチ名を参照している箇所
 
@@ -95,7 +103,7 @@ Vercel ダッシュボードからの手動デプロイでも本番デプロイ�
 ### ワークフローの構成
 
 - トリガー: `workflow_dispatch`（Actions タブから手動実行）
-- 対象コミット: 実行時に選択したブランチ／コミット（通常は `main`）
+- 対象コミット: `main` に限定する。`workflow_dispatch` は任意の ref を選択できるため、ワークフロー側で `github.ref` が `refs/heads/main` であることを検証し、それ以外は失敗させる
 - 実行順序: webapp → admin の直列
 - 使用する Secrets:
   - `VERCEL_TOKEN`
@@ -137,22 +145,25 @@ Vercel ダッシュボードからの手動デプロイでも本番デプロイ�
 
 ### フェーズ3: 手動デプロイワークフローの追加
 
-6. **Secrets の登録**
-   - リポジトリの Settings → Secrets and variables → Actions に、前掲の4つの Secrets を登録する
-   - `VERCEL_TOKEN` は Vercel のアカウント設定から発行する
-   - Project ID は `vercel project inspect <name> --scope team-mirai` で取得できる
-
-7. **GitHub Environment の作成**
+6. **GitHub Environment の作成**
    - Settings → Environments に `production` を作成する
-   - 必要に応じて Required reviewers を設定する
+   - Required reviewers を設定し、承認なしに本番デプロイが実行されないようにする
+
+7. **Secrets の登録**
+   - `VERCEL_TOKEN` は **`production` Environment の Environment secret として登録する**。リポジトリ Secret にすると Required reviewers による承認を経ずに参照できてしまうため、本番デプロイ用の認証情報は Environment 側に置く
+   - `VERCEL_TOKEN` は Vercel のアカウント設定から発行する。スコープは webapp / admin の両方を含める必要がある
+   - `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID_WEBAPP` / `VERCEL_PROJECT_ID_ADMIN` は識別子であり秘匿性が低いため、リポジトリ Secret でよい
+   - Project ID は `vercel project inspect <name> --scope team-mirai` で取得できる
 
 8. **ワークフローファイルの追加**
    - `.github/workflows/deploy-production.yml` を追加する
    - `workflow_dispatch` トリガー、webapp → admin の直列実行、`vercel deploy --prod`（`--prebuilt` なし）
 
 9. **手動デプロイの動作確認**
+   - `workflow_dispatch` はデフォルトブランチ上にワークフローファイルが存在しないと Actions タブに表示されない。この時点でのデフォルトブランチは `develop` のため、**先にワークフローを `develop` へマージしておく**こと
    - Actions タブからワークフローを実行し、webapp / admin の両方が本番へデプロイされることを確認する
    - 本番DBへマイグレーションが適用されることをあわせて確認する
+   - `ignoreCommand` が CLI 経由のデプロイにも作用してビルドがスキップされないか確認する。スキップされる場合は `vercel deploy --prod --force` を用いる
 
 ### フェーズ4: GitHub の設定変更
 
@@ -220,7 +231,7 @@ main は「常にリリース可能な状態」ではなく「ステージング
 
 本番デプロイでコードとスキーマが同時に進むため、Vercel の Instant Rollback でコードを戻してもマイグレーションは戻らない。
 
-破壊的なマイグレーション（カラム削除・リネーム・型変更など）を含むデプロイでは、ロールバックが機能しない可能性がある。該当する変更を出す際は事前に確認する。
+破壊的なマイグレーションを含むデプロイでは、ロールバック後に旧コードが新しいスキーマを参照して動作しなくなる。前掲の expand/contract 方式に従い、1回のリリースで旧コードが動かなくなる変更を含めないこと。これはビルド失敗時の中間状態への対策と同じ理由による。
 
 ### 作業の順序
 

--- a/docs/20260823_1813_Gitブランチ運用のmain単一化移行手順.md
+++ b/docs/20260823_1813_Gitブランチ運用のmain単一化移行手順.md
@@ -2,33 +2,51 @@
 
 ## 目的
 
-開発者が「develop と main の2本のブランチを同期させ続ける手間」から解放されるため。
+開発者が「develop と main の2本のブランチを維持する」ことをやめ、ブランチ運用を単純化するため。
 
-現状は develop（ステージング）と main（プロダクション）の2本立てで、本番反映のたびに develop → main の PR を作成・マージする必要がある。実際 `origin/develop..origin/main` には develop 側へ取り込まれていないコミットが7件あり（`SECURITY.md` 追加など main 直接コミット由来のものを含む）、両ブランチの乖離が発生している。
+あわせて本番デプロイを手動化し、main へマージした変更をいつ本番へ出すかを開発者が選べるようにする。
 
-これを main 単一ブランチに統合し、次の運用に変更する。
-
-| 環境 | デプロイ契機 |
-|------|-------------|
-| ステージング | main への push で自動デプロイ（従来どおり） |
-| プロダクション | 手動でボタンを押してデプロイ |
+| 環境 | 移行後のデプロイ契機 |
+|------|-------------------|
+| ステージング | `main` への push で自動デプロイ（従来どおり） |
+| プロダクション | GitHub Actions の手動実行（`workflow_dispatch`） |
 
 ## 現状の構成
 
-### リポジトリ
+### Vercel プロジェクト
 
-- リポジトリ: `team-mirai/marumie`
-- デフォルトブランチ: `develop`（`origin/HEAD -> origin/develop`）
-- 対象アプリ: `webapp`（公開用フロントエンド）、`admin`（管理画面）の2つ。それぞれ Vercel プロジェクトが存在する想定
+Vercel プロジェクトは webapp / admin それぞれ1つずつで、環境で使い分けている（ステージング用と本番用に別プロジェクトを持つ構成ではない）。
 
-### ブランチの乖離状況
+| プロジェクト | Root Directory |
+|-------------|---------------|
+| `marumie-webapp` | `webapp` |
+| `marumie-admin` | `admin` |
+
+各プロジェクトが持つ環境は次の3つ。`staging` は Vercel のカスタム環境として作成済み。
+
+| 環境 | 追跡ブランチ | 用途 |
+|------|------------|------|
+| `Production` | `main` | 本番 |
+| `staging` | `main`（移行にあわせて develop から変更済み） | ステージング |
+| `Preview` | PR のブランチ | PR ごとのプレビュー |
+
+### データベース
+
+Supabase は単一プロジェクトだが、`DATABASE_URL` / `DIRECT_URL` は `Production` と `staging` / `Preview` とで別々に設定されており、**参照先は分離されている**。
+
+このため、ステージングのビルドと本番のビルドはそれぞれ異なるデータベースに対してマイグレーションを適用する。
+
+### マイグレーションの実行経路
+
+`webapp/package.json` の `build:vercel` が `db:setup`（`prisma generate && prisma migrate deploy`）を含む。
 
 ```
-origin/main..origin/develop : 15 コミット（develop にあって main にない）
-origin/develop..origin/main :  7 コミット（main にあって develop にない）
+build:vercel = db:setup && build
 ```
 
-両方向に差分があるため、移行前に必ず双方向の同期が必要。
+つまり **webapp のビルド＝マイグレーション適用＝コード公開が不可分**であり、ビルドが走った環境の `DATABASE_URL` が指すデータベースへマイグレーションが適用される。
+
+この性質は移行後も維持する。本番デプロイを実行した時点で本番DBへのマイグレーションとコード公開が同時に起きるため、「コードは古いままスキーマだけ進む」状態は発生しない。
 
 ### ブランチ名を参照している箇所
 
@@ -39,22 +57,46 @@ origin/develop..origin/main :  7 コミット（main にあって develop にな
 | `.claude/commands/pr.md` | L26, L27, L38, L48 | PR 作成手順の develop 前提の記述 |
 | `.claude/commands/e2e.md` | L18 | 差分取得の基準ブランチが `develop` |
 
-`.github/workflows/ci.yml` は `on: pull_request` のみでブランチ名の指定がないため**変更不要**。`.github/workflows/dependabot-auto-merge.yml` も `workflow_run` 起動でブランチ名を持たないため**変更不要**。`renovate.json` も `baseBranches` 未指定（デフォルトブランチに追随）のため**変更不要**。
+`.github/workflows/ci.yml` は `on: pull_request` のみでブランチ名を指定していないため変更不要。`.github/workflows/dependabot-auto-merge.yml` も `workflow_run` 起動のため変更不要。`renovate.json` も `baseBranches` 未指定（デフォルトブランチに追随）のため変更不要。
 
-### Vercel 側の現状（要確認）
+### ブランチの同期状況
 
-`webapp/vercel.json` / `admin/vercel.json` にはビルドコマンドのみ記載されており、ブランチとデプロイ環境の紐付けは Vercel ダッシュボード側の設定で管理されている。
+develop と main の内容は同期済み（PR #1234 でマージ完了）。
 
-コード内で `VERCEL_ENV` を参照している箇所が1つある。
+## 設計
 
-- `webapp/src/server/contexts/public-finance/presentation/loaders/constants.ts`
-  - `process.env.VERCEL_ENV === "production" ? 3600 : 10`（キャッシュ revalidate 秒数）
+### 本番デプロイのトリガーを GitHub Actions に置く理由
 
-**この定数の挙動は移行方式によって変わるため、後述の「注意点」を必ず確認すること。**
+Vercel ダッシュボードからの手動デプロイでも本番デプロイ自体は可能だが、次の理由から GitHub Actions の `workflow_dispatch` を採用する。
+
+- **webapp と admin をまとめて1操作でデプロイできる**。ダッシュボード操作では2プロジェクトを個別に操作する必要がある
+- **デプロイ順序を固定できる**。webapp のビルドがマイグレーションを伴うため、webapp → admin の順に直列実行することでスキーマ適用の順序を保証できる
+- **GitHub Environments の Required reviewers による承認フローを組める**
+- **デプロイ操作の履歴が GitHub に残る**
+
+### Vercel CLI の実行方式
+
+ワークフローからは `vercel deploy --prod` を使い、**`--prebuilt` は使わない**。
+
+`--prebuilt` は `vercel build` の成果物をアップロードする方式だが、この場合ビルド時に System Environment Variables が渡らない。本プロジェクトでは `webapp/src/server/contexts/public-finance/presentation/loaders/constants.ts` が `VERCEL_ENV` を参照してキャッシュの revalidate 秒数を決めており、`--prebuilt` を使うと `VERCEL_ENV` が未定義となって本番でも 10 秒（本来は 3600 秒）が焼き込まれてしまう。ビルド時定数のため実行時には修正されない。
+
+`--prebuilt` を使わない場合、ビルドは Vercel 側で実行される。`vercel.json` の設定と `build:vercel` はそのまま有効に働く。
+
+### ワークフローの構成
+
+- トリガー: `workflow_dispatch`（Actions タブから手動実行）
+- 対象コミット: 実行時に選択したブランチ／コミット（通常は `main`）
+- 実行順序: webapp → admin の直列
+- 使用する Secrets:
+  - `VERCEL_TOKEN`
+  - `VERCEL_ORG_ID`
+  - `VERCEL_PROJECT_ID_WEBAPP`
+  - `VERCEL_PROJECT_ID_ADMIN`
+- GitHub Environment `production` を指定し、必要に応じて Required reviewers を設定する
 
 ## 移行手順
 
-### フェーズ1: 事前準備（コード変更なし）
+### フェーズ1: 事前準備
 
 1. **チームへの周知**
    - 移行日時と、移行後は develop を使わないことをアナウンスする
@@ -62,52 +104,49 @@ origin/develop..origin/main :  7 コミット（main にあって develop にな
 
 2. **オープンな PR の棚卸し**
    - base が `develop` になっている PR を一覧化する（`gh pr list --base develop`）
-   - 移行後、これらの PR の base を `main` に変更する必要がある（GitHub のデフォルトブランチ変更時に自動追随しないため）
+   - 移行後、これらの PR の base を `main` に変更する必要がある（デフォルトブランチ変更時に自動追随しないため）
 
-3. **Vercel の現行設定をスクリーンショット等で記録**
-   - webapp / admin それぞれの Production Branch 設定
-   - 各環境（Production / Preview）の環境変数一覧
+3. **Vercel の現行設定の記録**
+   - webapp / admin それぞれの各環境のブランチ追跡設定
    - ロールバック時に元へ戻せるようにしておく
 
-### フェーズ2: ブランチの同期
+### フェーズ2: 本番デプロイの自動化を停止
 
-4. **main → develop の取り込み**
-   - main にしかないコミット7件を develop へマージする PR を作成しマージする
-   - すでに `merge/main-to-develop` というブランチが存在するため、これが使えるか確認する
+4. **Production 環境のブランチ追跡を解除**
+   - Vercel ダッシュボードで、webapp / admin それぞれの Settings → Environments → Production を開く
+   - Branch Tracking の設定を解除し、`main` への push で本番デプロイが起動しないようにする
+   - この時点でステージングは `main` 追跡のまま自動デプロイが継続する
 
-5. **develop → main の取り込み**
-   - develop の内容を main へマージする PR を作成しマージする（従来の本番リリースと同じ操作）
-   - これにより develop と main の内容が完全に一致する
+5. **自動デプロイが止まったことの確認**
+   - `main` へ変更をマージし、ステージングのみデプロイされ本番はデプロイされないことを確認する
 
-6. **一致の確認**
-   - `git rev-list --count origin/main..origin/develop` と `git rev-list --count origin/develop..origin/main` が両方 0 になることを確認する
+### フェーズ3: 手動デプロイワークフローの追加
 
-### フェーズ3: Vercel の設定変更
+6. **Secrets の登録**
+   - リポジトリの Settings → Secrets and variables → Actions に、前掲の4つの Secrets を登録する
+   - `VERCEL_TOKEN` は Vercel のアカウント設定から発行する
+   - Project ID は `vercel project inspect <name> --scope team-mirai` で取得できる
 
-7. **ステージング環境の向き先変更**
-   - ステージング用の Vercel プロジェクト（または環境）の対象ブランチを `develop` から `main` へ変更する
-   - webapp / admin の両方について実施する
+7. **GitHub Environment の作成**
+   - Settings → Environments に `production` を作成する
+   - 必要に応じて Required reviewers を設定する
 
-8. **プロダクション環境の自動デプロイ停止**
-   - プロダクション用 Vercel プロジェクトで、main への push による自動デプロイを無効化する
-   - Vercel の設定方法は複数あるため、いずれかを選択する:
-     - **Ignored Build Step** に `exit 0`（＝常にビルドをスキップ）を設定し、手動 Redeploy のみ受け付ける
-     - **Git Integration の Production Deployment を無効化**（Settings → Git → Production Deployments を off）
-   - webapp / admin の両方について実施する
+8. **ワークフローファイルの追加**
+   - `.github/workflows/deploy-production.yml` を追加する
+   - `workflow_dispatch` トリガー、webapp → admin の直列実行、`vercel deploy --prod`（`--prebuilt` なし）
 
-9. **手動デプロイ手順の確認**
-   - プロダクションへの手動デプロイ操作を実際に1回試し、想定どおり動くことを確認する
-   - Vercel ダッシュボードの Deployments 一覧から、対象コミットの「Promote to Production」または「Redeploy」を使う運用になる
+9. **手動デプロイの動作確認**
+   - Actions タブからワークフローを実行し、webapp / admin の両方が本番へデプロイされることを確認する
+   - 本番DBへマイグレーションが適用されることをあわせて確認する
 
 ### フェーズ4: GitHub の設定変更
 
 10. **デフォルトブランチの変更**
     - Settings → General → Default branch を `develop` から `main` へ変更する
-    - これにより `gh pr create` が自動的に main を base にするようになる（`pr.md` は `--base` を付けない方針のため）
+    - これにより `gh pr create` が自動的に main を base にする
 
 11. **ブランチ保護ルールの移行**
     - develop に設定されている保護ルール（Require status checks など）を main に対して設定する
-    - CI のステータスチェック必須設定を main へ移す
     - develop の保護ルールを削除する
 
 12. **フェーズ1で洗い出した PR の base 付け替え**
@@ -115,7 +154,7 @@ origin/develop..origin/main :  7 コミット（main にあって develop にな
 
 13. **develop ブランチの削除**
     - リモートの develop を削除する（`git push origin --delete develop`）
-    - 削除前に、main に develop の内容がすべて含まれていることを再確認する
+    - 削除前に、main に develop の内容がすべて含まれていることを確認する
     - 各開発者にローカルの develop 削除と `git fetch --prune` を依頼する
 
 ### フェーズ5: リポジトリ内の記述変更
@@ -127,7 +166,7 @@ origin/develop..origin/main :  7 コミット（main にあって develop にな
     - codecov バッジ URL の `branch/develop` を `branch/main` に変更する
 
 16. **`.claude/commands/pr.md`**
-    - L26, L27: ブランチ決定手順の「developやmain」「developから新しいブランチを作成」を main 基準に書き換える
+    - L26, L27: ブランチ決定手順を main 基準に書き換える
     - L38: コンフリクト確認の `origin/develop` を `origin/main` に変更する
     - L48: 「developやmainへの直接pushは禁止」を「mainへの直接pushは禁止」に変更する
 
@@ -135,53 +174,39 @@ origin/develop..origin/main :  7 コミット（main にあって develop にな
     - L18: 差分取得の基準を `develop...HEAD` から `main...HEAD` に変更する
 
 18. **codecov 側の設定確認**
-    - codecov のデフォルトブランチ設定が develop になっている場合、main へ変更する（バッジ URL 変更だけでは不十分な場合がある）
+    - codecov のデフォルトブランチ設定が develop の場合、main へ変更する
 
 ### フェーズ6: 動作確認
 
 19. **ステージングの自動デプロイ確認**
-    - main へ何らかの変更をマージし、ステージングに自動反映されることを確認する
+    - `main` へ変更をマージし、ステージングに自動反映されることを確認する
 
-20. **プロダクションの手動デプロイ確認**
-    - main への push でプロダクションが**自動デプロイされないこと**を確認する
-    - 手動デプロイ操作でプロダクションへ反映されることを確認する
-
-21. **CI とレビュー自動化の確認**
+20. **CI とレビュー自動化の確認**
     - main を base とした PR で CI が起動することを確認する
     - CodeRabbit の自動レビューが起動することを確認する
 
 ## 注意点
 
-### VERCEL_ENV とキャッシュ設定の関係
+### main へのマージの意味が変わる
 
-`webapp/src/server/contexts/public-finance/presentation/loaders/constants.ts` は `VERCEL_ENV === "production"` のときだけ revalidate を 3600 秒にし、それ以外は 10 秒にしている。
+これまで develop へのマージが「ステージングで検証する」意味を持っていたが、移行後は main へのマージが同じ役割を担う。
 
-Vercel の `VERCEL_ENV` は「どのブランチか」ではなく「Production デプロイか Preview デプロイか」で決まる。したがって:
+main は「常にリリース可能な状態」ではなく「ステージングで検証中の状態」になる。本番に出ているものは main の HEAD とは限らない。
 
-- ステージングを **Preview デプロイ**として運用する場合 → `VERCEL_ENV` は `preview` となり、revalidate は 10 秒のまま（現状の develop 運用と同じ挙動）
-- ステージングを **別 Vercel プロジェクトの Production** として運用する場合 → `VERCEL_ENV` は `production` となり、revalidate が 3600 秒になる
+本番に何が出ているかは Vercel のデプロイ履歴、または GitHub Actions の実行履歴で追跡する。
 
-現状のステージングがどちらの方式かによって、移行後の挙動が変わりうる。フェーズ3の設定変更時に現行方式を確認し、挙動が変わる場合はこの定数の判定条件を見直すこと。
+### ステージングDBへのマイグレーションは main マージ時点で適用される
 
-### DB マイグレーションの実行タイミング
+`main` へマージするとステージングのビルドが走り、ステージングDBへマイグレーションが適用される。本番DBへの適用は手動デプロイを実行するまで行われない。
 
-`webapp/vercel.json` の `buildCommand` は `pnpm run build:vercel` で、これは `db:setup`（`prisma migrate deploy`）を含む。つまり **webapp のビルドが走るたびにマイグレーションが実行される**。
+両環境のスキーマが一時的に異なる状態になるが、それぞれのコードとスキーマは対応が取れているため問題は生じない。
 
-プロダクションを手動デプロイに変えると、「main にマージ済みだがプロダクション未デプロイ」という状態が常態化する。このとき:
+### 本番デプロイはロールバックでスキーマが戻らない
 
-- ステージングのビルドではステージング DB にマイグレーションが適用される
-- プロダクション DB には手動デプロイするまでマイグレーションが適用されない
+本番デプロイでコードとスキーマが同時に進むため、Vercel の Instant Rollback でコードを戻してもマイグレーションは戻らない。
 
-つまり main のコードとプロダクション DB のスキーマがずれる期間が生まれる。破壊的なマイグレーション（カラム削除・リネームなど）を含む変更では、この期間を意識した運用が必要になる。
-
-### main へのマージ = ステージング反映という意味変化
-
-これまで develop へのマージは「ステージングで検証する」意味だったが、移行後は main へのマージが同じ役割を担う。main は「常にリリース可能な状態」ではなく「ステージングで検証中の状態」になる点をチームで合意しておく必要がある。
-
-プロダクションへ何をデプロイしたかは Vercel のデプロイ履歴でのみ追跡できるようになるため、リリースタグを打つなどの運用を別途検討する余地がある。
+破壊的なマイグレーション（カラム削除・リネーム・型変更など）を含むデプロイでは、ロールバックが機能しない可能性がある。該当する変更を出す際は事前に確認する。
 
 ### 作業の順序
 
-フェーズ2（ブランチ同期）を完了せずにフェーズ4（develop 削除）へ進むと、main にしかないコミットや develop にしかないコミットが失われる。フェーズは順番どおりに実施すること。
-
-また、フェーズ3（Vercel のプロダクション自動デプロイ停止）をフェーズ2（develop → main マージ）より先に行うと、意図しないタイミングでプロダクションへデプロイされる事故を防げる。順序を入れ替えたい場合はこの点を考慮する。
+フェーズ2（本番の自動デプロイ停止）をフェーズ4（デフォルトブランチ変更・develop 削除）より先に実施する。順序を逆にすると、develop 削除に伴う操作で意図しない本番デプロイが発生しうる。

--- a/docs/20260823_1813_Gitブランチ運用のmain単一化移行手順.md
+++ b/docs/20260823_1813_Gitブランチ運用のmain単一化移行手順.md
@@ -114,23 +114,35 @@ Vercel ダッシュボードからの手動デプロイでも本番デプロイ�
 
 ## 移行手順
 
-### フェーズ1: 事前準備
+### フェーズ1: デフォルトブランチの切り替え
+
+develop は既に役割を終えている。Vercel の staging は `main` を追跡済みで、main と develop の内容も同期済みのため、以降の作業はすべて `main` 上で行う。
 
 1. **チームへの周知**
-   - 移行日時と、移行後は develop を使わないことをアナウンスする
-   - 移行作業中は develop / main への push を止めてもらう
+   - 移行日時と、以降は develop を使わないことをアナウンスする
+   - 移行作業中は main への push を止めてもらう
 
-2. **オープンな PR の棚卸し**
-   - base が `develop` になっている PR を一覧化する（`gh pr list --base develop`）
-   - 移行後、これらの PR の base を `main` に変更する必要がある（デフォルトブランチ変更時に自動追随しないため）
+2. **デフォルトブランチの変更**
+   - Settings → General → Default branch を `develop` から `main` へ変更する
+   - これにより `gh pr create` が自動的に main を base にする
+   - `workflow_dispatch` のワークフローもデフォルトブランチ上のものが参照される
 
-3. **Vercel の現行設定の記録**
-   - webapp / admin それぞれの各環境のブランチ追跡設定
-   - ロールバック時に元へ戻せるようにしておく
+3. **既存 PR の base 付け替え**
+   - base が `develop` の PR を一覧化する（`gh pr list --base develop`）
+   - デフォルトブランチ変更では自動追随しないため、`gh pr edit <番号> --base main` で個別に変更する
+
+4. **ブランチ保護ルールの移行**
+   - develop に設定されている保護ルール（Require status checks など）を main に対して設定する
+   - develop の保護ルールを削除する
+
+5. **develop ブランチの削除**
+   - main に develop の内容がすべて含まれていることを確認する（`git diff origin/main origin/develop` に差分が出ないこと）
+   - リモートの develop を削除する（`git push origin --delete develop`）
+   - 各開発者にローカルの develop 削除と `git fetch --prune` を依頼する
 
 ### フェーズ2: 本番デプロイの自動化を停止
 
-4. **`ignoreCommand` による本番ビルドのスキップ**
+6. **`ignoreCommand` による本番ビルドのスキップ**
    - `webapp/vercel.json` と `admin/vercel.json` に `ignoreCommand` を追加する
 
    ```json
@@ -140,74 +152,55 @@ Vercel ダッシュボードからの手動デプロイでも本番デプロイ�
    - `ignoreCommand` は exit 0 でビルドを無視し、exit 1 でビルドを続行する
    - `VERCEL_ENV` が `production` のときのみ exit 0 となるため、本番ビルドだけがスキップされ、`staging` と `Preview` は従来どおりビルドされる
 
-5. **自動デプロイが止まったことの確認**
+7. **自動デプロイが止まったことの確認**
    - `main` へ変更をマージし、ステージングのみデプロイされ本番はスキップされることを確認する
 
 ### フェーズ3: 手動デプロイワークフローの追加
 
-6. **GitHub Environment の作成**
+8. **GitHub Environment の作成**
    - Settings → Environments に `production` を作成する
    - Required reviewers を設定し、承認なしに本番デプロイが実行されないようにする
 
-7. **Secrets の登録**
+9. **Secrets の登録**
    - `VERCEL_TOKEN` は **`production` Environment の Environment secret として登録する**。リポジトリ Secret にすると Required reviewers による承認を経ずに参照できてしまうため、本番デプロイ用の認証情報は Environment 側に置く
    - `VERCEL_TOKEN` は Vercel のアカウント設定から発行する。スコープは webapp / admin の両方を含める必要がある
    - `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID_WEBAPP` / `VERCEL_PROJECT_ID_ADMIN` は識別子であり秘匿性が低いため、リポジトリ Secret でよい
    - Project ID は `vercel project inspect <name> --scope team-mirai` で取得できる
 
-8. **ワークフローファイルの追加**
-   - `.github/workflows/deploy-production.yml` を追加する
-   - `workflow_dispatch` トリガー、webapp → admin の直列実行、`vercel deploy --prod`（`--prebuilt` なし）
+10. **ワークフローファイルの追加**
+    - `.github/workflows/deploy-production.yml` を追加する
+    - `workflow_dispatch` トリガー、`github.ref` の検証、webapp → admin の直列実行、`vercel deploy --prod`（`--prebuilt` なし）
 
-9. **手動デプロイの動作確認**
-   - `workflow_dispatch` はデフォルトブランチ上にワークフローファイルが存在しないと Actions タブに表示されない。この時点でのデフォルトブランチは `develop` のため、**先にワークフローを `develop` へマージしておく**こと
-   - Actions タブからワークフローを実行し、webapp / admin の両方が本番へデプロイされることを確認する
-   - 本番DBへマイグレーションが適用されることをあわせて確認する
-   - `ignoreCommand` が CLI 経由のデプロイにも作用してビルドがスキップされないか確認する。スキップされる場合は `vercel deploy --prod --force` を用いる
+11. **手動デプロイの動作確認**
+    - Actions タブからワークフローを実行し、webapp / admin の両方が本番へデプロイされることを確認する
+    - 本番DBへマイグレーションが適用されることをあわせて確認する
+    - `ignoreCommand` が CLI 経由のデプロイにも作用してビルドがスキップされないか確認する。スキップされる場合は `vercel deploy --prod --force` を用いる
 
-### フェーズ4: GitHub の設定変更
+### フェーズ4: リポジトリ内の記述変更
 
-10. **デフォルトブランチの変更**
-    - Settings → General → Default branch を `develop` から `main` へ変更する
-    - これにより `gh pr create` が自動的に main を base にする
-
-11. **ブランチ保護ルールの移行**
-    - develop に設定されている保護ルール（Require status checks など）を main に対して設定する
-    - develop の保護ルールを削除する
-
-12. **フェーズ1で洗い出した PR の base 付け替え**
-    - `gh pr edit <番号> --base main` で順次変更する
-
-13. **develop ブランチの削除**
-    - リモートの develop を削除する（`git push origin --delete develop`）
-    - 削除前に、main に develop の内容がすべて含まれていることを確認する
-    - 各開発者にローカルの develop 削除と `git fetch --prune` を依頼する
-
-### フェーズ5: リポジトリ内の記述変更
-
-14. **`.coderabbit.yml`**
+12. **`.coderabbit.yml`**
     - `reviews.auto_review.base_branches` の `develop` を `main` に変更する
 
-15. **`README.md`**
+13. **`README.md`**
     - codecov バッジ URL の `branch/develop` を `branch/main` に変更する
 
-16. **`.claude/commands/pr.md`**
+14. **`.claude/commands/pr.md`**
     - L26, L27: ブランチ決定手順を main 基準に書き換える
     - L38: コンフリクト確認の `origin/develop` を `origin/main` に変更する
     - L48: 「developやmainへの直接pushは禁止」を「mainへの直接pushは禁止」に変更する
 
-17. **`.claude/commands/e2e.md`**
+15. **`.claude/commands/e2e.md`**
     - L18: 差分取得の基準を `develop...HEAD` から `main...HEAD` に変更する
 
-18. **codecov 側の設定確認**
+16. **codecov 側の設定確認**
     - codecov のデフォルトブランチ設定が develop の場合、main へ変更する
 
-### フェーズ6: 動作確認
+### フェーズ5: 動作確認
 
-19. **ステージングの自動デプロイ確認**
+17. **ステージングの自動デプロイ確認**
     - `main` へ変更をマージし、ステージングに自動反映されることを確認する
 
-20. **CI とレビュー自動化の確認**
+18. **CI とレビュー自動化の確認**
     - main を base とした PR で CI が起動することを確認する
     - CodeRabbit の自動レビューが起動することを確認する
 
@@ -235,4 +228,6 @@ main は「常にリリース可能な状態」ではなく「ステージング
 
 ### 作業の順序
 
-フェーズ2（本番の自動デプロイ停止）をフェーズ4（デフォルトブランチ変更・develop 削除）より先に実施する。順序を逆にすると、develop 削除に伴う操作で意図しない本番デプロイが発生しうる。
+フェーズ1でデフォルトブランチを main に切り替えた後、フェーズ2の `ignoreCommand` がマージされるまでの間は、main への push で本番デプロイが走る状態が続く。この期間を短くするため、フェーズ1とフェーズ2は続けて実施する。
+
+なお本番デプロイの経路がフェーズ2で塞がり、フェーズ3の手動ワークフローが動作確認できるまでは本番デプロイができない状態になる。緊急のリリース予定がない時期に実施すること。

--- a/docs/20260823_1813_Gitブランチ運用のmain単一化移行手順.md
+++ b/docs/20260823_1813_Gitブランチ運用のmain単一化移行手順.md
@@ -65,6 +65,16 @@ develop と main の内容は同期済み（PR #1234 でマージ完了）。
 
 ## 設計
 
+### 本番の自動デプロイを止める方法
+
+`staging` と `Production` は同じ `main` ブランチを追跡しているため、Git 連携の無効化（`git.deploymentEnabled` や Git 連携の切断）ではステージングも同時に止まってしまう。Vercel には「Production 環境のビルドだけを無効化する」という設定は存在しない。
+
+そこで `ignoreCommand` を使い、`VERCEL_ENV` が `production` のときだけビルドをスキップする。これが現在の構成のまま本番ビルドだけを止められる方法である。
+
+なお「Auto-assign Custom Production Domains」を無効化する方法では、ビルド自体は実行される。`webapp` のビルドには `prisma migrate deploy` が含まれるため、ドメインが割り当てられないまま本番DBのスキーマだけが進み、配信中の古いコードが新しいスキーマを参照する状態が生じる。このため本構成では採用しない。
+
+`ignoreCommand` によりビルドがスキップされると、Vercel ダッシュボードから Promote できる成果物が生成されない。本番デプロイの経路は後述の GitHub Actions のみとなる。
+
 ### 本番デプロイのトリガーを GitHub Actions に置く理由
 
 Vercel ダッシュボードからの手動デプロイでも本番デプロイ自体は可能だが、次の理由から GitHub Actions の `workflow_dispatch` を採用する。
@@ -112,13 +122,18 @@ Vercel ダッシュボードからの手動デプロイでも本番デプロイ�
 
 ### フェーズ2: 本番デプロイの自動化を停止
 
-4. **Production 環境のブランチ追跡を解除**
-   - Vercel ダッシュボードで、webapp / admin それぞれの Settings → Environments → Production を開く
-   - Branch Tracking の設定を解除し、`main` への push で本番デプロイが起動しないようにする
-   - この時点でステージングは `main` 追跡のまま自動デプロイが継続する
+4. **`ignoreCommand` による本番ビルドのスキップ**
+   - `webapp/vercel.json` と `admin/vercel.json` に `ignoreCommand` を追加する
+
+   ```json
+   "ignoreCommand": "[ \"$VERCEL_ENV\" = \"production\" ] && exit 0 || exit 1"
+   ```
+
+   - `ignoreCommand` は exit 0 でビルドを無視し、exit 1 でビルドを続行する
+   - `VERCEL_ENV` が `production` のときのみ exit 0 となるため、本番ビルドだけがスキップされ、`staging` と `Preview` は従来どおりビルドされる
 
 5. **自動デプロイが止まったことの確認**
-   - `main` へ変更をマージし、ステージングのみデプロイされ本番はデプロイされないことを確認する
+   - `main` へ変更をマージし、ステージングのみデプロイされ本番はスキップされることを確認する
 
 ### フェーズ3: 手動デプロイワークフローの追加
 
@@ -197,7 +212,7 @@ main は「常にリリース可能な状態」ではなく「ステージング
 
 ### ステージングDBへのマイグレーションは main マージ時点で適用される
 
-`main` へマージするとステージングのビルドが走り、ステージングDBへマイグレーションが適用される。本番DBへの適用は手動デプロイを実行するまで行われない。
+`main` へマージするとステージングのビルドが走り、ステージングDBへマイグレーションが適用される。本番ビルドは `ignoreCommand` によりスキップされるため、本番DBへの適用は手動デプロイを実行するまで行われない。
 
 両環境のスキーマが一時的に異なる状態になるが、それぞれのコードとスキーマは対応が取れているため問題は生じない。
 

--- a/docs/20260823_1813_Gitブランチ運用のmain単一化移行手順.md
+++ b/docs/20260823_1813_Gitブランチ運用のmain単一化移行手順.md
@@ -77,7 +77,23 @@ develop と main の内容は同期済み（PR #1234 でマージ完了）。
 
 `staging` と `Production` は同じ `main` ブランチを追跡しているため、Git 連携の無効化（`git.deploymentEnabled` や Git 連携の切断）ではステージングも同時に止まってしまう。Vercel には「Production 環境のビルドだけを無効化する」という設定は存在しない。
 
-そこで `ignoreCommand` を使い、`VERCEL_ENV` が `production` のときだけビルドをスキップする。これが現在の構成のまま本番ビルドだけを止められる方法である。
+そこで `ignoreCommand` を使い、本番環境のビルドだけをスキップする。これが現在の構成のまま本番ビルドだけを止められる方法である。
+
+ただし `ignoreCommand` は Git 連携によるデプロイだけでなく、CLI（`vercel deploy`）によるデプロイでも実行される。`VERCEL_ENV = production` のみを条件にすると GitHub Actions からの本番デプロイもスキップされ、手動デプロイの経路が塞がってしまう。
+
+このため `MANUAL_DEPLOY` というビルド環境変数を判定に加え、CLI からのデプロイ時のみ `--build-env MANUAL_DEPLOY=1` で明示的に渡す。Git 連携経由のビルドではこの変数が存在しないためスキップされる。
+
+```
+"ignoreCommand": "[ \"$VERCEL_ENV\" = \"production\" ] && [ \"$MANUAL_DEPLOY\" != \"1\" ] && exit 0 || exit 1"
+```
+
+| VERCEL_ENV | MANUAL_DEPLOY | 挙動 |
+|-----------|--------------|------|
+| production | 未設定（Git 連携） | スキップ |
+| production | `1`（CLI） | ビルド実行 |
+| preview / staging | 任意 | ビルド実行 |
+
+なお `vercel deploy --force` は `ignoreCommand` を回避しない。`--force` はビルドキャッシュを無視するオプションであり、判定そのものには影響しない。
 
 なお「Auto-assign Custom Production Domains」を無効化する方法では、ビルド自体は実行される。`webapp` のビルドには `prisma migrate deploy` が含まれるため、ドメインが割り当てられないまま本番DBのスキーマだけが進み、配信中の古いコードが新しいスキーマを参照する状態が生じる。このため本構成では採用しない。
 
@@ -105,6 +121,7 @@ Vercel ダッシュボードからの手動デプロイでも本番デプロイ�
 - トリガー: `workflow_dispatch`（Actions タブから手動実行）
 - 対象コミット: `main` に限定する。`workflow_dispatch` は任意の ref を選択できるため、ワークフロー側で `github.ref` が `refs/heads/main` であることを検証し、それ以外は失敗させる
 - 実行順序: webapp → admin の直列
+- ビルド環境変数: `--build-env MANUAL_DEPLOY=1` を付与し、`ignoreCommand` によるスキップを回避する
 - 使用する Secrets:
   - `VERCEL_TOKEN`
   - `VERCEL_ORG_ID`
@@ -146,11 +163,12 @@ develop は既に役割を終えている。Vercel の staging は `main` を追
    - `webapp/vercel.json` と `admin/vercel.json` に `ignoreCommand` を追加する
 
    ```json
-   "ignoreCommand": "[ \"$VERCEL_ENV\" = \"production\" ] && exit 0 || exit 1"
+   "ignoreCommand": "[ \"$VERCEL_ENV\" = \"production\" ] && [ \"$MANUAL_DEPLOY\" != \"1\" ] && exit 0 || exit 1"
    ```
 
    - `ignoreCommand` は exit 0 でビルドを無視し、exit 1 でビルドを続行する
-   - `VERCEL_ENV` が `production` のときのみ exit 0 となるため、本番ビルドだけがスキップされ、`staging` と `Preview` は従来どおりビルドされる
+   - Git 連携による本番ビルドはスキップされ、`staging` と `Preview` は従来どおりビルドされる
+   - GitHub Actions からの CLI デプロイは `--build-env MANUAL_DEPLOY=1` を渡すため、スキップされずにビルドされる
 
 7. **自動デプロイが止まったことの確認**
    - `main` へ変更をマージし、ステージングのみデプロイされ本番はスキップされることを確認する
@@ -172,9 +190,17 @@ develop は既に役割を終えている。Vercel の staging は `main` を追
     - `workflow_dispatch` トリガー、`github.ref` の検証、webapp → admin の直列実行、`vercel deploy --prod`（`--prebuilt` なし）
 
 11. **手動デプロイの動作確認**
-    - Actions タブからワークフローを実行し、webapp / admin の両方が本番へデプロイされることを確認する
-    - 本番DBへマイグレーションが適用されることをあわせて確認する
-    - `ignoreCommand` が CLI 経由のデプロイにも作用してビルドがスキップされないか確認する。スキップされる場合は `vercel deploy --prod --force` を用いる
+    - Actions タブからワークフローを実行する
+    - **webapp のデプロイ成功を確認する**
+      - ワークフローの Deploy webapp ステップが成功していること
+      - Vercel のデプロイが `Ready` かつ Environment が `Production` であること（`CANCELED` の場合は `ignoreCommand` にスキップされている）
+      - ビルドログに `prisma migrate deploy` の実行結果が出力され、本番DBへのマイグレーションが成功していること
+    - **admin のデプロイ成功を確認する**
+      - ワークフローの Deploy admin ステップが成功していること
+      - Vercel のデプロイが `Ready` かつ Environment が `Production` であること
+    - **本番サイトの表示を確認する**
+      - 本番ドメインに変更が反映されていること
+      - webapp / admin の両方でエラーが出ていないこと
 
 ### フェーズ4: リポジトリ内の記述変更
 

--- a/webapp/vercel.json
+++ b/webapp/vercel.json
@@ -1,3 +1,5 @@
 {
-  "buildCommand": "pnpm run build:vercel"
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "pnpm run build:vercel",
+  "ignoreCommand": "[ \"$VERCEL_ENV\" = \"production\" ] && exit 0 || exit 1"
 }

--- a/webapp/vercel.json
+++ b/webapp/vercel.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "pnpm run build:vercel",
-  "ignoreCommand": "[ \"$VERCEL_ENV\" = \"production\" ] && exit 0 || exit 1"
+  "ignoreCommand": "[ \"$VERCEL_ENV\" = \"production\" ] && [ \"$MANUAL_DEPLOY\" != \"1\" ] && exit 0 || exit 1"
 }


### PR DESCRIPTION
## 目的

開発者が develop と main の2本のブランチを維持することをやめ、ブランチ運用を単純化するため。あわせて本番デプロイを手動化し、main へマージした変更をいつ本番へ出すかを選べるようにする。

先行 PR #1232 の設計は Vercel の実構成を確認せずに書いていたため、全面的に見直した。

## 確認した実構成

`vercel` CLI で team-mirai スコープを調査した結果、当初の想定と異なっていた点がある。

**Vercel プロジェクトは webapp / admin の2つのみ**（ステージング用と本番用に別プロジェクトを持つ構成ではない）。各プロジェクトが `Production` / `staging` / `Preview` の3環境を持ち、`staging` はカスタム環境として既に存在している。`staging` の追跡ブランチは develop から main へ変更済み。

**DB は環境ごとに分離されている。** Supabase は単一プロジェクトだが、`DATABASE_URL` / `DIRECT_URL` は `Production` と `staging` / `Preview` とで別々に設定されており、値も異なることを確認した（値は参照せずハッシュ比較で確認）。

このため `webapp/package.json` の `build:vercel` に含まれる `prisma migrate deploy` は、ビルドが走った環境のDBへ個別に適用される。**ビルド＝マイグレーション適用＝コード公開が不可分**という現状の性質がそのまま維持できるため、マイグレーションをビルドから分離する必要はない。

## 設計

本番デプロイのトリガーは GitHub Actions の `workflow_dispatch` に置く。

- webapp と admin をまとめて1操作でデプロイできる
- webapp のビルドがマイグレーションを伴うため、webapp → admin の順に直列実行して順序を保証する
- GitHub Environments の Required reviewers で承認フローを組める
- デプロイ履歴が GitHub に残る

**`--prebuilt` は使用しない。** `webapp/src/server/contexts/public-finance/presentation/loaders/constants.ts` が `VERCEL_ENV` を参照してキャッシュの revalidate 秒数を決めており、`--prebuilt` ではビルド時に System Environment Variables が渡らないため、本番でも 10 秒（本来 3600 秒）が焼き込まれてしまう。ビルド時定数のため実行時には修正されない。

## 変更内容

- `docs/20260823_1813_Gitブランチ運用のmain単一化移行手順.md` を全面的に書き直し
- `.github/workflows/deploy-production.yml` を追加（`workflow_dispatch` トリガー、webapp → admin 直列）

## レビューで確認いただきたい点

**ワークフローは未検証です。** Secrets（`VERCEL_TOKEN` / `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID_WEBAPP` / `VERCEL_PROJECT_ID_ADMIN`）が未登録のため、実行しても現状は失敗します。設計書のフェーズ3に登録手順を記載しています。

また `--cwd` によるモノレポのサブディレクトリ指定が、`admin/vercel.json` の `installCommand`（`cd ..` を含む）と整合するかは実行して確認が必要です。

## 補足

- ブランチ同期（#1234）はマージ済みで、develop と main の内容は一致している
- 訂正 PR #1233 は本 PR に内容を統合したためクローズ済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * Gitブランチ運用を`main`中心へ移行する手順を全面的に更新しました。
  * 本番デプロイを手動実行に変更する新しい運用フローを追加しました。
  * Vercel、Supabase、データベースマイグレーションの構成と注意点を整理しました。
  * ブランチ保護ルールやプルリクエストの移行手順を明確化しました。

* **運用改善**
  * 本番環境への自動デプロイを停止し、手動デプロイに対応しました。
  * ステージング環境への反映条件を`main`へのプッシュに統一しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->