### PR TITLE
fix: vercel deploy の --cwd 指定を削除する

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -33,11 +33,15 @@ jobs:
 
       # webapp のビルドに prisma migrate deploy が含まれるため、
       # 先に webapp をデプロイして本番DBのスキーマを更新する
+      #
+      # Root Directory (webapp / admin) は Vercel のプロジェクト設定側で
+      # 適用されるため --cwd は指定しない（指定するとパスが二重になる）
+      #
       # --build-env MANUAL_DEPLOY=1 が ignoreCommand の条件を満たし、
       # Git 連携によるビルドはスキップしたまま CLI からのデプロイのみ通す
       - name: Deploy webapp
         run: |
-          vercel deploy --prod --yes --cwd webapp \
+          vercel deploy --prod --yes \
             --build-env MANUAL_DEPLOY=1 \
             --token "$VERCEL_TOKEN"
         env:
@@ -46,7 +50,7 @@ jobs:
 
       - name: Deploy admin
         run: |
-          vercel deploy --prod --yes --cwd admin \
+          vercel deploy --prod --yes \
             --build-env MANUAL_DEPLOY=1 \
             --token "$VERCEL_TOKEN"
         env:

--- a/docs/20260823_1813_Gitブランチ運用のmain単一化移行手順.md
+++ b/docs/20260823_1813_Gitブランチ運用のmain単一化移行手順.md
@@ -122,6 +122,7 @@ Vercel ダッシュボードからの手動デプロイでも本番デプロイ�
 - 対象コミット: `main` に限定する。`workflow_dispatch` は任意の ref を選択できるため、ワークフロー側で `github.ref` が `refs/heads/main` であることを検証し、それ以外は失敗させる
 - 実行順序: webapp → admin の直列
 - ビルド環境変数: `--build-env MANUAL_DEPLOY=1` を付与し、`ignoreCommand` によるスキップを回避する
+- 作業ディレクトリ: `--cwd` は指定しない。Root Directory（`webapp` / `admin`）は Vercel のプロジェクト設定側で適用されるため、`--cwd webapp` を渡すとパスが `webapp/webapp` と二重になり失敗する。プロジェクトの指定は `VERCEL_PROJECT_ID` で行う
 - 使用する Secrets:
   - `VERCEL_TOKEN`
   - `VERCEL_ORG_ID`


### PR DESCRIPTION
## 目的

本番デプロイワークフローが失敗する状態を解消するため。

## 問題

`vercel deploy --prod --cwd webapp` がパスの二重適用で失敗していた。

```
Error: The provided path "~/work/marumie/marumie/webapp/webapp" does not exist.
```

Root Directory（`webapp` / `admin`）は Vercel のプロジェクト設定側で既に適用されるため、`--cwd webapp` を渡すと `webapp/webapp` となる。

## 修正

`--cwd` の指定を削除した。プロジェクトの指定は `VERCEL_PROJECT_ID` 環境変数で行われるため `--cwd` は不要。

設計書のワークフロー構成にも、`--cwd` を指定しない理由を追記した。

## 確認

マージ後、Actions から Deploy Production を再実行して確認が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * 手動デプロイ時に`--cwd`を指定しない運用手順を追記しました。
  * Vercelのプロジェクト設定とプロジェクト識別方法について説明を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->